### PR TITLE
fix(tab): make tab respect radio groups (fix #207)

### DIFF
--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -273,3 +273,51 @@ test('should keep focus on the document if there are no enabled, focusable eleme
   userEvent.tab({shift: true})
   expect(document.body).toHaveFocus()
 })
+
+test('should respect radio groups', () => {
+  render(
+    <>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="first_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="first_right"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="second"
+        value="second_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="second"
+        value="second_right"
+        defaultChecked
+      />
+    </>,
+  )
+
+  const [firstLeft, firstRight, , secondRight] = screen.getAllByTestId(
+    'element',
+  )
+
+  userEvent.tab()
+
+  expect(firstLeft).toHaveFocus()
+
+  userEvent.tab()
+
+  expect(secondRight).toHaveFocus()
+
+  userEvent.tab({shift: true})
+
+  expect(firstRight).toHaveFocus()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: make tab respect radio groups
<!-- Why are these changes necessary? -->

**Why**: fixes bugs / inaccurate simulation with `tab()` naively focusing all radio buttons

<!-- How were these changes implemented? -->

**How**: ignore radio buttons that aren't checked or at the ends within their named groups

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
The algorithm I used to prune irrelevant radio buttons is a bit ugly and hacky because of all the edge cases, so I'd appreciate any ideas to improve it. We also might need to carefully document this change as it could cause tests to fail if they're relying on the incorrect focusing behavior (though changing incorrect functionality to fix a bug is technically not a breaking change in semver).