### PR TITLE
Fix label.querySelector for select

### DIFF
--- a/__tests__/react/selectoptions.js
+++ b/__tests__/react/selectoptions.js
@@ -171,4 +171,60 @@ describe("userEvent.selectOptions", () => {
     expect(getByTestId("val2").selected).toBe(false);
     expect(getByTestId("val3").selected).toBe(true);
   });
+
+  it("sets the selected prop on the selected OPTION using htmlFor", () => {
+    const onSubmit = jest.fn();
+
+    const { getByTestId } = render(
+      <form onSubmit={onSubmit}>
+        <label htmlFor="select">Example Select</label>
+        <select id="select£" multiple data-testid="element">
+          <option data-testid="val1" value="1">
+            1
+          </option>
+          <option data-testid="val2" value="2">
+            2
+          </option>
+          <option data-testid="val3" value="3">
+            3
+          </option>
+        </select>
+      </form>
+    );
+
+    userEvent.selectOptions(getByTestId("element"), ["1", "3"]);
+
+    expect(getByTestId("val1").selected).toBe(true);
+    expect(getByTestId("val2").selected).toBe(false);
+    expect(getByTestId("val3").selected).toBe(true);
+  });
+
+  it("sets the selected prop on the selected OPTION using nested SELECT", () => {
+    const onSubmit = jest.fn();
+
+    const { getByTestId } = render(
+      <form onSubmit={onSubmit}>
+        <label>
+          Example Select
+          <select id="select£" multiple data-testid="element">
+            <option data-testid="val1" value="1">
+              1
+            </option>
+            <option data-testid="val2" value="2">
+              2
+            </option>
+            <option data-testid="val3" value="3">
+              3
+            </option>
+          </select>
+        </label>
+      </form>
+    );
+
+    userEvent.selectOptions(getByTestId("element"), ["1", "3"]);
+
+    expect(getByTestId("val1").selected).toBe(true);
+    expect(getByTestId("val2").selected).toBe(false);
+    expect(getByTestId("val3").selected).toBe(true);
+  });
 });

--- a/__tests__/react/selectoptions.js
+++ b/__tests__/react/selectoptions.js
@@ -178,7 +178,7 @@ describe("userEvent.selectOptions", () => {
     const { getByTestId } = render(
       <form onSubmit={onSubmit}>
         <label htmlFor="select">Example Select</label>
-        <select id="select£" multiple data-testid="element">
+        <select id="select" data-testid="element">
           <option data-testid="val1" value="1">
             1
           </option>
@@ -192,11 +192,11 @@ describe("userEvent.selectOptions", () => {
       </form>
     );
 
-    userEvent.selectOptions(getByTestId("element"), ["1", "3"]);
+    userEvent.selectOptions(getByTestId("element"), "2");
 
-    expect(getByTestId("val1").selected).toBe(true);
-    expect(getByTestId("val2").selected).toBe(false);
-    expect(getByTestId("val3").selected).toBe(true);
+    expect(getByTestId("val1").selected).toBe(false);
+    expect(getByTestId("val2").selected).toBe(true);
+    expect(getByTestId("val3").selected).toBe(false);
   });
 
   it("sets the selected prop on the selected OPTION using nested SELECT", () => {
@@ -206,7 +206,7 @@ describe("userEvent.selectOptions", () => {
       <form onSubmit={onSubmit}>
         <label>
           Example Select
-          <select id="select£" multiple data-testid="element">
+          <select data-testid="element">
             <option data-testid="val1" value="1">
               1
             </option>
@@ -221,10 +221,10 @@ describe("userEvent.selectOptions", () => {
       </form>
     );
 
-    userEvent.selectOptions(getByTestId("element"), ["1", "3"]);
+    userEvent.selectOptions(getByTestId("element"), "2");
 
-    expect(getByTestId("val1").selected).toBe(true);
-    expect(getByTestId("val2").selected).toBe(false);
-    expect(getByTestId("val3").selected).toBe(true);
+    expect(getByTestId("val1").selected).toBe(false);
+    expect(getByTestId("val2").selected).toBe(true);
+    expect(getByTestId("val3").selected).toBe(false);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ function clickLabel(label) {
     input.focus();
     fireEvent.click(label);
   } else {
-    const input = label.querySelector("input,textarea");
+    const input = label.querySelector("input,textarea,select");
     input.focus();
     label.focus();
     fireEvent.click(label);


### PR DESCRIPTION
When testing SELECT elements, If a label uses `htmlFor` then everything works fine, but if instead the label contains the form element inside it then an error is thrown.

    const { getByTestId } = render(
      <form onSubmit={onSubmit}>
        <label>
          Example Select
          <select data-testid="element">
            <option data-testid="val1" value="1">
              1
            </option>
            <option data-testid="val2" value="2">
              2
            </option>
            <option data-testid="val3" value="3">
              3
            </option>
          </select>
        </label>
      </form>
    );

    userEvent.selectOptions(getByTestId("element"), "2");

    expect(getByTestId("val1").selected).toBe(false);
    expect(getByTestId("val2").selected).toBe(true);
    expect(getByTestId("val3").selected).toBe(false);

Error is : `TypeError: Cannot read property 'focus' of null` 

    at clickLabel (node_modules/@testing-library/user-event/dist/index.js:38:11)
    at clickElement (node_modules/@testing-library/user-event/dist/index.js:73:20)
    at Object.selectOptions (node_modules/@testing-library/user-event/dist/index.js:198:5)

This already seems to be handled for INPUT and TEXTAREA. This pull request adds SELECT plus a couple of tests to check both usages work.
   