### PR TITLE
fix: Add TypeScript userEvent.clear definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,6 +12,7 @@ export interface ITabUserOptions {
 export type TargetElement = Element | Window;
 
 declare const userEvent: {
+    clear: (element: TargetElement) => void;
     click: (element: TargetElement) => void;
     dblClick: (element: TargetElement) => void;
     selectOptions: (element: TargetElement, values: string | string[]) => void;


### PR DESCRIPTION
I found there is no userEvent.clear type definition in version 10.1.0 (https://github.com/testing-library/user-event/pull/233)
I just added userEvcent.clear 