### PR TITLE
Remove duplicated change event for boolean inputs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,6 @@ function clickBooleanElement(element) {
   fireEvent.mouseDown(element);
   fireEvent.mouseUp(element);
   fireEvent.click(element);
-  fireEvent.change(element);
 }
 
 function clickElement(element) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,11 +74,9 @@ function dblClickCheckbox(checkbox) {
   fireEvent.mouseDown(checkbox);
   fireEvent.mouseUp(checkbox);
   fireEvent.click(checkbox);
-  fireEvent.change(checkbox);
   fireEvent.mouseDown(checkbox);
   fireEvent.mouseUp(checkbox);
   fireEvent.click(checkbox);
-  fireEvent.change(checkbox);
 }
 
 function selectOption(option) {


### PR DESCRIPTION
For `<input type="checkbox">` and `<input type="radio">`, the `change` event is automatically fired when the value changes. So for these types of inputs, we don't need to manually fire the change event. This was the cause of the duplicated `change` events seen in #129. I assume that the reason why we weren't seeing the duplicated `change` events is because React checks if the value is actually different from the last value before passing the event to the user: https://reactjs.org/docs/dom-elements.html#onchange