### PR TITLE
Fix typing into validated input types

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -496,15 +496,20 @@ test('ignored {backspace} in controlled input', async () => {
   `)
 })
 
-test('typing in an input with validated type works', async () => {
+test.each([
+  ['email', String],
+  ['password', String],
+  ['number', Number],
+  ['text', String],
+])(`typing in an input of type="%s" works`, async (inputType, resultType) => {
   const onChange = jest.fn()
   const {
     container: {firstChild: input},
   } = render(
-    <input type="number" onChange={onChange} aria-label="Test input" />,
+    <input type={inputType} onChange={onChange} aria-label="Test input" />,
   )
 
   await userEvent.type(input, '5550690')
   expect(onChange).toHaveBeenCalledTimes(7)
-  expect(input).toHaveValue(5550690)
+  expect(input).toHaveValue(resultType(5550690))
 })

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -495,3 +495,16 @@ test('ignored {backspace} in controlled input', async () => {
     keyup: 4 (52)
   `)
 })
+
+test('typing in an input with validated type works', async () => {
+  const onChange = jest.fn()
+  const {
+    container: {firstChild: input},
+  } = render(
+    <input type="number" onChange={onChange} aria-label="Test input" />,
+  )
+
+  await userEvent.type(input, '5550690')
+  expect(onChange).toHaveBeenCalledTimes(7)
+  expect(input).toHaveValue(5550690)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {fireEvent} from '@testing-library/dom'
 import {type} from './type'
+import {isInputElement} from './utils'
 
 function isMousePressEvent(event) {
   return (
@@ -226,10 +227,6 @@ function selectAll(element) {
   if (isInputElement(element)) {
     element.type = elementType
   }
-}
-
-function isInputElement(element) {
-  return element.tagName.toLowerCase() === 'input'
 }
 
 function getPreviouslyFocusedElement(element) {

--- a/src/type.js
+++ b/src/type.js
@@ -3,6 +3,7 @@ import {
   fireEvent,
 } from '@testing-library/dom'
 import {tick} from './tick'
+import {isInputElement} from './utils'
 
 function wait(time) {
   return new Promise(resolve => setTimeout(() => resolve(), time))
@@ -19,6 +20,13 @@ async function type(...args) {
 
 async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
   if (element.disabled) return
+
+  const elementType = element.type
+  // type is a readonly property on textarea, so check if element is an input before trying to modify it
+  if (isInputElement(element)) {
+    // setSelectionRange is not supported on certain types of inputs, e.g. "number" or "email"
+    element.type = 'text'
+  }
 
   element.focus()
 
@@ -198,6 +206,10 @@ async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
         Object.assign(eventOverrides, returnValue?.eventOverrides)
       }
     }
+  }
+
+  if (isInputElement(element)) {
+    element.type = elementType
   }
 
   async function fireInputEventIfNeeded({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+export function isInputElement(element) {
+  return element.tagName.toLowerCase() === 'input'
+}


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Temporarily sets the target element's type to `text` until the `type` function resolves

**Why**:

The `type` implementation depends on `setSelectionRange` which [raises an error for validated input types](https://github.com/testing-library/user-event/issues/316) like `email`, `number`

**How**:

Take a guess 😝 

**Checklist**:

- [ ] Documentation N/A (?)
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged

I did try replacing `type` with a getter property to log a warning along the lines of "hey, you're accessing `type` while `type`ing and the result will be inaccurate", but it turns out that it's referenced by testing machinery so frequently as to be useless. Does this behavior need to be documented anywhere?