### PR TITLE
Add Vue tests

### DIFF
--- a/__tests__/click.js
+++ b/__tests__/click.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup } from "@testing-library/react";
 import "jest-dom/extend-expect";
 import userEvent from "../src";
 

--- a/__tests__/vue/click.js
+++ b/__tests__/vue/click.js
@@ -1,0 +1,342 @@
+import { render, cleanup } from "@testing-library/vue";
+import "jest-dom/extend-expect";
+import userEvent from "../../src";
+
+afterEach(cleanup);
+
+describe("userEvent.click", () => {
+  it.each(["input", "textarea"])(
+    "should fire the correct events for <%s>",
+    type => {
+      const events = [];
+      const eventsHandler = jest.fn(evt => events.push(evt.type));
+      const { getByTestId } = render({
+        render: function(h) {
+          return h(type, {
+            attrs: {
+              "data-testid": "element"
+            },
+            on: {
+              mouseOver: eventsHandler,
+              mouseMove: eventsHandler,
+              mouseDown: eventsHandler,
+              focus: eventsHandler,
+              mouseUp: eventsHandler,
+              click: eventsHandler
+            }
+          });
+        }
+      });
+
+      userEvent.click(getByTestId("element"));
+
+      // baseElement is always <body>, si wasAnotherElementFocused is false
+      expect(events).toEqual([
+        // "mouseover",
+        // "mousemove",
+        // "mousedown",
+        "focus",
+        // "mouseup",
+        "click"
+      ]);
+    }
+  );
+
+  it('should fire the correct events for <input type="checkbox">', () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+
+    const { getByTestId } = render({
+      render: function(h) {
+        return h("input", {
+          attrs: {
+            type: "checkbox",
+            "data-testid": "element"
+          },
+          on: {
+            mouseOver: eventsHandler,
+            mouseMove: eventsHandler,
+            mouseDown: eventsHandler,
+            focus: eventsHandler,
+            mouseUp: eventsHandler,
+            click: eventsHandler,
+            change: eventsHandler
+          }
+        });
+      }
+    });
+
+    userEvent.click(getByTestId("element"));
+
+    expect(events).toEqual([
+      // "mouseover",
+      // "mousemove",
+      // "mousedown",
+      // "mouseup",
+      "click",
+      "change",
+      "change" // Right now it's receiving two `change` events.
+    ]);
+
+    expect(getByTestId("element")).toHaveProperty("checked", true);
+  });
+
+  it('should fire the correct events for <input type="checkbox" disabled>', () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+    const { getByTestId } = render({
+      render: function(h) {
+        return h("input", {
+          attrs: {
+            type: "checkbox",
+            "data-testid": "element",
+            disabled: "disabled"
+          },
+          on: {
+            mouseOver: eventsHandler,
+            mouseMove: eventsHandler,
+            mouseDown: eventsHandler,
+            focus: eventsHandler,
+            mouseUp: eventsHandler,
+            click: eventsHandler,
+            change: eventsHandler
+          }
+        });
+      }
+    });
+
+    userEvent.click(getByTestId("element"));
+
+    expect(events).toEqual([]);
+
+    expect(getByTestId("element")).toHaveProperty("checked", false);
+  });
+
+  it('should fire the correct events for <input type="radio">', () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+    const { getByTestId } = render({
+      render: function(h) {
+        return h("input", {
+          attrs: {
+            type: "radio",
+            "data-testid": "element"
+          },
+          on: {
+            mouseOver: eventsHandler,
+            mouseMove: eventsHandler,
+            mouseDown: eventsHandler,
+            focus: eventsHandler,
+            mouseUp: eventsHandler,
+            click: eventsHandler,
+            change: eventsHandler
+          }
+        });
+      }
+    });
+
+    userEvent.click(getByTestId("element"));
+
+    expect(events).toEqual([
+      // "mouseover",
+      // "mousemove",
+      // "mousedown",
+      // "mouseup",
+      "click",
+      "change",
+      "change"
+    ]);
+
+    expect(getByTestId("element")).toHaveProperty("checked", true);
+  });
+
+  it('should fire the correct events for <input type="radio" disabled>', () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+    const { getByTestId } = render({
+      render: function(h) {
+        return h("input", {
+          attrs: {
+            type: "radio",
+            "data-testid": "element",
+            disabled: "disabled"
+          },
+          on: {
+            mouseOver: eventsHandler,
+            mouseMove: eventsHandler,
+            mouseDown: eventsHandler,
+            focus: eventsHandler,
+            mouseUp: eventsHandler,
+            click: eventsHandler,
+            change: eventsHandler
+          }
+        });
+      }
+    });
+
+    userEvent.click(getByTestId("element"));
+
+    expect(events).toEqual([]);
+
+    expect(getByTestId("element")).toHaveProperty("checked", false);
+  });
+
+  it("should fire the correct events for <div>", () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+    const { getByTestId } = render({
+      render: function(h) {
+        return h("div", {
+          attrs: {
+            "data-testid": "div"
+          },
+          on: {
+            mouseOver: eventsHandler,
+            mouseMove: eventsHandler,
+            mouseDown: eventsHandler,
+            focus: eventsHandler,
+            mouseUp: eventsHandler,
+            click: eventsHandler
+          }
+        });
+      }
+    });
+
+    userEvent.click(getByTestId("div"));
+    expect(events).toEqual([
+      // "mouseover",
+      // "mousemove",
+      // "mousedown",
+      // "mouseup",
+      "click"
+    ]);
+  });
+
+  it("toggles the focus", () => {
+    const { getByTestId } = render({
+      template: `
+      <div>
+        <input data-testid="A" />
+        <input data-testid="B" />
+      </div>`
+    });
+
+    const a = getByTestId("A");
+    const b = getByTestId("B");
+
+    expect(a).not.toHaveFocus();
+    expect(b).not.toHaveFocus();
+
+    userEvent.click(a);
+    expect(a).toHaveFocus();
+    expect(b).not.toHaveFocus();
+
+    userEvent.click(b);
+    expect(a).not.toHaveFocus();
+    expect(b).toHaveFocus();
+  });
+
+  it.each(["input", "textarea"])(
+    "gives focus to <%s> when clicking a <label> with for",
+    type => {
+      const { getByTestId } = render({
+        template: `
+        <div>
+          <label data-testid="label" for="input" />
+          <component is="${type}" data-testid="input" id="input" />
+        </div>`
+      });
+
+      userEvent.click(getByTestId("label"));
+      expect(getByTestId("input")).toHaveFocus();
+    }
+  );
+
+  it.each(["input", "textarea"])(
+    "gives focus to <%s> when clicking a <label> without htmlFor",
+    type => {
+      const { getByTestId } = render({
+        template: `
+        <label data-testid="label">
+          My label text
+          <component is="${type}" data-testid="input" />
+        </label>`
+      });
+
+      userEvent.click(getByTestId("label"));
+      expect(getByTestId("input")).toHaveFocus();
+    }
+  );
+
+  it.each(["input", "textarea"])(
+    "gives focus to <%s> when clicking on an element contained within a <label>",
+    type => {
+      const { getByText, getByTestId } = render({
+        template: `
+        <div>
+          <label for="input" data-testid="label">Label</Label>
+          <component is="${type}" id="input" data-testid="input" />
+        </div>`
+      });
+
+      userEvent.click(getByText("Label"));
+      expect(getByTestId("input")).toHaveFocus();
+    }
+  );
+
+  it('checks <input type="checkbox"> when clicking a <label> with htmlFor', () => {
+    const { getByTestId } = render({
+      template: `
+      <div>
+        <label for="input" data-testid="label">
+          Label
+        </label>
+        <input id="input" data-testid="input" type="checkbox" />
+      </div>`
+    });
+
+    expect(getByTestId("input")).toHaveProperty("checked", false);
+    userEvent.click(getByTestId("label"));
+    expect(getByTestId("input")).toHaveProperty("checked", true);
+  });
+
+  it('checks <input type="checkbox"> when clicking a <label> without htmlFor', () => {
+    const { getByTestId } = render({
+      template: `
+      <div>
+        <label data-testid="label">
+          Label
+          <input id="input" data-testid="input" type="checkbox" />
+        </label>
+      </div>`
+    });
+
+    expect(getByTestId("input")).toHaveProperty("checked", false);
+    userEvent.click(getByTestId("label"));
+    expect(getByTestId("input")).toHaveProperty("checked", true);
+  });
+
+  it("should submit a form when clicking on a <button>", () => {
+    const { getByText, emitted } = render({
+      template: `
+      <form @submit="$emit('submit')">
+        <button>Submit</button>
+      </form>`
+    });
+
+    userEvent.click(getByText("Submit"));
+    expect(emitted().submit).toHaveLength(1);
+  });
+
+  it('should not submit a form when clicking on a <button type="button">', () => {
+    const { getByText, emitted } = render({
+      template: `
+      <form @submit="$emit('submit')">
+        <button type="button">Submit</button>
+      </form>`
+    });
+
+    userEvent.click(getByText("Submit"));
+    expect(emitted()).toEqual({});
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "user-event",
+  "name": "@testing-library/user-event",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
@@ -1995,6 +1995,18 @@
         }
       }
     },
+    "@testing-library/vue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-1.0.3.tgz",
+      "integrity": "sha512-KJVznDxRBm3jYr/7tFP48lwaWWVWXhANWHy5JyX9lKflnHAPjofAKFX/G8iqp0Jh4Y+Z7SpktpVKkCWWEH/tWQ==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^5.0.1",
+        "@vue/test-utils": "^1.0.0-beta.29",
+        "vue": "^2.6.10",
+        "vue-template-compiler": "^2.6.10"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
@@ -2103,6 +2115,16 @@
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
       "integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ=="
+    },
+    "@vue/test-utils": {
+      "version": "1.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz",
+      "integrity": "sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==",
+      "dev": true,
+      "requires": {
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.4"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -4009,6 +4031,12 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4228,6 +4256,12 @@
         "esutils": "^2.0.2",
         "isarray": "^1.0.0"
       }
+    },
+    "dom-event-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
+      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -6150,6 +6184,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -15610,6 +15650,22 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
+      }
+    },
+    "vue": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "dev": true
+    },
+    "vue-template-compiler": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
+      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "7.0.0",
     "@testing-library/react": "8.0.1",
+    "@testing-library/vue": "^1.0.3",
     "all-contributors-cli": "6.6.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "24.8.0",


### PR DESCRIPTION
Hi! 👋 As discussed in #119, I'm submitting a draft PR with a proof of concept for Vue tests. I just added tests for `userEvent.click`, as firstly I'd like to discuss the result and see if it's worth it :)

Tests do the exact same thing as React's. The main difference is the callback prop pattern (which I changed in favor of emitted events, way more idiomatic).


There are several things I'd like to highlight (and debate):

~1. List of emitted events doesn't include `mouse*` events, because AFAIK `wasAnotherElementFocused` is always false (Added code comments). Should I find a way to mount components differently, so I can check that mouse events are being sent?~

2. Also, `change` events are triggered twice. (e.g. [here](https://github.com/testing-library/user-event/pull/129/files#diff-d6a3965b2177d19c49ab5daaf670314cR78)).

3. In VTL, all `fireEvent.*` are converted into async functions. Here, they are (obviously) not. Not sure about the consequences, but I'm a bit worried. Yet, tests work 🤷‍♂.

I wasn't able to configure JSX for Vue (as it clashed with React's). So I first wrote tests using render functions, but I believe tagged templates are easily read. I wish I could use JSX, but it's OK I guess!

All in all, I feel it looks quite good! 😄 

So, (2) needs fixing, but I feel those are the kind of differences we were discussing in the issue linked above. (3) worries me the most. I guess @dfcook has the answer 😇 .


Any thoughts?

---


oh, and btw: there's an ongoing error with js-dom and `Error: Not implemented: HTMLFormElement.prototype.submit` ([related](https://github.com/jsdom/jsdom/issues/1937)). It's just a console warning, and tests are still passing. I think my changes had nothing to do with it 🤔 