### PR TITLE
Fix example in README for `type` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { getByText } = test("click", () => {
+const { getByTestId } = test("click", () => {
   render(<textarea data-testid="email" />);
 });
 


### PR DESCRIPTION
Was reading the README and noticed that this example destructures `getByText` but uses `getByTestId`.

Wasn't able to find a `CONTRIBUTORS` file so I'm not sure if you're accepting PRs but I hope this is helpful! Happy to make any changes to commit format etc.

And finally a huge thanks to this project and all of the `@testing-library` ecosystem!