### PR TITLE
fix(click): click no longer blurs when focus changes during onClick event

### DIFF
--- a/__tests__/react/click.js
+++ b/__tests__/react/click.js
@@ -198,6 +198,32 @@ describe("userEvent.click", () => {
     expect(b).toHaveFocus();
   });
 
+  it("does not lose focus when click updates focus", () => {
+    const FocusComponent = () => {
+      const inputRef = React.useRef();
+      const focusInput = () => inputRef.current.focus();
+
+      return (
+        <React.Fragment>
+          <input data-testid="input" ref={inputRef} />
+          <button onClick={focusInput}>Update Focus</button>
+        </React.Fragment>
+      );
+    };
+    const { getByTestId, getByText } = render(<FocusComponent />);
+
+    const input = getByTestId("input");
+    const button = getByText("Update Focus");
+
+    expect(input).not.toHaveFocus();
+
+    userEvent.click(button);
+    expect(input).toHaveFocus();
+
+    userEvent.click(button);
+    expect(input).toHaveFocus();
+  });
+
   it.each(["input", "textarea"])(
     "gives focus to <%s> when clicking a <label> with htmlFor",
     type => {

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,15 @@ function fireChangeEvent(event) {
   event.target.removeEventListener("blur", fireChangeEvent);
 }
 
+function blurFocusedElement(element, focusedElement, wasAnotherElementFocused) {
+  if (
+    wasAnotherElementFocused &&
+    element.ownerDocument.activeElement === element
+  ) {
+    focusedElement.blur();
+  }
+}
+
 const userEvent = {
   click(element) {
     const focusedElement = element.ownerDocument.activeElement;
@@ -123,7 +132,7 @@ const userEvent = {
         clickElement(element);
     }
 
-    wasAnotherElementFocused && focusedElement.blur();
+    blurFocusedElement(element, focusedElement, wasAnotherElementFocused);
   },
 
   dblClick(element) {
@@ -145,7 +154,7 @@ const userEvent = {
         dblClickElement(element);
     }
 
-    wasAnotherElementFocused && focusedElement.blur();
+    blurFocusedElement(element, focusedElement, wasAnotherElementFocused);
   },
 
   selectOptions(element, values) {
@@ -172,7 +181,7 @@ const userEvent = {
       }
     }
 
-    wasAnotherElementFocused && focusedElement.blur();
+    blurFocusedElement(element, focusedElement, wasAnotherElementFocused);
   },
 
   async type(element, text, userOpts = {}) {


### PR DESCRIPTION
I came across this issue while testing form components. It is common for a form to focus inputs that are invalid, and I was seeing strange behavior where I couldn't invalidate and focus the same input element twice. I did a bit of digging and see that events call blur after the click event is fired, so I believe we can fix this by checking to see if focus has already changed before calling blur. 