### PR TITLE
Support customElements

### DIFF
--- a/src/__tests__/helpers/customElement.js
+++ b/src/__tests__/helpers/customElement.js
@@ -1,0 +1,35 @@
+const observed = ['value']
+
+class CustomEl extends HTMLElement {
+  static getObservedAttributes() {
+    return observed
+  }
+
+  constructor() {
+    super()
+    this.attachShadow({mode: 'open'})
+    this.shadowRoot.innerHTML = `<input>`
+    this.$input = this.shadowRoot.querySelector('input')
+  }
+
+  connectedCallback() {
+    observed.forEach(name => {
+      this.render(name, this.getAttribute(name))
+    })
+  }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (oldVal === newVal) return
+    this.render(name, newVal)
+  }
+
+  render(name, value) {
+    if (value == null) {
+      this.$input.removeAttribute(name)
+    } else {
+      this.$input.setAttribute(name, value)
+    }
+  }
+}
+
+customElements.define('custom-el', CustomEl)

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -41,7 +41,6 @@ function setup(ui) {
   const {
     container: {firstChild: element},
   } = render(ui)
-
   element.previousTestData = getTestData(element)
 
   const {getEventCalls, clearEventCalls} = addListeners(element)

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -37,21 +37,15 @@ function addEventListener(el, type, listener, options) {
   el.addEventListener(type, hijackedListener, options)
 }
 
-function setup(ui, {shadowRootSelector} = {}) {
-  let hostElement
-  let {
+function setup(ui) {
+  const {
     container: {firstChild: element},
   } = render(ui)
-
-  if (shadowRootSelector) {
-    hostElement = element
-    element = element.shadowRoot.querySelector(shadowRootSelector)
-  }
 
   element.previousTestData = getTestData(element)
 
   const {getEventCalls, clearEventCalls} = addListeners(element)
-  return {element, hostElement, getEventCalls, clearEventCalls}
+  return {element, getEventCalls, clearEventCalls}
 }
 
 function addListeners(element) {

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -37,14 +37,21 @@ function addEventListener(el, type, listener, options) {
   el.addEventListener(type, hijackedListener, options)
 }
 
-function setup(ui) {
-  const {
+function setup(ui, {shadowRootSelector} = {}) {
+  let hostElement
+  let {
     container: {firstChild: element},
   } = render(ui)
+
+  if (shadowRootSelector) {
+    hostElement = element
+    element = element.shadowRoot.querySelector(shadowRootSelector)
+  }
+
   element.previousTestData = getTestData(element)
 
   const {getEventCalls, clearEventCalls} = addListeners(element)
-  return {element, getEventCalls, clearEventCalls}
+  return {element, hostElement, getEventCalls, clearEventCalls}
 }
 
 function addListeners(element) {

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1,7 +1,7 @@
 import React, {Fragment} from 'react'
 import {render, screen} from '@testing-library/react'
 import userEvent from '..'
-import {setup} from './helpers/utils'
+import {setup, addListeners} from './helpers/utils'
 import './helpers/customElement'
 
 it('types text in input', async () => {
@@ -25,11 +25,13 @@ it('types text in input', async () => {
 })
 
 it('types text inside custom element', async () => {
-  const {element, hostElement, getEventCalls} = setup(<custom-el />, {
-    shadowRootSelector: 'input',
-  })
+  const {
+    container: {firstChild: customElement},
+  } = render(<custom-el />)
+  const inputEl = customElement.shadowRoot.querySelector('input')
+  const {getEventCalls} = addListeners(inputEl)
 
-  await userEvent.type(element, 'Sup', {hostElement})
+  await userEvent.type(inputEl, 'Sup')
   expect(getEventCalls()).toMatchInlineSnapshot(`
     focus
     keydown: S (83)

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -2,10 +2,34 @@ import React, {Fragment} from 'react'
 import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
+import './helpers/customElement'
 
 it('types text in input', async () => {
   const {element, getEventCalls} = setup(<input />)
   await userEvent.type(element, 'Sup')
+  expect(getEventCalls()).toMatchInlineSnapshot(`
+    focus
+    keydown: S (83)
+    keypress: S (83)
+    input: "{CURSOR}" -> "S"
+    keyup: S (83)
+    keydown: u (117)
+    keypress: u (117)
+    input: "S{CURSOR}" -> "Su"
+    keyup: u (117)
+    keydown: p (112)
+    keypress: p (112)
+    input: "Su{CURSOR}" -> "Sup"
+    keyup: p (112)
+  `)
+})
+
+it('types text inside custom element', async () => {
+  const {element, hostElement, getEventCalls} = setup(<custom-el />, {
+    shadowRootSelector: 'input',
+  })
+
+  await userEvent.type(element, 'Sup', {hostElement})
   expect(getEventCalls()).toMatchInlineSnapshot(`
     focus
     keydown: S (83)

--- a/src/type.js
+++ b/src/type.js
@@ -17,8 +17,8 @@ async function type(...args) {
   return result
 }
 
-const getActiveElement = element => {
-  const activeElement = element.activeElement
+const getActiveElement = document => {
+  const activeElement = document.activeElement
   if (activeElement.shadowRoot) {
     return getActiveElement(activeElement.shadowRoot) || activeElement
   } else {

--- a/src/type.js
+++ b/src/type.js
@@ -17,14 +17,23 @@ async function type(...args) {
   return result
 }
 
+const getActiveElement = element => {
+  const activeElement = element.activeElement
+  if (activeElement.shadowRoot) {
+    return getActiveElement(activeElement.shadowRoot) || activeElement
+  } else {
+    return activeElement
+  }
+}
+
 async function typeImpl(element, text, {allAtOnce = false, delay} = {}) {
   if (element.disabled) return
 
   element.focus()
 
   // The focused element could change between each event, so get the currently active element each time
-  const currentElement = () => element.ownerDocument.activeElement
-  const currentValue = () => element.ownerDocument.activeElement.value
+  const currentElement = () => getActiveElement(element.ownerDocument)
+  const currentValue = () => currentElement().value
   const setSelectionRange = newSelectionStart => {
     // if the actual selection start is different from the one we expected
     // then we set it to the end of the input


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fixes #319

**Why**: in order to support custom elements

**How**: modify the `currentElement` helper to return nested `activeElement` inside shadow DOM

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Typings - I'm not familiar with TS - not sure if I need to do anything here
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

There were more changes required in the testing helpers than in the actual library - I'm open to suggestions on how to improve my suggested solution :)