### PR TITLE
Add ops.target to selectOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ one character at the time. `false` is the default value.
 are typed. By default it's 0. You can use this option if your component has a
 different behavior for fast or slow users.
 
-### `selectOptions(element, values)`
+### `selectOptions(element, values, [options])`
 
 Selects the specified option(s) of a `<select>` or a `<select multiple>`
 element.
@@ -166,6 +166,9 @@ expect(getByTestId("val3").selected).toBe(true);
 
 The `values` parameter can be either an array of values or a singular scalar
 value.
+
+If `options.target` parameter is set, it will use its value to extract option to
+select.
 
 ## Contributors
 

--- a/__tests__/react/selectoptions.js
+++ b/__tests__/react/selectoptions.js
@@ -172,6 +172,34 @@ describe("userEvent.selectOptions", () => {
     expect(getByTestId("val3").selected).toBe(true);
   });
 
+  it("sets the selected prop on the selected OPTION when opts.target is set", () => {
+    const onSubmit = jest.fn();
+
+    const { getByTestId } = render(
+      <form onSubmit={onSubmit}>
+        <select multiple data-testid="element">
+          <option data-testid="val1" value="1">
+            text-1
+          </option>
+          <option data-testid="val2" value="2">
+            text-2
+          </option>
+          <option data-testid="val3" value="3">
+            text-3
+          </option>
+        </select>
+      </form>
+    );
+
+    userEvent.selectOptions(getByTestId("element"), ["text-1", "text-3"], {
+      target: "text"
+    });
+
+    expect(getByTestId("val1").selected).toBe(true);
+    expect(getByTestId("val2").selected).toBe(false);
+    expect(getByTestId("val3").selected).toBe(true);
+  });
+
   it("sets the selected prop on the selected OPTION using htmlFor", () => {
     const onSubmit = jest.fn();
 

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,11 @@ const userEvent = {
     wasAnotherElementFocused && focusedElement.blur();
   },
 
-  selectOptions(element, values) {
+  selectOptions(element, values, userOpts = {}) {
+    const defaultOpts = {
+      target: "value"
+    };
+    const opts = Object.assign(defaultOpts, userOpts);
     const focusedElement = document.activeElement;
     const wasAnotherElementFocused =
       focusedElement !== document.body && focusedElement !== element;
@@ -157,7 +161,7 @@ const userEvent = {
 
     const valArray = Array.isArray(values) ? values : [values];
     const selectedOptions = Array.from(element.children).filter(
-      opt => opt.tagName === "OPTION" && valArray.includes(opt.value)
+      opt => opt.tagName === "OPTION" && valArray.includes(opt[opts.target])
     );
 
     if (selectedOptions.length > 0) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,12 +4,20 @@ export interface IUserOptions {
     delay?: number;
 }
 
+export interface IUserSelectOptions {
+    target?: string;
+}
+
 type TargetElement = Element | Window;
 
 declare const userEvent: {
     click: (element: TargetElement) => void;
     dblClick: (element: TargetElement) => void;
-    selectOptions: (element: TargetElement, values: string | string[]) => void;
+    selectOptions: (
+        element: TargetElement,
+        values: string | string[],
+        userOpts?: IUserSelectOptions
+    ) => void;
     type: (
         element: TargetElement,
         text: string,


### PR DESCRIPTION
In some cases, the `option.value` and `option.text` are not tightly coupled.

Some developers want to hide the internal `option.value` and show nicely-formatted text.

This PR will provide a way to specify how the options should be extracted.