### PR TITLE
#232 type should support replacing the current input

### DIFF
--- a/__tests__/react/type.js
+++ b/__tests__/react/type.js
@@ -42,6 +42,34 @@ describe("userEvent.type", () => {
     expect(getByTestId("input")).toHaveProperty("value", "hello world");
   });
 
+  it("should replace text one by one", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <input data-testid="input" onChange={onChange} />
+    );
+    userEvent.type(getByTestId("input"), "hello", { replaceExisting: true });
+    userEvent.type(getByTestId("input"), "welcome", { replaceExisting: true });
+    expect(onChange).toHaveBeenCalledTimes("hello".length + "welcome".length);
+    expect(getByTestId("input")).toHaveProperty("value", "welcome");
+  });
+
+  it("should replace text all at once", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <input data-testid="input" onChange={onChange} />
+    );
+    userEvent.type(getByTestId("input"), "hello", {
+      allAtOnce: true,
+      replaceExisting: true,
+    });
+    userEvent.type(getByTestId("input"), "welcome", {
+      allAtOnce: true,
+      replaceExisting: true,
+    });
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(getByTestId("input")).toHaveProperty("value", "welcome");
+  });
+
   it("should not type when event.preventDefault() is called", () => {
     const onChange = jest.fn();
     const onKeydown = jest

--- a/src/index.js
+++ b/src/index.js
@@ -180,12 +180,13 @@ const userEvent = {
     const defaultOpts = {
       allAtOnce: false,
       delay: 0,
+      replaceExisting: false,
     };
     const opts = Object.assign(defaultOpts, userOpts);
 
     const computedText = text.slice(0, element.maxLength || text.length);
 
-    const previousText = element.value;
+    const previousText = opts.replaceExisting ? "" : element.value;
 
     if (opts.allAtOnce) {
       if (element.readOnly) return;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,6 +2,7 @@
 export interface IUserOptions {
     allAtOnce?: boolean;
     delay?: number;
+    replaceExisting?: boolean;
 }
 
 export interface ITabUserOptions {


### PR DESCRIPTION
This PR supports an extra option replaceExisting in the type function, which when set to true will replace the content of the input instead of appending.

The replaceExisting parameter will be optional and will be default to false.