### PR TITLE
feat: focus trap on tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const { getByTestId } = render(
 );
 
 userEvent.selectOptions(getByTestId("select-multiple"), ["1", "3"]);
-
+j
 expect(getByTestId("val1").selected).toBe(true);
 expect(getByTestId("val2").selected).toBe(false);
 expect(getByTestId("val3").selected).toBe(true);
@@ -177,6 +177,8 @@ Options:
 - `shift` (default `false`) can be true or false to invert tab direction.
 - `focusTrap` (default `document`) a container element to restrict the tabbing
   within.
+
+> **A note about tab**: [jsdom does not support tabbing](https://github.com/jsdom/jsdom/issues/2102), so this feature  is a way to enable tests to verify tabbing from the end user's perspective.  However, this limitation in jsdom will mean that components like [focus-trap-react](https://github.com/davidtheclark/focus-trap-react) will not work with `userEvent.tab()` or jsdom.  For that reason, the `focusTrap` option is available to let you ensure your user is restricted within a focus-trap.  
 
 ```jsx
 import React from "react";

--- a/README.md
+++ b/README.md
@@ -169,11 +169,14 @@ value.
 
 ### `tab({shift, focusTrap})`
 
-Fires a tab event changing the document.activeElement in the same way the browser does.
+Fires a tab event changing the document.activeElement in the same way the
+browser does.
 
-Options: 
+Options:
+
 - `shift` (default `false`) can be true or false to invert tab direction.
-- `focusTrap` (default `document`) a container element to restrict the tabbing within.
+- `focusTrap` (default `document`) a container element to restrict the tabbing
+  within.
 
 ```jsx
 import React from "react";
@@ -181,36 +184,35 @@ import { render } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import userEvent from "@testing-library/user-event";
 
-
 it("should cycle elements in document tab order", () => {
-      const { getAllByTestId } = render(
-          <div>
-              <input data-testid="element" type="checkbox" />
-              <input data-testid="element" type="radio" />
-              <input data-testid="element" type="number" />
-          </div>
-      );
+  const { getAllByTestId } = render(
+    <div>
+      <input data-testid="element" type="checkbox" />
+      <input data-testid="element" type="radio" />
+      <input data-testid="element" type="number" />
+    </div>
+  );
 
-      const [checkbox, radio, number] = getAllByTestId("element");
+  const [checkbox, radio, number] = getAllByTestId("element");
 
-      expect(document.body).toHaveFocus()
+  expect(document.body).toHaveFocus();
 
-      userEvent.tab();
+  userEvent.tab();
 
-      expect(checkbox).toHaveFocus();
+  expect(checkbox).toHaveFocus();
 
-      userEvent.tab();
+  userEvent.tab();
 
-      expect(radio).toHaveFocus()
+  expect(radio).toHaveFocus();
 
-      userEvent.tab();
+  userEvent.tab();
 
-      expect(number).toHaveFocus()
+  expect(number).toHaveFocus();
 
-      userEvent.tab();
+  userEvent.tab();
 
-      // cycle goes back to first element
-      expect(checkbox).toHaveFocus()
+  // cycle goes back to first element
+  expect(checkbox).toHaveFocus();
 });
 ```
 
@@ -244,6 +246,7 @@ Thanks goes to these wonderful people
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const { getByTestId } = render(
 );
 
 userEvent.selectOptions(getByTestId("select-multiple"), ["1", "3"]);
-j
+
 expect(getByTestId("val1").selected).toBe(true);
 expect(getByTestId("val2").selected).toBe(false);
 expect(getByTestId("val3").selected).toBe(true);

--- a/README.md
+++ b/README.md
@@ -167,6 +167,53 @@ expect(getByTestId("val3").selected).toBe(true);
 The `values` parameter can be either an array of values or a singular scalar
 value.
 
+### `tab({shift, focusTrap})`
+
+Fires a tab event changing the document.activeElement in the same way the browser does.
+
+Options: 
+- `shift` (default `false`) can be true or false to invert tab direction.
+- `focusTrap` (default `document`) a container element to restrict the tabbing within.
+
+```jsx
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import userEvent from "@testing-library/user-event";
+
+
+it("should cycle elements in document tab order", () => {
+      const { getAllByTestId } = render(
+          <div>
+              <input data-testid="element" type="checkbox" />
+              <input data-testid="element" type="radio" />
+              <input data-testid="element" type="number" />
+          </div>
+      );
+
+      const [checkbox, radio, number] = getAllByTestId("element");
+
+      expect(document.body).toHaveFocus()
+
+      userEvent.tab();
+
+      expect(checkbox).toHaveFocus();
+
+      userEvent.tab();
+
+      expect(radio).toHaveFocus()
+
+      userEvent.tab();
+
+      expect(number).toHaveFocus()
+
+      userEvent.tab();
+
+      // cycle goes back to first element
+      expect(checkbox).toHaveFocus()
+});
+```
+
 ## Contributors
 
 Thanks goes to these wonderful people

--- a/__tests__/react/tab.js
+++ b/__tests__/react/tab.js
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom/extend-expect";
 import userEvent from "../../src";
 
 describe("userEvent.tab", () => {
-     it("should cycle elements in document tab order", () => {
+    it("should cycle elements in document tab order", () => {
         const { getAllByTestId } = render(
             <div>
                 <input data-testid="element" type="checkbox" />
@@ -31,8 +31,8 @@ describe("userEvent.tab", () => {
 
         userEvent.tab();
 
-         // cycle goes back to first element
-         expect(document.activeElement).toBe(checkbox); 
+        // cycle goes back to first element
+        expect(document.activeElement).toBe(checkbox);
     });
 
     it("should go backwards when shift = true", () => {
@@ -155,5 +155,61 @@ describe("userEvent.tab", () => {
 
         expect(document.activeElement).toBe(link);
     });
+
+    it("should stay within a focus trab", () => {
+        const { getAllByTestId, getByTestId } = render(
+            <>
+                <div data-testid="div1">
+                    <input data-testid="element" type="checkbox" />
+                    <input data-testid="element" type="radio" />
+                    <input data-testid="element" type="number" />
+                </div>
+                <div data-testid="div2">
+                    <input data-testid="element" foo="bar" type="checkbox" />
+                    <input data-testid="element" foo="bar" type="radio" />
+                    <input data-testid="element" foo="bar" type="number" />
+                </div>
+            </>
+        );
+
+        const [div1, div2] = [getByTestId("div1"), getByTestId("div2")]
+        const [checkbox1, radio1, number1, checkbox2, radio2, number2] = getAllByTestId("element");
+
+        expect(document.activeElement).toBe(document.body);
+
+        userEvent.tab({ focusTrap: div1 });
+
+        expect(document.activeElement).toBe(checkbox1);
+
+        userEvent.tab({ focusTrap: div1 });
+
+        expect(document.activeElement).toBe(radio1);
+
+        userEvent.tab({ focusTrap: div1 });
+
+        expect(document.activeElement).toBe(number1);
+
+        userEvent.tab({ focusTrap: div1 });
+
+        // cycle goes back to first element
+        expect(document.activeElement).toBe(checkbox1);
+
+        userEvent.tab({ focusTrap: div2 });
+
+        expect(document.activeElement).toBe(checkbox2);
+
+        userEvent.tab({ focusTrap: div2 });
+
+        expect(document.activeElement).toBe(radio2);
+
+        userEvent.tab({ focusTrap: div2 });
+
+        expect(document.activeElement).toBe(number2);
+
+        userEvent.tab({ focusTrap: div2 });
+
+        // cycle goes back to first element
+        expect(document.activeElement).toBe(checkbox2);
+    })
 
 });

--- a/__tests__/react/tab.js
+++ b/__tests__/react/tab.js
@@ -15,24 +15,24 @@ describe("userEvent.tab", () => {
 
         const [checkbox, radio, number] = getAllByTestId("element");
 
-        expect(document.activeElement).toBe(document.body);
+        expect(document.body).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus();
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(radio);
+        expect(radio).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(number);
+        expect(number).toHaveFocus()
 
         userEvent.tab();
 
         // cycle goes back to first element
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
     });
 
     it("should go backwards when shift = true", () => {
@@ -50,11 +50,11 @@ describe("userEvent.tab", () => {
 
         userEvent.tab({ shift: true });
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
 
         userEvent.tab({ shift: true });
 
-        expect(document.activeElement).toBe(number);
+        expect(number).toHaveFocus()
     });
 
     it("should respect tabindex, regardless of dom position", () => {
@@ -70,22 +70,22 @@ describe("userEvent.tab", () => {
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(radio);
+        expect(radio).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(number);
+        expect(number).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(radio);
+        expect(radio).toHaveFocus()
     });
 
-    it('should respect dom order when tabindex are all the same', () => {
+    it("should respect dom order when tabindex are all the same", () => {
         const { getAllByTestId } = render(
             <div>
                 <input data-testid="element" tabIndex={0} type="checkbox" />
@@ -98,22 +98,22 @@ describe("userEvent.tab", () => {
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(number);
+        expect(number).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(radio);
+        expect(radio).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
     });
 
-    it('should suport a mix of elements with/without tab index', () => {
+    it("should suport a mix of elements with/without tab index", () => {
         const { getAllByTestId } = render(
             <div>
                 <input data-testid="element" tabIndex={0} type="checkbox" />
@@ -126,22 +126,23 @@ describe("userEvent.tab", () => {
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
         userEvent.tab();
 
-        expect(document.activeElement).toBe(number);
+        expect(number).toHaveFocus()
         userEvent.tab();
 
-        expect(document.activeElement).toBe(radio);
-
+        expect(radio).toHaveFocus()
     });
 
-    it('should not tab to <a> with no href', () => {
+    it("should not tab to <a> with no href", () => {
         const { getAllByTestId } = render(
             <div>
                 <input data-testid="element" tabIndex={0} type="checkbox" />
                 <a>ignore this</a>
-                <a data-testid="element" href="http://www.testingjavascript.com">a link</a>
+                <a data-testid="element" href="http://www.testingjavascript.com">
+                    a link
+        </a>
             </div>
         );
 
@@ -149,11 +150,11 @@ describe("userEvent.tab", () => {
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(checkbox);
+        expect(checkbox).toHaveFocus()
 
         userEvent.tab();
 
-        expect(document.activeElement).toBe(link);
+        expect(link).toHaveFocus()
     });
 
     it("should stay within a focus trab", () => {
@@ -172,44 +173,50 @@ describe("userEvent.tab", () => {
             </>
         );
 
-        const [div1, div2] = [getByTestId("div1"), getByTestId("div2")]
-        const [checkbox1, radio1, number1, checkbox2, radio2, number2] = getAllByTestId("element");
+        const [div1, div2] = [getByTestId("div1"), getByTestId("div2")];
+        const [
+            checkbox1,
+            radio1,
+            number1,
+            checkbox2,
+            radio2,
+            number2
+        ] = getAllByTestId("element");
 
-        expect(document.activeElement).toBe(document.body);
+        expect(document.body).toHaveFocus()
 
         userEvent.tab({ focusTrap: div1 });
 
-        expect(document.activeElement).toBe(checkbox1);
+        expect(checkbox1).toHaveFocus()
 
         userEvent.tab({ focusTrap: div1 });
 
-        expect(document.activeElement).toBe(radio1);
+        expect(radio1).toHaveFocus()
 
         userEvent.tab({ focusTrap: div1 });
 
-        expect(document.activeElement).toBe(number1);
+        expect(number1).toHaveFocus()
 
         userEvent.tab({ focusTrap: div1 });
 
         // cycle goes back to first element
-        expect(document.activeElement).toBe(checkbox1);
+        expect(checkbox1).toHaveFocus()
 
         userEvent.tab({ focusTrap: div2 });
 
-        expect(document.activeElement).toBe(checkbox2);
+        expect(checkbox2).toHaveFocus()
 
         userEvent.tab({ focusTrap: div2 });
 
-        expect(document.activeElement).toBe(radio2);
+        expect(radio2).toHaveFocus()
 
         userEvent.tab({ focusTrap: div2 });
 
-        expect(document.activeElement).toBe(number2);
+        expect(number2).toHaveFocus()
 
         userEvent.tab({ focusTrap: div2 });
 
         // cycle goes back to first element
-        expect(document.activeElement).toBe(checkbox2);
-    })
-
+        expect(checkbox2).toHaveFocus()
+    });
 });

--- a/__tests__/react/tab.js
+++ b/__tests__/react/tab.js
@@ -4,219 +4,219 @@ import "@testing-library/jest-dom/extend-expect";
 import userEvent from "../../src";
 
 describe("userEvent.tab", () => {
-    it("should cycle elements in document tab order", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" type="checkbox" />
-                <input data-testid="element" type="radio" />
-                <input data-testid="element" type="number" />
-            </div>
-        );
+  it("should cycle elements in document tab order", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" type="checkbox" />
+        <input data-testid="element" type="radio" />
+        <input data-testid="element" type="number" />
+      </div>
+    );
 
-        const [checkbox, radio, number] = getAllByTestId("element");
+    const [checkbox, radio, number] = getAllByTestId("element");
 
-        expect(document.body).toHaveFocus()
+    expect(document.body).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus();
+    expect(checkbox).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(radio).toHaveFocus()
+    expect(radio).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(number).toHaveFocus()
+    expect(number).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        // cycle goes back to first element
-        expect(checkbox).toHaveFocus()
-    });
+    // cycle goes back to first element
+    expect(checkbox).toHaveFocus();
+  });
 
-    it("should go backwards when shift = true", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" type="checkbox" />
-                <input data-testid="element" type="radio" />
-                <input data-testid="element" type="number" />
-            </div>
-        );
+  it("should go backwards when shift = true", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" type="checkbox" />
+        <input data-testid="element" type="radio" />
+        <input data-testid="element" type="number" />
+      </div>
+    );
 
-        const [checkbox, radio, number] = getAllByTestId("element");
+    const [checkbox, radio, number] = getAllByTestId("element");
 
-        radio.focus();
+    radio.focus();
 
-        userEvent.tab({ shift: true });
+    userEvent.tab({ shift: true });
 
-        expect(checkbox).toHaveFocus()
+    expect(checkbox).toHaveFocus();
 
-        userEvent.tab({ shift: true });
+    userEvent.tab({ shift: true });
 
-        expect(number).toHaveFocus()
-    });
+    expect(number).toHaveFocus();
+  });
 
-    it("should respect tabindex, regardless of dom position", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" tabIndex={2} type="checkbox" />
-                <input data-testid="element" tabIndex={1} type="radio" />
-                <input data-testid="element" tabIndex={3} type="number" />
-            </div>
-        );
+  it("should respect tabindex, regardless of dom position", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" tabIndex={2} type="checkbox" />
+        <input data-testid="element" tabIndex={1} type="radio" />
+        <input data-testid="element" tabIndex={3} type="number" />
+      </div>
+    );
 
-        const [checkbox, radio, number] = getAllByTestId("element");
+    const [checkbox, radio, number] = getAllByTestId("element");
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(radio).toHaveFocus()
+    expect(radio).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus()
+    expect(checkbox).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(number).toHaveFocus()
+    expect(number).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(radio).toHaveFocus()
-    });
+    expect(radio).toHaveFocus();
+  });
 
-    it("should respect dom order when tabindex are all the same", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" tabIndex={0} type="checkbox" />
-                <input data-testid="element" tabIndex={1} type="radio" />
-                <input data-testid="element" tabIndex={0} type="number" />
-            </div>
-        );
+  it("should respect dom order when tabindex are all the same", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" tabIndex={0} type="checkbox" />
+        <input data-testid="element" tabIndex={1} type="radio" />
+        <input data-testid="element" tabIndex={0} type="number" />
+      </div>
+    );
 
-        const [checkbox, radio, number] = getAllByTestId("element");
+    const [checkbox, radio, number] = getAllByTestId("element");
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus()
+    expect(checkbox).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(number).toHaveFocus()
+    expect(number).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(radio).toHaveFocus()
+    expect(radio).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus()
-    });
+    expect(checkbox).toHaveFocus();
+  });
 
-    it("should suport a mix of elements with/without tab index", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" tabIndex={0} type="checkbox" />
-                <input data-testid="element" tabIndex={1} type="radio" />
-                <input data-testid="element" type="number" />
-            </div>
-        );
+  it("should suport a mix of elements with/without tab index", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" tabIndex={0} type="checkbox" />
+        <input data-testid="element" tabIndex={1} type="radio" />
+        <input data-testid="element" type="number" />
+      </div>
+    );
 
-        const [checkbox, radio, number] = getAllByTestId("element");
+    const [checkbox, radio, number] = getAllByTestId("element");
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus()
-        userEvent.tab();
+    expect(checkbox).toHaveFocus();
+    userEvent.tab();
 
-        expect(number).toHaveFocus()
-        userEvent.tab();
+    expect(number).toHaveFocus();
+    userEvent.tab();
 
-        expect(radio).toHaveFocus()
-    });
+    expect(radio).toHaveFocus();
+  });
 
-    it("should not tab to <a> with no href", () => {
-        const { getAllByTestId } = render(
-            <div>
-                <input data-testid="element" tabIndex={0} type="checkbox" />
-                <a>ignore this</a>
-                <a data-testid="element" href="http://www.testingjavascript.com">
-                    a link
+  it("should not tab to <a> with no href", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <input data-testid="element" tabIndex={0} type="checkbox" />
+        <a>ignore this</a>
+        <a data-testid="element" href="http://www.testingjavascript.com">
+          a link
         </a>
-            </div>
-        );
+      </div>
+    );
 
-        const [checkbox, link] = getAllByTestId("element");
+    const [checkbox, link] = getAllByTestId("element");
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(checkbox).toHaveFocus()
+    expect(checkbox).toHaveFocus();
 
-        userEvent.tab();
+    userEvent.tab();
 
-        expect(link).toHaveFocus()
-    });
+    expect(link).toHaveFocus();
+  });
 
-    it("should stay within a focus trab", () => {
-        const { getAllByTestId, getByTestId } = render(
-            <>
-                <div data-testid="div1">
-                    <input data-testid="element" type="checkbox" />
-                    <input data-testid="element" type="radio" />
-                    <input data-testid="element" type="number" />
-                </div>
-                <div data-testid="div2">
-                    <input data-testid="element" foo="bar" type="checkbox" />
-                    <input data-testid="element" foo="bar" type="radio" />
-                    <input data-testid="element" foo="bar" type="number" />
-                </div>
-            </>
-        );
+  it("should stay within a focus trab", () => {
+    const { getAllByTestId, getByTestId } = render(
+      <>
+        <div data-testid="div1">
+          <input data-testid="element" type="checkbox" />
+          <input data-testid="element" type="radio" />
+          <input data-testid="element" type="number" />
+        </div>
+        <div data-testid="div2">
+          <input data-testid="element" foo="bar" type="checkbox" />
+          <input data-testid="element" foo="bar" type="radio" />
+          <input data-testid="element" foo="bar" type="number" />
+        </div>
+      </>
+    );
 
-        const [div1, div2] = [getByTestId("div1"), getByTestId("div2")];
-        const [
-            checkbox1,
-            radio1,
-            number1,
-            checkbox2,
-            radio2,
-            number2
-        ] = getAllByTestId("element");
+    const [div1, div2] = [getByTestId("div1"), getByTestId("div2")];
+    const [
+      checkbox1,
+      radio1,
+      number1,
+      checkbox2,
+      radio2,
+      number2
+    ] = getAllByTestId("element");
 
-        expect(document.body).toHaveFocus()
+    expect(document.body).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div1 });
+    userEvent.tab({ focusTrap: div1 });
 
-        expect(checkbox1).toHaveFocus()
+    expect(checkbox1).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div1 });
+    userEvent.tab({ focusTrap: div1 });
 
-        expect(radio1).toHaveFocus()
+    expect(radio1).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div1 });
+    userEvent.tab({ focusTrap: div1 });
 
-        expect(number1).toHaveFocus()
+    expect(number1).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div1 });
+    userEvent.tab({ focusTrap: div1 });
 
-        // cycle goes back to first element
-        expect(checkbox1).toHaveFocus()
+    // cycle goes back to first element
+    expect(checkbox1).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div2 });
+    userEvent.tab({ focusTrap: div2 });
 
-        expect(checkbox2).toHaveFocus()
+    expect(checkbox2).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div2 });
+    userEvent.tab({ focusTrap: div2 });
 
-        expect(radio2).toHaveFocus()
+    expect(radio2).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div2 });
+    userEvent.tab({ focusTrap: div2 });
 
-        expect(number2).toHaveFocus()
+    expect(number2).toHaveFocus();
 
-        userEvent.tab({ focusTrap: div2 });
+    userEvent.tab({ focusTrap: div2 });
 
-        // cycle goes back to first element
-        expect(checkbox2).toHaveFocus()
-    });
+    // cycle goes back to first element
+    expect(checkbox2).toHaveFocus();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { fireEvent } from "@testing-library/dom";
 
 function wait(time) {
-  return new Promise(function (resolve) {
+  return new Promise(function(resolve) {
     setTimeout(() => resolve(), time);
   });
 }
@@ -231,7 +231,7 @@ const userEvent = {
       "input, button, select, textarea, a[href], [tabindex]"
     );
     const list = Array.prototype.filter
-      .call(focusableElements, function (item) {
+      .call(focusableElements, function(item) {
         return item.getAttribute("tabindex") !== "-1";
       })
       .sort((a, b) => {

--- a/src/index.js
+++ b/src/index.js
@@ -226,8 +226,8 @@ const userEvent = {
     element.addEventListener("blur", fireChangeEvent);
   },
 
-  tab({ shift = false } = {}) {
-    const focusableElements = document.querySelectorAll(
+  tab({ shift = false, focusTrap = document } = {}) {
+    const focusableElements = focusTrap.querySelectorAll(
       "input, button, select, textarea, a[href], [tabindex]"
     );
     const list = Array.prototype.filter


### PR DESCRIPTION
This feature allows you to easily test tabbing in focus traps. 

example:

```userEvent.tab({focusTrap: containerElement})```

also adds tab to readme and converts expects to use jest dom for tabs