### PR TITLE
fix(type): handle selectionRange properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "rules": {
       "jsx-a11y/click-events-have-key-events": "off",
       "jsx-a11y/tabindex-no-positive": "off",
-      "no-return-assign": "off"
+      "no-return-assign": "off",
+      "react/prop-types": "off"
     },
     "overrides": [
       {

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -43,8 +43,8 @@ function setup(ui) {
   } = render(ui)
   element.previousTestData = getTestData(element)
 
-  const getEventCalls = addListeners(element)
-  return {element, getEventCalls}
+  const {getEventCalls, clearEventCalls} = addListeners(element)
+  return {element, getEventCalls, clearEventCalls}
 }
 
 function addListeners(element) {
@@ -102,7 +102,8 @@ function addListeners(element) {
       })
       .join('\n')
   }
-  return getEventCalls
+  const clearEventCalls = () => generalListener.mockClear()
+  return {getEventCalls, clearEventCalls}
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button

--- a/src/__tests__/toggleselectoptions.js
+++ b/src/__tests__/toggleselectoptions.js
@@ -46,7 +46,7 @@ test('should fire the correct events for multiple select when focus is in other 
 
   const $otherBtn = screen.getByRole('button')
 
-  const getButtonEvents = addListeners($otherBtn)
+  const {getEventCalls: getButtonEvents} = addListeners($otherBtn)
 
   $otherBtn.focus()
 


### PR DESCRIPTION
**What**: fix(type): handle selectionRange properly

**Why**: Closes #309

**How**: create a new `calculateNewBackspaceValue` out of the `calculateNewValue` function because there's no reasonable way to abstract that. I promise.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged
