### PR TITLE
feat(type): replace selected text

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -43,8 +43,9 @@ test('should replace selected text one by one', async () => {
       onChange={onChange}
     />,
   )
-  screen.getByTestId('input').selectionStart = 'hello '.length
-  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  screen
+    .getByTestId('input')
+    .setSelectionRange('hello '.length, 'hello world'.length)
   await userEvent.type(screen.getByTestId('input'), 'friend')
   expect(onChange).toHaveBeenCalledTimes('friend'.length)
   expect(screen.getByTestId('input')).toHaveValue('hello friend')
@@ -61,8 +62,9 @@ test('should replace selected text one by one up to maxLength if provided', asyn
       maxLength={maxLength}
     />,
   )
-  screen.getByTestId('input').selectionStart = 'hello '.length
-  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  screen
+    .getByTestId('input')
+    .setSelectionRange('hello '.length, 'hello world'.length)
   const resultIfUnlimited = 'hello friend'
   const slicedText = resultIfUnlimited.slice(0, maxLength)
   await userEvent.type(screen.getByTestId('input'), 'friend')
@@ -80,8 +82,9 @@ test('should replace selected text all at once', async () => {
       onChange={onChange}
     />,
   )
-  screen.getByTestId('input').selectionStart = 'hello '.length
-  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  screen
+    .getByTestId('input')
+    .setSelectionRange('hello '.length, 'hello world'.length)
   await userEvent.type(screen.getByTestId('input'), 'friend', {allAtOnce: true})
   expect(onChange).toHaveBeenCalledTimes(1)
   expect(screen.getByTestId('input')).toHaveValue('hello friend')

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -43,9 +43,9 @@ test('should replace selected text one by one', async () => {
       onChange={onChange}
     />,
   )
-  screen
-    .getByTestId('input')
-    .setSelectionRange('hello '.length, 'hello world'.length)
+  const selectionStart = 'hello world'.search('world')
+  const selectionEnd = selectionStart + 'world'.length
+  screen.getByTestId('input').setSelectionRange(selectionStart, selectionEnd)
   await userEvent.type(screen.getByTestId('input'), 'friend')
   expect(onChange).toHaveBeenCalledTimes('friend'.length)
   expect(screen.getByTestId('input')).toHaveValue('hello friend')
@@ -62,9 +62,9 @@ test('should replace selected text one by one up to maxLength if provided', asyn
       maxLength={maxLength}
     />,
   )
-  screen
-    .getByTestId('input')
-    .setSelectionRange('hello '.length, 'hello world'.length)
+  const selectionStart = 'hello world'.search('world')
+  const selectionEnd = selectionStart + 'world'.length
+  screen.getByTestId('input').setSelectionRange(selectionStart, selectionEnd)
   const resultIfUnlimited = 'hello friend'
   const slicedText = resultIfUnlimited.slice(0, maxLength)
   await userEvent.type(screen.getByTestId('input'), 'friend')
@@ -82,9 +82,9 @@ test('should replace selected text all at once', async () => {
       onChange={onChange}
     />,
   )
-  screen
-    .getByTestId('input')
-    .setSelectionRange('hello '.length, 'hello world'.length)
+  const selectionStart = 'hello world'.search('world')
+  const selectionEnd = selectionStart + 'world'.length
+  screen.getByTestId('input').setSelectionRange(selectionStart, selectionEnd)
   await userEvent.type(screen.getByTestId('input'), 'friend', {allAtOnce: true})
   expect(onChange).toHaveBeenCalledTimes(1)
   expect(screen.getByTestId('input')).toHaveValue('hello friend')

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -34,6 +34,59 @@ test('should append text all at once', async () => {
   expect(screen.getByTestId('input')).toHaveProperty('value', 'hello world')
 })
 
+test('should replace selected text one by one', async () => {
+  const onChange = jest.fn()
+  render(
+    <input
+      data-testid="input"
+      defaultValue="hello world"
+      onChange={onChange}
+    />,
+  )
+  screen.getByTestId('input').selectionStart = 'hello '.length
+  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  await userEvent.type(screen.getByTestId('input'), 'friend')
+  expect(onChange).toHaveBeenCalledTimes('friend'.length)
+  expect(screen.getByTestId('input')).toHaveValue('hello friend')
+})
+
+test('should replace selected text one by one up to maxLength if provided', async () => {
+  const maxLength = 10
+  const onChange = jest.fn()
+  render(
+    <input
+      data-testid="input"
+      defaultValue="hello world"
+      onChange={onChange}
+      maxLength={maxLength}
+    />,
+  )
+  screen.getByTestId('input').selectionStart = 'hello '.length
+  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  const resultIfUnlimited = 'hello friend'
+  const slicedText = resultIfUnlimited.slice(0, maxLength)
+  await userEvent.type(screen.getByTestId('input'), 'friend')
+  const truncatedCharCount = resultIfUnlimited.length - slicedText.length
+  expect(onChange).toHaveBeenCalledTimes('friend'.length - truncatedCharCount)
+  expect(screen.getByTestId('input')).toHaveValue(slicedText)
+})
+
+test('should replace selected text all at once', async () => {
+  const onChange = jest.fn()
+  render(
+    <input
+      data-testid="input"
+      defaultValue="hello world"
+      onChange={onChange}
+    />,
+  )
+  screen.getByTestId('input').selectionStart = 'hello '.length
+  screen.getByTestId('input').selectionEnd = 'hello world'.length
+  await userEvent.type(screen.getByTestId('input'), 'friend', {allAtOnce: true})
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(screen.getByTestId('input')).toHaveValue('hello friend')
+})
+
 test('should not type when event.preventDefault() is called', async () => {
   const onChange = jest.fn()
   const onKeydown = jest


### PR DESCRIPTION
Closes #301

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: allowing `type` to replace selected text

<!-- Why are these changes necessary? -->

**Why**: currently, `type` always appends to the end of the current value (ignoring selected text, which is replaced when a real user starts typing in the browser)

<!-- How were these changes implemented? -->

**How**: check for `element.selectionEnd > element.selectionEnd` and replace that segment instead of appending

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

@kentcdodds This change (as currently implemented) breaks the ESLint complexity threshold (clocks in at 15 when the limit is 14). Do we need to simplify it somehow, adjust the rule, disable the rule, other?

Thanks.