### PR TITLE
Fire mouse events with the correct properties

### DIFF
--- a/src/__tests__/click.js
+++ b/src/__tests__/click.js
@@ -431,3 +431,181 @@ test.each(['input', 'textarea'])(
     expect(screen.getByTestId('element')).not.toHaveFocus()
   },
 )
+
+it('should fire mouse events with the correct properties', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+    />,
+  )
+
+  userEvent.click(screen.getByTestId('div'))
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousedown',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+    {
+      type: 'mouseup',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+    {
+      type: 'click',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+  ])
+})
+
+it('should fire mouse events with custom button property', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail,
+    altKey: evt.altKey
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+    />,
+  )
+
+  userEvent.click(screen.getByTestId('div'), {
+    button: 1,
+    altKey: true
+  })
+
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0,
+      altKey: true
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0,
+      altKey: true
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+  ])
+})
+
+it('should fire mouse events with custom buttons property', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+    />,
+  )
+
+  userEvent.click(screen.getByTestId('div'), {
+    buttons: 4
+  })
+
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+  ])
+})

--- a/src/__tests__/dblclick.js
+++ b/src/__tests__/dblclick.js
@@ -204,3 +204,261 @@ test('should not blur when mousedown prevents default', () => {
     'click',
   ])
 })
+
+
+it('should fire mouse events with the correct properties', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+      onDoubleClick={eventsHandler}
+    />,
+  )
+
+  userEvent.dblClick(screen.getByTestId('div'))
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousedown',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+    {
+      type: 'mouseup',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+    {
+      type: 'click',
+      button: 0,
+      buttons: 1,
+      detail: 1
+    },
+    {
+      type: 'mousedown',
+      button: 0,
+      buttons: 1,
+      detail: 2
+    },
+    {
+      type: 'mouseup',
+      button: 0,
+      buttons: 1,
+      detail: 2
+    },
+    {
+      type: 'click',
+      button: 0,
+      buttons: 1,
+      detail: 2
+    },
+    {
+      type: 'dblclick',
+      button: 0,
+      buttons: 1,
+      detail: 2
+    },
+  ])
+})
+
+it('should fire mouse events with custom button property', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail,
+    altKey: evt.altKey
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+      onDoubleClick={eventsHandler}
+    />,
+  )
+
+  userEvent.dblClick(screen.getByTestId('div'), {
+    button: 1,
+    altKey: true
+  })
+
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0,
+      altKey: true
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0,
+      altKey: true
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 1,
+      altKey: true
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 2,
+      altKey: true
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 2,
+      altKey: true
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 2,
+      altKey: true
+    },
+    {
+      type: 'dblclick',
+      button: 1,
+      buttons: 4,
+      detail: 2,
+      altKey: true
+    },
+  ])
+})
+
+it('should fire mouse events with custom buttons property', () => {
+  const events = []
+  const eventsHandler = jest.fn(evt => events.push({
+    type: evt.type,
+    button: evt.button,
+    buttons: evt.buttons,
+    detail: evt.detail
+  }))
+  render(
+    <div
+      data-testid="div"
+      onMouseOver={eventsHandler}
+      onMouseMove={eventsHandler}
+      onMouseDown={eventsHandler}
+      onFocus={eventsHandler}
+      onMouseUp={eventsHandler}
+      onClick={eventsHandler}
+      onDoubleClick={eventsHandler}
+    />,
+  )
+
+  userEvent.dblClick(screen.getByTestId('div'), {
+    buttons: 4
+  })
+
+  expect(events).toEqual([
+    {
+      type: 'mouseover',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousemove',
+      button: 0,
+      buttons: 0,
+      detail: 0
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 1
+    },
+    {
+      type: 'mousedown',
+      button: 1,
+      buttons: 4,
+      detail: 2
+    },
+    {
+      type: 'mouseup',
+      button: 1,
+      buttons: 4,
+      detail: 2
+    },
+    {
+      type: 'click',
+      button: 1,
+      buttons: 4,
+      detail: 2
+    },
+    {
+      type: 'dblclick',
+      button: 1,
+      buttons: 4,
+      detail: 2
+    },
+  ])
+})

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,12 @@ function isMousePressEvent(event) {
 }
 
 function invert(map) {
-  return Object.fromEntries(Object.entries(map).map(([k, v]) => [v, k]));
+  const res = {};
+  for (const key of Object.keys(map)) {
+    res[map[key]] = key;
+  }
+
+  return res;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,8 +21,8 @@ export type UploadInitArgument = {
 declare const userEvent: {
   clear: (element: TargetElement) => void
   click: (element: TargetElement, init?: MouseEventInit) => void
-  dblClick: (element: TargetElement) => void
-  selectOptions: (element: TargetElement, values: string | string[]) => void
+  dblClick: (element: TargetElement, init?: MouseEventInit) => void
+  selectOptions: (element: TargetElement, values: string | string[], init?: MouseEventInit) => void
   upload: (
     element: TargetElement,
     files: FilesArgument,


### PR DESCRIPTION
**What**:

This ensures that all mouse events are fired with the correct values for the [button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button), [buttons](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons), and [detail](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) properties. This emulates what a browser would do, and is important for code that relies on this behavior. In addition, it should be possible to pass custom properties through to all events (e.g. `altKey`, and screen positions).

**Why**:

Tests should simulate how a browser fires them as closely as possible.

**How**:

Looked at the spec for each property and emulated the required behavior. Also tested in a real application that relies on some of them.

By default, `click` and `dblClick` simulate the left mouse button. However, you can set the `button` or `buttons` property when firing the event to override this. user-event will handle mapping the one that's set to the alternative one if unset, so it's consistent no matter which is specified.

In addition, the `detail` property is set according to the number of clicks that have occurred.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [x] Tests
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Thanks for the great library! 😍 
