### PR TITLE
Add focus event for checkbox/radio

### DIFF
--- a/__tests__/click.js
+++ b/__tests__/click.js
@@ -59,6 +59,7 @@ describe("userEvent.click", () => {
       "mouseover",
       "mousemove",
       "mousedown",
+      "focus",
       "mouseup",
       "click",
       "change"
@@ -115,6 +116,7 @@ describe("userEvent.click", () => {
       "mouseover",
       "mousemove",
       "mousedown",
+      "focus",
       "mouseup",
       "click",
       "change"

--- a/__tests__/dblclick.js
+++ b/__tests__/dblclick.js
@@ -64,6 +64,7 @@ describe("userEvent.dblClick", () => {
       "mouseover",
       "mousemove",
       "mousedown",
+      "focus",
       "mouseup",
       "click",
       "change",

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ function clickBooleanElement(element) {
   fireEvent.mouseOver(element);
   fireEvent.mouseMove(element);
   fireEvent.mouseDown(element);
+  fireEvent.focus(element);
   fireEvent.mouseUp(element);
   fireEvent.click(element);
   fireEvent.change(element);
@@ -73,6 +74,7 @@ function dblClickCheckbox(checkbox) {
   fireEvent.mouseOver(checkbox);
   fireEvent.mouseMove(checkbox);
   fireEvent.mouseDown(checkbox);
+  fireEvent.focus(checkbox);
   fireEvent.mouseUp(checkbox);
   fireEvent.click(checkbox);
   fireEvent.change(checkbox);


### PR DESCRIPTION
https://codesandbox.io/s/input-typecheckbox-events-9m8ts

This PR correctly fires the `focus` event when clicking on checkboxes/radio buttons