### PR TITLE
fix(type): ensure the selectionStart/End are consistent with browsers

### DIFF
--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -117,6 +117,14 @@ test('{backspace} deletes the selected range', async () => {
   `)
 })
 
+test('{backspace} on an input type that does not support selection ranges', async () => {
+  const {element} = setup(<input type="email" defaultValue="yo@example.com" />)
+  // note: you cannot even call setSelectionRange on these kinds of elements...
+  await userEvent.type(element, '{backspace}')
+  // removed "m"
+  expect(element).toHaveValue('yo@example.co')
+})
+
 test('{alt}a{/alt}', async () => {
   const {element: input, getEventCalls} = setup(<input />)
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,9 @@
 // Definitions by: Wu Haotian <https://github.com/whtsky>
-export interface IUserOptions {
+export interface ITypeOpts {
   allAtOnce?: boolean
   delay?: number
+  initialSelectionStart?: number
+  initialSelectionEnd?: number
 }
 
 export interface ITabUserOptions {
@@ -40,7 +42,7 @@ declare const userEvent: {
   type: (
     element: TargetElement,
     text: string,
-    userOpts?: IUserOptions,
+    userOpts?: ITypeOpts,
   ) => Promise<void>
   tab: (userOpts?: ITabUserOptions) => void
 }


### PR DESCRIPTION
**What**: fix(type): ensure the selectionStart/End are consistent with browsers 

**Why**:

Closes: #321
Closes: #318
Closes: #316

**How**:

Investigated how the browser deals with situations where values are changed programmatically: https://jsbin.com/decutel/3/edit?html,js,output

The rule is: If the value changes to something that it would not have naturally from the user's input, then send the selection range to the end.

Because we're programmatically changing it, the browser automatically sends the selection range to the end, so we have to correct for that by moving the selection range back to where it would be (if the value doesn't change from what we expected after we fire the input event).

And *this* is why people use `userEvent` 😉

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
