### PR TITLE
fix(selectOptions): don't select option if select is disabled

### DIFF
--- a/src/__tests__/selectoptions.js
+++ b/src/__tests__/selectoptions.js
@@ -318,3 +318,19 @@ test('does not select anything if no matching options are given', () => {
   userEvent.selectOptions(select, 'Matches nothing')
   expect(select.selectedIndex).toBe(0)
 })
+
+test('does not select anything if select is disabled', () => {
+  const {
+    container: {firstChild: select},
+  } = render(
+    <select disabled>
+      <option>No value selected</option>
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </select>,
+  )
+
+  userEvent.selectOptions(select, '1')
+  expect(select.selectedIndex).toBe(0)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,8 @@ function dblClickCheckbox(checkbox, init) {
 }
 
 function selectOption(select, option, init) {
+  if (select.disabled) return
+
   fireEvent.mouseOver(option, getMouseEventOptions('mouseover', init))
   fireEvent.mouseMove(option, getMouseEventOptions('mousemove', init))
   fireEvent.mouseDown(option, getMouseEventOptions('mousedown', init))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Prevent a select's value from changing with `selectOptions` if it is disabled

<!-- Why are these changes necessary? -->

**Why**: It's possible to change the value of a disabled select using `selectOptions`. For instance this is passing:
```
  const {
    container: {firstChild: select},
  } = render(
    <select disabled>
      <option>No value selected</option>
      <option value="1">1</option>
      <option value="2">2</option>
      <option value="3">3</option>
    </select>,
  )

  expect(select.selectedIndex).toBe(0)

  userEvent.selectOptions(select, '1')
  expect(select.selectedIndex).toBe(1)
```

<!-- How were these changes implemented? -->

**How**: Exit early in `selectOptions` if the element is disabled, similar to what is done in `clear` and `upload`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

AFAIK it is ready to be merged, however I am not experienced with this project (only as a user) and there may be very good reasons why this was not already done this way.

<!-- feel free to add additional comments -->
