### PR TITLE
Bugix/fire type events on active element

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -295,10 +295,10 @@ test('should enter text up to maxLength of the current element if provided', asy
   })
 
   render(
-    <Fragment>
+    <>
       <input data-testid="input" onKeyDown={onKeyDown} />
       <input data-testid="input2" maxLength={input2MaxLength} />
-    </Fragment>,
+    </>,
   )
 
   const text = 'Hello, world!'

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -257,7 +257,7 @@ test.each(['input', 'textarea'])(
   },
 )
 
-test('should fire events on the currently focussed element', async () => {
+test('should fire events on the currently focused element', async () => {
   const changeFocusLimit = 7
   const onKeyDown = jest.fn(event => {
     if (event.target.value.length === changeFocusLimit) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,21 @@ function wait(time) {
 }
 
 function isMousePressEvent(event) {
-  return event === 'mousedown' || event === 'mouseup' || event === 'click' || event === 'dblclick';
+  return (
+    event === 'mousedown' ||
+    event === 'mouseup' ||
+    event === 'click' ||
+    event === 'dblclick'
+  )
 }
 
 function invert(map) {
-  const res = {};
+  const res = {}
   for (const key of Object.keys(map)) {
-    res[map[key]] = key;
+    res[map[key]] = key
   }
 
-  return res;
+  return res
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
@@ -22,48 +27,51 @@ const BUTTONS_TO_NAMES = {
   0: 'none',
   1: 'primary',
   2: 'secondary',
-  4: 'auxiliary'
-};
-const NAMES_TO_BUTTONS = invert(BUTTONS_TO_NAMES);
+  4: 'auxiliary',
+}
+const NAMES_TO_BUTTONS = invert(BUTTONS_TO_NAMES)
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 const BUTTON_TO_NAMES = {
   0: 'primary',
   1: 'auxiliary',
-  2: 'secondary'
-};
+  2: 'secondary',
+}
 
-const NAMES_TO_BUTTON = invert(BUTTON_TO_NAMES);
+const NAMES_TO_BUTTON = invert(BUTTON_TO_NAMES)
 
 function convertMouseButtons(event, init, property, mapping) {
   if (!isMousePressEvent(event)) {
-    return 0;
+    return 0
   }
 
   if (init[property] != null) {
-    return init[property];
+    return init[property]
   }
 
   if (init.buttons != null) {
-    return mapping[BUTTONS_TO_NAMES[init.buttons]] || 0;
+    return mapping[BUTTONS_TO_NAMES[init.buttons]] || 0
   }
 
   if (init.button != null) {
-    return mapping[BUTTON_TO_NAMES[init.button]] || 0;
+    return mapping[BUTTON_TO_NAMES[init.button]] || 0
   }
 
-  return property != 'button' && isMousePressEvent(event) ? 1 : 0;
+  return property != 'button' && isMousePressEvent(event) ? 1 : 0
 }
 
 function getMouseEventOptions(event, init, clickCount = 0) {
-  init = init || {};
+  init = init || {}
   return {
     ...init,
     // https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
-    detail: event === 'mousedown' || event === 'mouseup' ? 1 + clickCount : clickCount,
+    detail:
+      event === 'mousedown' || event === 'mouseup'
+        ? 1 + clickCount
+        : clickCount,
     buttons: convertMouseButtons(event, init, 'buttons', NAMES_TO_BUTTONS),
     button: convertMouseButtons(event, init, 'button', NAMES_TO_BUTTON),
-  };
+  }
 }
 
 function clickLabel(label, init) {
@@ -93,7 +101,10 @@ function clickBooleanElement(element, init) {
 function clickElement(element, previousElement, init) {
   fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
-  const continueDefaultHandling = fireEvent.mouseDown(element, getMouseEventOptions('mousedown', init))
+  const continueDefaultHandling = fireEvent.mouseDown(
+    element,
+    getMouseEventOptions('mousedown', init),
+  )
   const shouldFocus = element.ownerDocument.activeElement !== element
   if (continueDefaultHandling) {
     if (previousElement) previousElement.blur()
@@ -108,7 +119,10 @@ function clickElement(element, previousElement, init) {
 function dblClickElement(element, previousElement, init) {
   fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
-  const continueDefaultHandling = fireEvent.mouseDown(element, getMouseEventOptions('mousedown', init))
+  const continueDefaultHandling = fireEvent.mouseDown(
+    element,
+    getMouseEventOptions('mousedown', init),
+  )
   const shouldFocus = element.ownerDocument.activeElement !== element
   if (continueDefaultHandling) {
     if (previousElement) previousElement.blur()
@@ -220,8 +234,14 @@ function getPreviouslyFocusedElement(element) {
 function click(element, init) {
   const previouslyFocusedElement = getPreviouslyFocusedElement(element)
   if (previouslyFocusedElement) {
-    fireEvent.mouseMove(previouslyFocusedElement, getMouseEventOptions('mousemove', init))
-    fireEvent.mouseLeave(previouslyFocusedElement, getMouseEventOptions('mouseleave', init))
+    fireEvent.mouseMove(
+      previouslyFocusedElement,
+      getMouseEventOptions('mousemove', init),
+    )
+    fireEvent.mouseLeave(
+      previouslyFocusedElement,
+      getMouseEventOptions('mouseleave', init),
+    )
   }
 
   switch (element.tagName) {
@@ -242,8 +262,14 @@ function click(element, init) {
 function dblClick(element, init) {
   const previouslyFocusedElement = getPreviouslyFocusedElement(element)
   if (previouslyFocusedElement) {
-    fireEvent.mouseMove(previouslyFocusedElement, getMouseEventOptions('mousemove', init))
-    fireEvent.mouseLeave(previouslyFocusedElement, getMouseEventOptions('mouseleave', init))
+    fireEvent.mouseMove(
+      previouslyFocusedElement,
+      getMouseEventOptions('mousemove', init),
+    )
+    fireEvent.mouseLeave(
+      previouslyFocusedElement,
+      getMouseEventOptions('mouseleave', init),
+    )
   }
 
   switch (element.tagName) {
@@ -261,16 +287,22 @@ function dblClick(element, init) {
 function selectOptions(element, values, init) {
   const previouslyFocusedElement = getPreviouslyFocusedElement(element)
   if (previouslyFocusedElement) {
-    fireEvent.mouseMove(previouslyFocusedElement, getMouseEventOptions('mousemove', init))
-    fireEvent.mouseLeave(previouslyFocusedElement, getMouseEventOptions('mouseleave', init))
+    fireEvent.mouseMove(
+      previouslyFocusedElement,
+      getMouseEventOptions('mousemove', init),
+    )
+    fireEvent.mouseLeave(
+      previouslyFocusedElement,
+      getMouseEventOptions('mouseleave', init),
+    )
   }
 
   clickElement(element, previouslyFocusedElement, init)
 
   const valArray = Array.isArray(values) ? values : [values]
-  const selectedOptions = Array.from(
-    element.querySelectorAll('option'),
-  ).filter(opt => valArray.includes(opt.value) || valArray.includes(opt))
+  const selectedOptions = Array.from(element.querySelectorAll('option')).filter(
+    opt => valArray.includes(opt.value) || valArray.includes(opt),
+  )
 
   if (selectedOptions.length > 0) {
     if (element.multiple) {
@@ -290,21 +322,27 @@ function clear(element) {
 
 async function type(element, text, {allAtOnce = false, delay} = {}) {
   if (element.disabled) return
-  const previousText = element.value
 
-  const computedText =
-    element.maxLength > 0
-      ? text.slice(0, Math.max(element.maxLength - previousText.length, 0))
-      : text
+  element.focus()
 
   if (allAtOnce) {
     if (!element.readOnly) {
+      const previousText = element.value
+
+      const computedText =
+        element.maxLength > 0
+          ? text.slice(0, Math.max(element.maxLength - previousText.length, 0))
+          : text
+
       fireEvent.input(element, {
         target: {value: previousText + computedText},
       })
     }
   } else {
-    let actuallyTyped = previousText
+    // The focussed element could change between each event, so get the currently active element each time
+    const currentElement = () => document.activeElement
+    const actuallyTyped = () => document.activeElement.value
+
     for (let index = 0; index < text.length; index++) {
       const char = text[index]
       const key = char // TODO: check if this also valid for characters with diacritic markers e.g. úé etc
@@ -313,28 +351,28 @@ async function type(element, text, {allAtOnce = false, delay} = {}) {
       // eslint-disable-next-line no-await-in-loop
       if (delay > 0) await wait(delay)
 
-      const downEvent = fireEvent.keyDown(element, {
+      const downEvent = fireEvent.keyDown(currentElement(), {
         key,
         keyCode,
         which: keyCode,
       })
 
       if (downEvent) {
-        const pressEvent = fireEvent.keyPress(element, {
+        const pressEvent = fireEvent.keyPress(currentElement(), {
           key,
           keyCode,
           charCode: keyCode,
         })
 
         const isTextPastThreshold =
-          (actuallyTyped + key).length > (previousText + computedText).length
+          (actuallyTyped() + key).length >
+          (currentElement().maxLength || text.length)
 
         if (pressEvent && !isTextPastThreshold) {
-          actuallyTyped += key
           if (!element.readOnly) {
-            fireEvent.input(element, {
+            fireEvent.input(currentElement(), {
               target: {
-                value: actuallyTyped,
+                value: actuallyTyped() + key,
               },
               bubbles: true,
               cancelable: true,
@@ -343,7 +381,7 @@ async function type(element, text, {allAtOnce = false, delay} = {}) {
         }
       }
 
-      fireEvent.keyUp(element, {
+      fireEvent.keyUp(currentElement(), {
         key,
         keyCode,
         which: keyCode,

--- a/src/index.js
+++ b/src/index.js
@@ -352,8 +352,8 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
     }
   } else {
     // The focussed element could change between each event, so get the currently active element each time
-    const currentElement = () => document.activeElement
-    const actuallyTyped = () => document.activeElement.value
+    const currentElement = () => element.ownerDocument.activeElement
+    const actuallyTyped = () => element.ownerDocument.activeElement.value
 
     for (let index = 0; index < text.length; index++) {
       const char = text[index]

--- a/src/index.js
+++ b/src/index.js
@@ -363,6 +363,8 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
       // eslint-disable-next-line no-await-in-loop
       if (delay > 0) await wait(delay)
 
+      if(currentElement.disabled) return
+
       const downEvent = fireEvent.keyDown(currentElement(), {
         key,
         keyCode,

--- a/src/index.js
+++ b/src/index.js
@@ -339,13 +339,13 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
 
   // The focussed element could change between each event, so get the currently active element each time
   const currentElement = () => element.ownerDocument.activeElement
-  const actuallyTyped = () => element.ownerDocument.activeElement.value
+  const currentValue = () => element.ownerDocument.activeElement.value
 
   const computeText = () =>
     currentElement().maxLength > 0
       ? text.slice(
           0,
-          Math.max(currentElement().maxLength - actuallyTyped().length, 0),
+          Math.max(currentElement().maxLength - currentValue().length, 0),
         )
       : text
 
@@ -382,14 +382,14 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
         })
 
         const isTextPastThreshold =
-          (actuallyTyped() + key).length >
-          (actuallyTyped() + computeText()).length
+          (currentValue() + key).length >
+          (currentValue() + computeText()).length
 
         if (pressEvent && !isTextPastThreshold) {
           if (!element.readOnly) {
             fireEvent.input(currentElement(), {
               target: {
-                value: actuallyTyped() + key,
+                value: currentValue() + key,
               },
               bubbles: true,
               cancelable: true,

--- a/src/index.js
+++ b/src/index.js
@@ -366,7 +366,7 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
       // eslint-disable-next-line no-await-in-loop
       if (delay > 0) await wait(delay)
 
-      if (currentElement.disabled) return
+      if (currentElement().disabled) return
 
       const downEvent = fireEvent.keyDown(currentElement(), {
         key,

--- a/src/index.js
+++ b/src/index.js
@@ -381,9 +381,7 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
           charCode: keyCode,
         })
 
-        const isTextPastThreshold =
-          (currentValue() + key).length >
-          (currentValue() + computeText()).length
+        const isTextPastThreshold = !computeText().length
 
         if (pressEvent && !isTextPastThreshold) {
           if (!element.readOnly) {


### PR DESCRIPTION
**What**:
I raised an issue (#295) to allow focus to change between type events. This supports scenarios where focus is switched to a second input in between `keyDown` and `keyUp` events, for example.

This PR also contains a lot of formatting fixes that happened automatically on commit.

**Why**:
I personally, needed this to test a multiple input field, but this also more closely matches user behaviour.

**How**:
I've updated the `type` function to:
- Set focus on the `element` provided
- Reference the current `document.activeElement` when firing individual events
- Reference the current `document.activeElement`'s value and `maxLength` when checking `isTextPastThreshold` so that we check the relevant element's threshold before firing `input`
- Moved the `computedText` and `previousText` variables inside the `allAtOnce` check as it's no longer needed elsewhere. 
-`allAtOnce` functionality is unchanged.
(As there are a lot of formatting changes to sift through, the functionality changes described above can be found around this comment: https://github.com/testing-library/user-event/pull/299/files#r431147168)


**Checklist**:
- [ ] Documentation - N/A (I don't think this is required, but happy to add some if needed)
- [x] Tests
- [ ] Typings - N/A
- [x] Ready to be merged

The work in this PR looks like it conflicts with the work / relates to the conversations happening in https://github.com/testing-library/user-event/pull/231
So, this may be blocked until that PR is resolved.