### PR TITLE
Revert "docs: Move contributions to dom-testing-library"

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,15 @@
-<!-- user-event is moving. Please create new issues in dom-testing-library (https://github.com/testing-library/dom-testing-library). -->
+<!--
+Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
+Please make sure that you are familiar with and follow the Code of Conduct for
+this project (found in the CODE_OF_CONDUCT.md file).
+
+Please fill out this template with all the relevant information so we can
+understand what's going on and fix the issue.
+
+I'll probably ask you to submit the fix (after giving some direction). If you've
+never done that before, that's great! Check this free short video tutorial to
+learn how: http://kcd.im/pull-request
+-->
 
 - `@testing-library/user-event` version:
 - Testing Framework and version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,18 @@
-<!-- user-event is moving. Please create new issues in dom-testing-library (https://github.com/testing-library/dom-testing-library). -->
+<!--
+Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!
+
+Please make sure that you are familiar with and follow the Code of Conduct for
+this project (found in the CODE_OF_CONDUCT.md file).
+
+Also, please make sure you're familiar with and follow the instructions in the
+contributing guidelines (found in the CONTRIBUTING.md file).
+
+If you're new to contributing to open source projects, you might find this free
+video course helpful: http://kcd.im/pull-request
+
+Please fill out the information below to expedite the review and (hopefully)
+merge of your pull request!
+-->
 
 <!-- What changes are being made? (What feature/bug is being fixed here?) -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,3 @@
-**`user-event` is moving. Please create new issues in
-[`dom-testing-library`](https://github.com/testing-library/dom-testing-library).**
-
 # Contributing
 
 Thanks for being willing to contribute!

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ change the state of the checkbox.
   - [`unhover(element)`](#unhoverelement)
   - [`paste(element, text, eventInit, options)`](#pasteelement-text-eventinit-options)
 - [Issues](#issues)
+  - [🐛 Bugs](#-bugs)
+  - [💡 Feature Requests](#-feature-requests)
 - [Contributors ✨](#contributors-)
 - [LICENSE](#license)
 
@@ -455,8 +457,21 @@ You can use the `eventInit` if what you're pasting should have `clipboardData`
 
 ## Issues
 
-**`user-event` is moving. Please create new issues in
-[`dom-testing-library`](https://github.com/testing-library/dom-testing-library).**
+_Looking to contribute? Look for the [Good First Issue][good-first-issue]
+label._
+
+### 🐛 Bugs
+
+Please file an issue for bugs, missing documentation, or unexpected behavior.
+
+[**See Bugs**][bugs]
+
+### 💡 Feature Requests
+
+Please file an issue to suggest new features. Vote on feature requests by adding
+a 👍. This helps maintainers prioritize what to work on.
+
+[**See Feature Requests**][requests]
 
 ## Contributors ✨
 
@@ -528,7 +543,6 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -557,4 +571,7 @@ MIT
 [coc]: https://github.com/testing-library/user-event/blob/master/other/CODE_OF_CONDUCT.md
 [emojis]: https://github.com/all-contributors/all-contributors#emoji-key
 [all-contributors]: https://github.com/all-contributors/all-contributors
+[bugs]: https://github.com/testing-library/user-event/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Acreated-desc+label%3Abug
+[requests]: https://github.com/testing-library/user-event/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement
+[good-first-issue]: https://github.com/testing-library/user-event/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement+label%3A%22good+first+issue%22
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Reverts testing-library/user-event#345

We should merge this if the decision to not migrate to `dom-testing-library` now is final