### PR TITLE
fix: type when element.maxLength is -1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,8 @@ const userEvent = {
     };
     const opts = Object.assign(defaultOpts, userOpts);
 
-    const computedText = text.slice(0, element.maxLength || text.length);
+    const computedText =
+      element.maxLength > 0 ? text.slice(0, element.maxLength) : text;
 
     const previousText = element.value;
 


### PR DESCRIPTION
I'm using user-event in the browser, not sure if it's officially supported but it mostly works. 

There's a problem with `type`, it's removing the last char from the text because the browser returns -1 from `element.maxLength`. I changed it to only slice with maxLength when it's a positive number.