### PR TITLE
ignore maxLength -1 for userEvent.type

### DIFF
--- a/__tests__/react/type.js
+++ b/__tests__/react/type.js
@@ -208,4 +208,13 @@ describe("userEvent.type", () => {
       expect(onKeyUp).not.toHaveBeenCalled();
     }
   );
+
+  it("should ignore maxLength with value -1", () => {
+    const { getByTestId } = render(
+      <input data-testid="input" maxLength="-1" />
+    );
+    const input = getByTestId("input");
+    userEvent.type(input, "test");
+    expect(input).toHaveProperty("value", "test");
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ const userEvent = {
 
     let computedText;
     if (!element.maxLength || element.maxLength === -1) {
-      computedText = text.slice(0, text.length);
+      computedText = text.slice(0, element.maxLength > 0 ? element.maxLength : text.length);
     } else {
       computedText = text.slice(0, element.maxLength);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,12 @@ const userEvent = {
     };
     const opts = Object.assign(defaultOpts, userOpts);
 
-    const computedText = text.slice(0, element.maxLength || text.length);
+    let computedText;
+    if (!element.maxLength || element.maxLength === -1) {
+      computedText = text.slice(0, text.length);
+    } else {
+      computedText = text.slice(0, element.maxLength);
+    }
 
     const previousText = element.value;
 


### PR DESCRIPTION
### the problem
We use Karma as a test runner and run tests in the browser. When using userEvent.type, the last character of the value is sliced of. The default value for maxLength for inputs in browsers is -1. So this is true in all our tests. So for example `mytestvalue` becomes `mytestvalu`. A possible fix is ignoring maxLength -1. 

Wat do you think?