### PR TITLE
Reduce size of npm package by 99%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 after_success:
   - npm run codecov
   - npm run build
+  - rm ./cc-test-reporter
   - npm run travis-deploy-once "npm run semantic-release"
 branches:
   except:


### PR DESCRIPTION
There exists a 12MB binary in the tarball published to npm called `cc-test-reporter`.

This looks like a happy accident to me. It's only neccessary on the CI machine and should be removed before publishing the library.

The npm tarball for `user-event` is 12.9MB ; of which 12.8MB is this `cc-test-reporter` binary.