### PR TITLE
feat: allow selecting options by nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ test('selectOptions', () => {
 The `values` parameter can be either an array of values or a singular scalar
 value.
 
+It also accepts option nodes:
+
+```js
+userEvent.selectOptions(screen.getByTestId('select-multiple'), [
+  screen.getByText('A'),
+  screen.getByText('B'),
+])
+```
+
 ### `tab({shift, focusTrap})`
 
 Fires a tab event changing the document.activeElement in the same way the

--- a/src/__tests__/selectoptions.js
+++ b/src/__tests__/selectoptions.js
@@ -168,6 +168,33 @@ test('sets the selected prop on the selected OPTION', () => {
   expect(screen.getByTestId('val3').selected).toBe(true)
 })
 
+test('sets the selected prop on the selected OPTION using nodes', () => {
+  render(
+    <form onSubmit={() => {}}>
+      <select multiple data-testid="element">
+        <option data-testid="val1" value="1">
+          first option
+        </option>
+        <option data-testid="val2" value="2">
+          second option
+        </option>
+        <option data-testid="val3" value="3">
+          third option
+        </option>
+      </select>
+    </form>,
+  )
+
+  userEvent.selectOptions(screen.getByTestId('element'), [
+    screen.getByText('second option'),
+    screen.getByText('third option'),
+  ])
+
+  expect(screen.getByTestId('val1').selected).toBe(false)
+  expect(screen.getByTestId('val2').selected).toBe(true)
+  expect(screen.getByTestId('val3').selected).toBe(true)
+})
+
 test('sets the selected prop on the selected OPTION using htmlFor', () => {
   const onSubmit = jest.fn()
 

--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,7 @@ function selectOptions(element, values, init) {
   const valArray = Array.isArray(values) ? values : [values]
   const selectedOptions = Array.from(
     element.querySelectorAll('option'),
-  ).filter(opt => valArray.includes(opt.value))
+  ).filter(opt => valArray.includes(opt.value) || valArray.includes(opt))
 
   if (selectedOptions.length > 0) {
     if (element.multiple) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,11 @@ declare const userEvent: {
   clear: (element: TargetElement) => void
   click: (element: TargetElement, init?: MouseEventInit) => void
   dblClick: (element: TargetElement, init?: MouseEventInit) => void
-  selectOptions: (element: TargetElement, values: string | string[], init?: MouseEventInit) => void
+  selectOptions: (
+    element: TargetElement,
+    values: string | string[] | HTMLElement | HTMLElement[],
+    init?: MouseEventInit,
+  ) => void
   upload: (
     element: TargetElement,
     files: FilesArgument,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Allow selection of combobox options by html nodes. e.g.
```js
render(
    <select>
      <option value="1">first option</option>
    </select>,
  )
userEvent.selectOptions(screen.getByRole('combobox'), screen.getByText('first option'))
```

<!-- Why are these changes necessary? -->

**Why**:

Since users don't directly interact with option values, this should allow for testing in a more user-like way.

<!-- How were these changes implemented? -->

**How**:
In addition to checking for the `option.value` string, now it also checks if the node itself is in the given array.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
---
**Comments**:
Ideally, I think `userEvent.selectOptions` should receive option text instead of option values, and warn if it can't find the given option.text.

Since that would be a breaking change, I think this PR could be a good first step towards that direction.

**Related to**:
* https://github.com/testing-library/user-event/issues/203
* https://github.com/testing-library/user-event/pull/155