### PR TITLE
fix tab focus on disabled elements false positive

### DIFF
--- a/__tests__/react/tab.js
+++ b/__tests__/react/tab.js
@@ -220,3 +220,23 @@ describe("userEvent.tab", () => {
     expect(checkbox2).toHaveFocus();
   });
 });
+
+it("should not focus disabled elements", () => {
+  const { getByTestId } = render(
+    <div>
+      <input data-testid="one" />
+      <input tabIndex={-1} />
+      <button disabled>click</button>
+      <input disabled />
+      <input data-testid="five" />
+    </div>
+  );
+
+  const [one, five] = [getByTestId("one"), getByTestId("five")];
+
+  userEvent.tab();
+  expect(one).toHaveFocus();
+
+  userEvent.tab();
+  expect(five).toHaveFocus();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ const userEvent = {
     );
     const list = Array.prototype.filter
       .call(focusableElements, function(item) {
-        return item.getAttribute("tabindex") !== "-1";
+        return item.getAttribute("tabindex") !== "-1" && !item.disabled;
       })
       .sort((a, b) => {
         const tabIndexA = a.getAttribute("tabindex");


### PR DESCRIPTION
this PR fixes a false positive that allowed the `tab` function to focus disabled elements, which is not the browser behavior


done @ [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/) Milano