### PR TITLE
feat(paste): Add paste API (fixes #311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ change the state of the checkbox.
   - [`click(element)`](#clickelement)
   - [`dblClick(element)`](#dblclickelement)
   - [`async type(element, text, [options])`](#async-typeelement-text-options)
+  - [`async paste(element, text, [options])`](#async-pasteelement-text-options)
   - [`upload(element, file, [{ clickInit, changeInit }])`](#uploadelement-file--clickinit-changeinit-)
   - [`clear(element)`](#clearelement)
   - [`selectOptions(element, values)`](#selectoptionselement-values)
@@ -166,9 +167,6 @@ test('type', async () => {
 })
 ```
 
-If `options.allAtOnce` is `true`, `type` will write `text` at once rather than
-one character at the time. `false` is the default value.
-
 `options.delay` is the number of milliseconds that pass between two characters
 are typed. By default it's 0. You can use this option if your component has a
 different behavior for fast or slow users.
@@ -198,6 +196,23 @@ The following special character strings are supported:
 > in that we do not simulate the behavior that happens with modifier key
 > combinations as different operating systems function differently in this
 > regard.
+
+### `async paste(element, text, [options])`
+
+Pastes `text` inside an `<input>` or a `<textarea>`.
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('paste', async () => {
+  render(<textarea />)
+
+  await userEvent.paste(screen.getByRole('textbox'), 'Hello,{enter}World!')
+  expect(screen.getByRole('textbox')).toHaveValue('Hello,\nWorld!')
+})
+```
 
 ### `upload(element, file, [{ clickInit, changeInit }])`
 
@@ -517,6 +532,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/paste.js
+++ b/src/__tests__/paste.js
@@ -1,0 +1,157 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '..'
+import {setup} from './helpers/utils'
+import './helpers/customElement'
+
+test('should paste text', async () => {
+  const {element, getEventCalls} = setup(<input />)
+  await userEvent.paste(element, 'Sup')
+  expect(getEventCalls()).toMatchInlineSnapshot(`
+    focus
+    input: "{CURSOR}" -> "Sup"
+  `)
+})
+
+test('does not paste when readOnly', () => {
+  const handleChange = jest.fn()
+  render(<input data-testid="input" readOnly onChange={handleChange} />)
+  userEvent.paste(screen.getByTestId('input'), 'hi')
+  expect(handleChange).not.toHaveBeenCalled()
+})
+
+test('does not paste when disabled', () => {
+  const handleChange = jest.fn()
+  render(<input data-testid="input" disabled onChange={handleChange} />)
+  userEvent.paste(screen.getByTestId('input'), 'hi')
+  expect(handleChange).not.toHaveBeenCalled()
+})
+
+test.each(['input', 'textarea'])('should paste text in <%s>', type => {
+  const onChange = jest.fn()
+  render(
+    React.createElement(type, {
+      'data-testid': 'input',
+      onChange,
+    }),
+  )
+  const text = 'Hello, world!'
+  userEvent.paste(screen.getByTestId('input'), text)
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(screen.getByTestId('input')).toHaveProperty('value', text)
+})
+
+test.each(['input', 'textarea'])(
+  'should paste text in <%s> up to maxLength if provided',
+  async type => {
+    const onChange = jest.fn()
+    const onKeyDown = jest.fn()
+    const onKeyPress = jest.fn()
+    const onKeyUp = jest.fn()
+    const maxLength = 10
+
+    render(
+      React.createElement(type, {
+        'data-testid': 'input',
+        onChange,
+        onKeyDown,
+        onKeyPress,
+        onKeyUp,
+        maxLength,
+      }),
+    )
+
+    const text = 'superlongtext'
+    const slicedText = text.slice(0, maxLength)
+
+    const inputEl = screen.getByTestId('input')
+
+    await userEvent.type(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(slicedText.length)
+    expect(onKeyPress).toHaveBeenCalledTimes(text.length)
+    expect(onKeyDown).toHaveBeenCalledTimes(text.length)
+    expect(onKeyUp).toHaveBeenCalledTimes(text.length)
+
+    inputEl.value = ''
+    onChange.mockClear()
+    onKeyPress.mockClear()
+    onKeyDown.mockClear()
+    onKeyUp.mockClear()
+
+    userEvent.paste(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onKeyPress).not.toHaveBeenCalled()
+    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onKeyUp).not.toHaveBeenCalled()
+  },
+)
+
+test.each(['input', 'textarea'])(
+  'should append text in <%s> up to maxLength if provided',
+  async type => {
+    const onChange = jest.fn()
+    const onKeyDown = jest.fn()
+    const onKeyPress = jest.fn()
+    const onKeyUp = jest.fn()
+    const maxLength = 10
+
+    render(
+      React.createElement(type, {
+        'data-testid': 'input',
+        onChange,
+        onKeyDown,
+        onKeyPress,
+        onKeyUp,
+        maxLength,
+      }),
+    )
+
+    const text1 = 'superlong'
+    const text2 = 'text'
+    const text = text1 + text2
+    const slicedText = text.slice(0, maxLength)
+
+    const inputEl = screen.getByTestId('input')
+
+    await userEvent.type(inputEl, text1)
+    await userEvent.type(inputEl, text2)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(slicedText.length)
+    expect(onKeyPress).toHaveBeenCalledTimes(text.length)
+    expect(onKeyDown).toHaveBeenCalledTimes(text.length)
+    expect(onKeyUp).toHaveBeenCalledTimes(text.length)
+
+    inputEl.value = ''
+    onChange.mockClear()
+    onKeyPress.mockClear()
+    onKeyDown.mockClear()
+    onKeyUp.mockClear()
+
+    userEvent.paste(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onKeyPress).not.toHaveBeenCalled()
+    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onKeyUp).not.toHaveBeenCalled()
+  },
+)
+
+test('should replace selected text all at once', async () => {
+  const onChange = jest.fn()
+  const {
+    container: {firstChild: input},
+  } = render(<input defaultValue="hello world" onChange={onChange} />)
+  const selectionStart = 'hello world'.search('world')
+  const selectionEnd = selectionStart + 'world'.length
+  input.setSelectionRange(selectionStart, selectionEnd)
+  await userEvent.paste(input, 'friend')
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(input).toHaveValue('hello friend')
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {fireEvent} from '@testing-library/dom'
 import {type} from './type'
+import {paste} from './paste'
 import {tick} from './tick'
 
 function isMousePressEvent(event) {
@@ -477,6 +478,7 @@ const userEvent = {
   toggleSelectOptions,
   clear,
   type,
+  paste,
   upload,
   tab,
   hover,

--- a/src/paste.js
+++ b/src/paste.js
@@ -1,0 +1,122 @@
+import {
+  getConfig as getDOMTestingLibraryConfig,
+  fireEvent,
+} from '@testing-library/dom'
+
+// this needs to be wrapped in the asyncWrapper for React's act and angular's change detection
+async function paste(...args) {
+  let result
+  await getDOMTestingLibraryConfig().asyncWrapper(async () => {
+    result = await pasteImpl(...args)
+  })
+  return result
+}
+
+const getActiveElement = document => {
+  const activeElement = document.activeElement
+  if (activeElement.shadowRoot) {
+    return getActiveElement(activeElement.shadowRoot) || activeElement
+  } else {
+    return activeElement
+  }
+}
+
+// eslint-disable-next-line complexity
+function pasteImpl(
+  element,
+  text,
+  {initialSelectionStart, initialSelectionEnd} = {},
+) {
+  if (element.disabled) return
+
+  element.focus()
+
+  // The focused element could change between each event, so get the currently active element each time
+  const currentElement = () => getActiveElement(element.ownerDocument)
+  const currentValue = () => currentElement().value
+  const setSelectionRange = ({newValue, newSelectionStart}) => {
+    // if we *can* change the selection start, then we will if the new value
+    // is the same as the current value (so it wasn't programatically changed
+    // when the fireEvent.input was triggered).
+    // The reason we have to do this at all is because it actually *is*
+    // programmatically changed by fireEvent.input, so we have to simulate the
+    // browser's default behavior
+    if (
+      currentElement().selectionStart !== null &&
+      currentValue() === newValue
+    ) {
+      currentElement().setSelectionRange?.(newSelectionStart, newSelectionStart)
+    }
+  }
+
+  // by default, a new element has it's selection start and end at 0
+  // but most of the time when people call "paste", they expect it to paste
+  // at the end of the current input value. So, if the selection start
+  // and end are both the default of 0, then we'll go ahead and change
+  // them to the length of the current value.
+  // the only time it would make sense to pass the initialSelectionStart or
+  // initialSelectionEnd is if you have an input with a value and want to
+  // explicitely start typing with the cursor at 0. Not super common.
+  if (
+    currentElement().selectionStart === 0 &&
+    currentElement().selectionEnd === 0
+  ) {
+    currentElement().setSelectionRange(
+      initialSelectionStart ?? currentValue()?.length ?? 0,
+      initialSelectionEnd ?? currentValue()?.length ?? 0,
+    )
+  }
+
+  if (!element.readOnly) {
+    const {newValue, newSelectionStart} = calculateNewValue(text)
+    fireEvent.input(element, {
+      target: {value: newValue},
+    })
+    setSelectionRange({newValue, newSelectionStart})
+  }
+
+  function calculateNewValue(newEntry) {
+    const {selectionStart, selectionEnd} = currentElement()
+    // can't use .maxLength property because of a jsdom bug:
+    // https://github.com/jsdom/jsdom/issues/2927
+    const maxLength = Number(currentElement().getAttribute('maxlength') ?? -1)
+    const value = currentValue()
+    let newValue, newSelectionStart
+
+    if (selectionStart === null) {
+      // at the end of an input type that does not support selection ranges
+      // https://github.com/testing-library/user-event/issues/316#issuecomment-639744793
+      newValue = value + newEntry
+    } else if (selectionStart === selectionEnd) {
+      if (selectionStart === 0) {
+        // at the beginning of the input
+        newValue = newEntry + value
+      } else if (selectionStart === value.length) {
+        // at the end of the input
+        newValue = value + newEntry
+      } else {
+        // in the middle of the input
+        newValue =
+          value.slice(0, selectionStart) + newEntry + value.slice(selectionEnd)
+      }
+      newSelectionStart = selectionStart + newEntry.length
+    } else {
+      // we have something selected
+      const firstPart = value.slice(0, selectionStart) + newEntry
+      newValue = firstPart + value.slice(selectionEnd)
+      newSelectionStart = firstPart.length
+    }
+
+    if (maxLength < 0) {
+      return {newValue, newSelectionStart}
+    } else {
+      return {
+        newValue: newValue.slice(0, maxLength),
+        newSelectionStart:
+          newSelectionStart > maxLength ? maxLength : newSelectionStart,
+      }
+    }
+  }
+}
+
+export {paste}

--- a/src/type.js
+++ b/src/type.js
@@ -30,7 +30,7 @@ const getActiveElement = document => {
 async function typeImpl(
   element,
   text,
-  {allAtOnce = false, delay, initialSelectionStart, initialSelectionEnd} = {},
+  {delay, initialSelectionStart, initialSelectionEnd} = {},
 ) {
   if (element.disabled) return
 
@@ -72,15 +72,7 @@ async function typeImpl(
     )
   }
 
-  if (allAtOnce) {
-    if (!element.readOnly) {
-      const {newValue, newSelectionStart} = calculateNewValue(text)
-      fireEvent.input(element, {
-        target: {value: newValue},
-      })
-      setSelectionRange({newValue, newSelectionStart})
-    }
-  } else {
+  {
     const eventCallbackMap = {
       ...modifier({
         name: 'shift',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,11 @@
 // Definitions by: Wu Haotian <https://github.com/whtsky>
 export interface ITypeOpts {
-  allAtOnce?: boolean
   delay?: number
+  initialSelectionStart?: number
+  initialSelectionEnd?: number
+}
+
+export interface IPasteOpts {
   initialSelectionStart?: number
   initialSelectionEnd?: number
 }
@@ -43,6 +47,11 @@ declare const userEvent: {
     element: TargetElement,
     text: string,
     userOpts?: ITypeOpts,
+  ) => Promise<void>
+  paste: (
+    element: TargetElement,
+    text: string,
+    userOpts?: IPasteOpts,
   ) => Promise<void>
   tab: (userOpts?: ITabUserOptions) => void
   hover: (element: TargetElement, init?: MouseEventInit) => Promise<void>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add paste API (fixes #311)

<!-- Why are these changes necessary? -->

**Why**: The `allAtOnce` option of `type` doesn't represent real user interaction intuitively, and we need to fire `paste` events with the relevant `clipboardData`

<!-- How were these changes implemented? -->

**How**:

- [x] Extract `allAtOnce` option from `type` event into `paste` event
- [x] Implement `clipboardData` support upstream testing-library/dom-testing-library/pull/585
- [ ] Add events
  - [ ] `paste` with `clipboardData`
  - [ ] `input` with matching value
  - [ ] `focus`
- [ ] `DataTransfer` mock objects
  - [ ] Consider using in upstream tests

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
