### PR TITLE
feat(hover): Add hover API (fixes #254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,20 +407,20 @@ Hovers over `element`.
 import React from 'react'
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import Tooltip from '../tooltip'
 
 test('hover', async () => {
-  const handler = jest.fn()
+  const messageText = 'Hello'
   render(
-    <button
-      data-testid="button"
-      onMouseEnter={handler}
-      onMouseOver={handler}
-      onMouseMove={handler}
-    />,
+    <Tooltip messageText={messageText}>
+      <TrashIcon aria-label="Delete" />
+    </Tooltip>,
   )
 
-  await userEvent.hover(screen.getByTestId('button'))
-  expect(handler).toHaveBeenCalledTimes(3)
+  await userEvent.hover(screen.getByLabelText(/delete/i))
+  expect(screen.getByText(messageText)).toBeInTheDocument()
+  await userEvent.unhover(screen.getByLabelText(/delete/i))
+  expect(screen.queryByText(messageText)).not.toBeInTheDocument()
 })
 ```
 
@@ -428,26 +428,7 @@ test('hover', async () => {
 
 Unhovers out of `element`.
 
-```jsx
-import React from 'react'
-import {render, screen} from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-
-test('unhover', async () => {
-  const handler = jest.fn()
-  render(
-    <button
-      data-testid="button"
-      onMouseMove={handler}
-      onMouseOut={handler}
-      onMouseLeave={handler}
-    />,
-  )
-
-  await userEvent.unhover(screen.getByTestId('button'))
-  expect(handler).toHaveBeenCalledTimes(3)
-})
-```
+> See [above](#async-hoverelement) for an example
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ change the state of the checkbox.
   - [`selectOptions(element, values)`](#selectoptionselement-values)
   - [`toggleSelectOptions(element, values)`](#toggleselectoptionselement-values)
   - [`tab({shift, focusTrap})`](#tabshift-focustrap)
-  - [`hover(element)`](#hoverelement)
-  - [`unhover(element)`](#unhoverelement)
+  - [`async hover(element)`](#async-hoverelement)
+  - [`async unhover(element)`](#async-unhoverelement)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -399,7 +399,7 @@ it('should cycle elements in document tab order', () => {
 })
 ```
 
-### `hover(element)`
+### `async hover(element)`
 
 Hovers over `element`.
 
@@ -408,7 +408,7 @@ import React from 'react'
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-test('hover', () => {
+test('hover', async () => {
   const handler = jest.fn()
   render(
     <button
@@ -419,12 +419,12 @@ test('hover', () => {
     />,
   )
 
-  userEvent.hover(screen.getByTestId('button'))
+  await userEvent.hover(screen.getByTestId('button'))
   expect(handler).toHaveBeenCalledTimes(3)
 })
 ```
 
-### `unhover(element)`
+### `async unhover(element)`
 
 Unhovers out of `element`.
 
@@ -433,7 +433,7 @@ import React from 'react'
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-test('unhover', () => {
+test('unhover', async () => {
   const handler = jest.fn()
   render(
     <button
@@ -444,7 +444,7 @@ test('unhover', () => {
     />,
   )
 
-  userEvent.unhover(screen.getByTestId('button'))
+  await userEvent.unhover(screen.getByTestId('button'))
   expect(handler).toHaveBeenCalledTimes(3)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ change the state of the checkbox.
   - [`toggleSelectOptions(element, values)`](#toggleselectoptionselement-values)
   - [`tab({shift, focusTrap})`](#tabshift-focustrap)
   - [`hover(element)`](#hoverelement)
+  - [`unhover(element)`](#unhoverelement)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -415,13 +416,36 @@ test('hover', () => {
       onMouseEnter={handler}
       onMouseOver={handler}
       onMouseMove={handler}
+    />,
+  )
+
+  userEvent.hover(screen.getByTestId('button'))
+  expect(handler).toHaveBeenCalledTimes(3)
+})
+```
+
+### `unhover(element)`
+
+Unhovers out of `element`.
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('unhover', () => {
+  const handler = jest.fn()
+  render(
+    <button
+      data-testid="button"
+      onMouseMove={handler}
       onMouseOut={handler}
       onMouseLeave={handler}
     />,
   )
 
-  userEvent.hover(screen.getByTestId('button'))
-  expect(handler).toHaveBeenCalledTimes(5)
+  userEvent.unhover(screen.getByTestId('button'))
+  expect(handler).toHaveBeenCalledTimes(3)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ change the state of the checkbox.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [API](#api)
   - [`click(element)`](#clickelement)
@@ -61,6 +60,7 @@ change the state of the checkbox.
   - [`selectOptions(element, values)`](#selectoptionselement-values)
   - [`toggleSelectOptions(element, values)`](#toggleselectoptionselement-values)
   - [`tab({shift, focusTrap})`](#tabshift-focustrap)
+  - [`hover(element)`](#hoverelement)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -398,6 +398,33 @@ it('should cycle elements in document tab order', () => {
 })
 ```
 
+### `hover(element)`
+
+Hovers over `element`.
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('hover', () => {
+  const handler = jest.fn()
+  render(
+    <button
+      data-testid="button"
+      onMouseEnter={handler}
+      onMouseOver={handler}
+      onMouseMove={handler}
+      onMouseOut={handler}
+      onMouseLeave={handler}
+    />,
+  )
+
+  userEvent.hover(screen.getByTestId('button'))
+  expect(handler).toHaveBeenCalledTimes(5)
+})
+```
+
 ## Issues
 
 _Looking to contribute? Look for the [Good First Issue][good-first-issue]
@@ -482,6 +509,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/hover.js
+++ b/src/__tests__/hover.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '..'
+import {setup} from './helpers/utils'
+
+test('hover', () => {
+  const {element, getEventCalls} = setup(<button />)
+
+  userEvent.hover(element)
+  expect(getEventCalls()).toMatchInlineSnapshot(`
+    mouseenter: Left (0)
+    mouseover: Left (0)
+    mousemove: Left (0)
+    mouseout: Left (0)
+    mouseleave: Left (0)
+  `)
+})
+
+test('hover should fire events', () => {
+  const handler = jest.fn()
+  render(
+    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+    <button
+      data-testid="button"
+      onMouseEnter={handler}
+      onMouseOver={handler}
+      onMouseMove={handler}
+      onMouseOut={handler}
+      onMouseLeave={handler}
+    />,
+  )
+
+  userEvent.hover(screen.getByTestId('button'))
+  expect(handler).toHaveBeenCalledTimes(5)
+})

--- a/src/__tests__/hover.js
+++ b/src/__tests__/hover.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
 
@@ -8,24 +7,8 @@ test('hover', async () => {
 
   await userEvent.hover(element)
   expect(getEventCalls()).toMatchInlineSnapshot(`
-    mouseenter: Left (0)
     mouseover: Left (0)
+    mouseenter: Left (0)
     mousemove: Left (0)
   `)
-})
-
-test('hover should fire events', async () => {
-  const handler = jest.fn()
-  render(
-    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-    <button
-      data-testid="button"
-      onMouseEnter={handler}
-      onMouseOver={handler}
-      onMouseMove={handler}
-    />,
-  )
-
-  await userEvent.hover(screen.getByTestId('button'))
-  expect(handler).toHaveBeenCalledTimes(3)
 })

--- a/src/__tests__/hover.js
+++ b/src/__tests__/hover.js
@@ -3,10 +3,10 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
 
-test('hover', () => {
+test('hover', async () => {
   const {element, getEventCalls} = setup(<button />)
 
-  userEvent.hover(element)
+  await userEvent.hover(element)
   expect(getEventCalls()).toMatchInlineSnapshot(`
     mouseenter: Left (0)
     mouseover: Left (0)
@@ -14,7 +14,7 @@ test('hover', () => {
   `)
 })
 
-test('hover should fire events', () => {
+test('hover should fire events', async () => {
   const handler = jest.fn()
   render(
     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
@@ -26,6 +26,6 @@ test('hover should fire events', () => {
     />,
   )
 
-  userEvent.hover(screen.getByTestId('button'))
+  await userEvent.hover(screen.getByTestId('button'))
   expect(handler).toHaveBeenCalledTimes(3)
 })

--- a/src/__tests__/unhover.js
+++ b/src/__tests__/unhover.js
@@ -3,29 +3,29 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
 
-test('hover', () => {
+test('unhover', () => {
   const {element, getEventCalls} = setup(<button />)
 
-  userEvent.hover(element)
+  userEvent.unhover(element)
   expect(getEventCalls()).toMatchInlineSnapshot(`
-    mouseenter: Left (0)
-    mouseover: Left (0)
     mousemove: Left (0)
+    mouseout: Left (0)
+    mouseleave: Left (0)
   `)
 })
 
-test('hover should fire events', () => {
+test('unhover should fire events', () => {
   const handler = jest.fn()
   render(
     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
     <button
       data-testid="button"
-      onMouseEnter={handler}
-      onMouseOver={handler}
       onMouseMove={handler}
+      onMouseOut={handler}
+      onMouseLeave={handler}
     />,
   )
 
-  userEvent.hover(screen.getByTestId('button'))
+  userEvent.unhover(screen.getByTestId('button'))
   expect(handler).toHaveBeenCalledTimes(3)
 })

--- a/src/__tests__/unhover.js
+++ b/src/__tests__/unhover.js
@@ -3,10 +3,10 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
 
-test('unhover', () => {
+test('unhover', async () => {
   const {element, getEventCalls} = setup(<button />)
 
-  userEvent.unhover(element)
+  await userEvent.unhover(element)
   expect(getEventCalls()).toMatchInlineSnapshot(`
     mousemove: Left (0)
     mouseout: Left (0)
@@ -14,7 +14,7 @@ test('unhover', () => {
   `)
 })
 
-test('unhover should fire events', () => {
+test('unhover should fire events', async () => {
   const handler = jest.fn()
   render(
     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
@@ -26,6 +26,6 @@ test('unhover should fire events', () => {
     />,
   )
 
-  userEvent.unhover(screen.getByTestId('button'))
+  await userEvent.unhover(screen.getByTestId('button'))
   expect(handler).toHaveBeenCalledTimes(3)
 })

--- a/src/__tests__/unhover.js
+++ b/src/__tests__/unhover.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import {render, screen} from '@testing-library/react'
 import userEvent from '..'
 import {setup} from './helpers/utils'
 
@@ -9,23 +8,6 @@ test('unhover', async () => {
   await userEvent.unhover(element)
   expect(getEventCalls()).toMatchInlineSnapshot(`
     mousemove: Left (0)
-    mouseout: Left (0)
     mouseleave: Left (0)
   `)
-})
-
-test('unhover should fire events', async () => {
-  const handler = jest.fn()
-  render(
-    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-    <button
-      data-testid="button"
-      onMouseMove={handler}
-      onMouseOut={handler}
-      onMouseLeave={handler}
-    />,
-  )
-
-  await userEvent.unhover(screen.getByTestId('button'))
-  expect(handler).toHaveBeenCalledTimes(3)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -455,6 +455,10 @@ function hover(element, init) {
   fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
   fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
+}
+
+function unhover(element, init) {
+  fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
   fireEvent.mouseOut(element, getMouseEventOptions('mouseout', init))
   fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
 }
@@ -469,6 +473,7 @@ const userEvent = {
   upload,
   tab,
   hover,
+  unhover,
 }
 
 export default userEvent

--- a/src/index.js
+++ b/src/index.js
@@ -451,6 +451,14 @@ function tab({shift = false, focusTrap = document} = {}) {
   }
 }
 
+function hover(element, init) {
+  fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
+  fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
+  fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
+  fireEvent.mouseOut(element, getMouseEventOptions('mouseout', init))
+  fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
+}
+
 const userEvent = {
   click,
   dblClick,
@@ -460,6 +468,7 @@ const userEvent = {
   type,
   upload,
   tab,
+  hover,
 }
 
 export default userEvent

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {fireEvent} from '@testing-library/dom'
 import {type} from './type'
+import {tick} from './tick'
 
 function isMousePressEvent(event) {
   return (
@@ -451,15 +452,21 @@ function tab({shift = false, focusTrap = document} = {}) {
   }
 }
 
-function hover(element, init) {
+async function hover(element, init) {
+  await tick()
   fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
+  await tick()
   fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
+  await tick()
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
 }
 
-function unhover(element, init) {
+async function unhover(element, init) {
+  await tick()
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
+  await tick()
   fireEvent.mouseOut(element, getMouseEventOptions('mouseout', init))
+  await tick()
   fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -454,9 +454,9 @@ function tab({shift = false, focusTrap = document} = {}) {
 
 async function hover(element, init) {
   await tick()
-  fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
-  await tick()
   fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
+  await tick()
+  fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
   await tick()
   fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,6 +45,7 @@ declare const userEvent: {
     userOpts?: ITypeOpts,
   ) => Promise<void>
   tab: (userOpts?: ITabUserOptions) => void
+  hover: (element: TargetElement, init?: MouseEventInit) => void
 }
 
 export default userEvent

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,8 +45,8 @@ declare const userEvent: {
     userOpts?: ITypeOpts,
   ) => Promise<void>
   tab: (userOpts?: ITabUserOptions) => void
-  hover: (element: TargetElement, init?: MouseEventInit) => void
-  unhover: (element: TargetElement, init?: MouseEventInit) => void
+  hover: (element: TargetElement, init?: MouseEventInit) => Promise<void>
+  unhover: (element: TargetElement, init?: MouseEventInit) => Promise<void>
 }
 
 export default userEvent

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,6 +46,7 @@ declare const userEvent: {
   ) => Promise<void>
   tab: (userOpts?: ITabUserOptions) => void
   hover: (element: TargetElement, init?: MouseEventInit) => void
+  unhover: (element: TargetElement, init?: MouseEventInit) => void
 }
 
 export default userEvent


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add `hover()` for hovering elements

<!-- Why are these changes necessary? -->

**Why**: Testing tooltips and other behavior involving mouse hovering

<!-- How were these changes implemented? -->

**How**: Calling various mouse events

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

__Note:__ I intentionally left the test failing because I could use some help figuring out how to fix it. For some reason, `mouseout` is not added to the list of events, despite being called in the function and `onMouseOut` working in a React test.