### PR TITLE
fix:type no longer clips final character with negative maxlength

### DIFF
--- a/__tests__/react/type.js
+++ b/__tests__/react/type.js
@@ -31,6 +31,24 @@ describe("userEvent.type", () => {
     expect(getByTestId("input")).toHaveProperty("value", "hello world");
   });
 
+  it.each(["input", "textarea"])(
+    "includes entire textstring with negative maxlength in <%s>",
+    type => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        React.createElement(type, {
+          "data-testid": "input",
+          onChange: onChange,
+          maxLength: -1
+        })
+      );
+      const text = "Hello, world!";
+      userEvent.type(getByTestId("input"), text);
+      expect(onChange).toHaveBeenCalledTimes(text.length);
+      expect(getByTestId("input")).toHaveProperty("value", text);
+    }
+  );
+
   it("should append text all at once", () => {
     const onChange = jest.fn();
     const { getByTestId } = render(

--- a/__tests__/vue/type.js
+++ b/__tests__/vue/type.js
@@ -27,6 +27,24 @@ describe("userEvent.type", () => {
     expect(getByTestId("input")).toHaveProperty("value", text);
   });
 
+  it.each(["input", "textarea"])(
+    "includes entire textstring with negative maxlength in <%s>",
+    type => {
+      const input = jest.fn();
+
+      const { getByTestId } = renderComponent(
+        type,
+        { input },
+        { maxLength: -1 }
+      );
+
+      const text = "Hello, world!";
+      userEvent.type(getByTestId("input"), text);
+      expect(input).toHaveBeenCalledTimes(text.length);
+      expect(getByTestId("input")).toHaveProperty("value", text);
+    }
+  );
+
   it("should not type when event.preventDefault() is called", () => {
     const input = jest.fn();
     const change = jest.fn();

--- a/src/index.js
+++ b/src/index.js
@@ -183,10 +183,7 @@ const userEvent = {
     };
     const opts = Object.assign(defaultOpts, userOpts);
 
-    const maxLength =
-      element.maxLength && element.maxLength >= 0
-        ? element.maxLength
-        : text.length;
+    const maxLength = element.maxLength > 0 ? element.maxLength : text.length;
     const computedText = text.slice(0, maxLength);
 
     const previousText = element.value;

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,11 @@ const userEvent = {
     };
     const opts = Object.assign(defaultOpts, userOpts);
 
-    const computedText = text.slice(0, element.maxLength || text.length);
+    const maxLength =
+      element.maxLength && element.maxLength >= 0
+        ? element.maxLength
+        : text.length;
+    const computedText = text.slice(0, maxLength);
 
     const previousText = element.value;
 


### PR DESCRIPTION
Resolves #217.

I noticed this issue when writing tests in a private repo. 

I'm not very familiar with `jest`, so I'm not sure if it's something with that or something else, but I noticed that elements created in the existing specs don't run into the `maxLength` problem mentioned in the linked issue, so I handled it a bit heavy-handedly in the spec.

I do know that creating a bland element with no attrs from a Chrome console can show the max length "bug".

```javascript
element = document.createElement('input')
element.maxLength
// -1
element = document.createElement('textarea')
element.maxLength
// -1
```