### PR TITLE
Document type for `click()`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -13,7 +13,7 @@ export type TargetElement = Element | Window;
 
 declare const userEvent: {
     clear: (element: TargetElement) => void;
-    click: (element: TargetElement) => void;
+    click: (element: TargetElement, init?: MouseEventInit) => void;
     dblClick: (element: TargetElement) => void;
     selectOptions: (element: TargetElement, values: string | string[]) => void;
     type: (


### PR DESCRIPTION
We've added the ability to pass the init argument. We need to document that in the typescript definition