### PR TITLE
Correct focus changes based on mouseDown result

### DIFF
--- a/__tests__/react/click.js
+++ b/__tests__/react/click.js
@@ -293,4 +293,22 @@ describe("userEvent.click", () => {
     userEvent.click(getByText("Submit"));
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it.each(["input", "textarea"])(
+    "should not give focus for <%s> when mouseDown is prevented",
+    type => {
+      const { getByTestId } = render(
+        React.createElement(type, {
+          "data-testid": "element",
+          onMouseDown: (evt) => {
+            evt.preventDefault();
+          },
+        })
+      );
+
+      userEvent.click(getByTestId("element"));
+
+      expect(getByTestId("element")).not.toHaveFocus();
+    }
+  );
 });

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,10 @@ function clickBooleanElement(element) {
 function clickElement(element) {
   fireEvent.mouseOver(element);
   fireEvent.mouseMove(element);
-  fireEvent.mouseDown(element);
-  element.focus();
+  const continueDefaultHandling = fireEvent.mouseDown(element);
+  if (continueDefaultHandling) {
+    element.focus();
+  }
   fireEvent.mouseUp(element);
   fireEvent.click(element);
 


### PR DESCRIPTION
Because `userEvent.click` should simulate real browsers' behavior, we need to take into account the result of each event.

In this particular case if `mouseDown` event has `preventDefault`, it should stop focus event.

Here is the source code of Google Chrome Blink for reference (others follow the same convention):
https://chromium.googlesource.com/chromium/blink/+/master/Source/core/input/EventHandler.cpp#972

```
bool swallowEvent = !dispatchMouseEvent(EventTypeNames::mousedown, mev.innerNode(), m_clickCount, mouseEvent);
```

`dispatchMouseEvent` return value means "continue default handling", so `swallowEvent` is `true` in case of `preventDefault` usage.

Just below there is call for focus event which is triggered only if `swallowEvent === false` 
```
swallowEvent = swallowEvent || handleMouseFocus(MouseEventWithHitTestResults(mouseEvent, hitTestResult), sourceCapabilities);
``` 

We heavily rely on this case when developing complex components for the design system with focus management.

Another moment is that we probably should use `fireEvent.focus()` instead of `element.focus()` to also understand if `onFocus` was canceled, but that's for another change (related to scrollbar behavior on focus).
