### PR TITLE
fix(upload): FileList item function must return null instead undefined when it can't find a file

### DIFF
--- a/__tests__/react/upload.js
+++ b/__tests__/react/upload.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, fireEvent } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import userEvent from "../../src";
 
@@ -86,14 +86,6 @@ describe("userEvent.upload", () => {
     expect(input.files[0]).toStrictEqual(file);
     expect(input.files.item(0)).toStrictEqual(file);
     expect(input.files).toHaveLength(1);
-
-    fireEvent.change(input, {
-      target: { files: { item: () => {}, length: 0 } },
-    });
-
-    expect(input.files[0]).toBeUndefined();
-    expect(input.files.item[0]).toBeUndefined();
-    expect(input.files).toHaveLength(0);
   });
 
   it("should upload multiple files", () => {
@@ -113,14 +105,6 @@ describe("userEvent.upload", () => {
     expect(input.files[1]).toStrictEqual(files[1]);
     expect(input.files.item(1)).toStrictEqual(files[1]);
     expect(input.files).toHaveLength(2);
-
-    fireEvent.change(input, {
-      target: { files: { item: () => {}, length: 0 } },
-    });
-
-    expect(input.files[0]).toBeUndefined();
-    expect(input.files.item[0]).toBeUndefined();
-    expect(input.files).toHaveLength(0);
   });
 
   it("should not upload when is disabled", () => {
@@ -134,7 +118,7 @@ describe("userEvent.upload", () => {
     userEvent.upload(input, file);
 
     expect(input.files[0]).toBeUndefined();
-    expect(input.files.item[0]).toBeUndefined();
+    expect(input.files.item(0)).toBeNull();
     expect(input.files).toHaveLength(0);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ const userEvent = {
       target: {
         files: {
           length: files.length,
-          item: (index) => files[index],
+          item: (index) => files[index] || null,
           ...files,
         },
       },


### PR DESCRIPTION
I was looking at `FileList` implementation and noted that `item` function must return `File` or `null` instead `undefined`. Here is [`jsdom` implementation](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/living/file-api/FileList-impl.js#L10) of it. Also fix wrong expectation in test that's not cause an error when it must. Also I removed unnecessary expectations in `upload` tests.