### PR TITLE
Cycle focus between the body and page tab sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,11 @@ it('should cycle elements in document tab order', () => {
 
   userEvent.tab()
 
-  // cycle goes back to first element
+  // cycle goes back to the body element
+  expect(document.body).toHaveFocus()
+
+  userEvent.tab()
+
   expect(checkbox).toHaveFocus()
 })
 ```
@@ -545,6 +549,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -111,7 +111,11 @@ test('should cycle elements in document tab order', () => {
 
   userEvent.tab()
 
-  // cycle goes back to first element
+  // cycle goes back to the body
+  expect(document.body).toHaveFocus()
+
+  userEvent.tab()
+
   expect(checkbox).toHaveFocus()
 })
 
@@ -127,11 +131,24 @@ test('should go backwards when shift = true', () => {
     '[data-testid="element"]',
   )
 
-  radio.focus()
+  expect(document.body).toHaveFocus()
+
+  userEvent.tab({shift: true})
+
+  expect(number).toHaveFocus()
+
+  userEvent.tab({shift: true})
+
+  expect(radio).toHaveFocus()
 
   userEvent.tab({shift: true})
 
   expect(checkbox).toHaveFocus()
+
+  userEvent.tab({shift: true})
+
+  // cycle goes back to the body
+  expect(document.body).toHaveFocus()
 
   userEvent.tab({shift: true})
 
@@ -164,6 +181,10 @@ test('should respect tabindex, regardless of dom position', () => {
 
   userEvent.tab()
 
+  expect(document.body).toHaveFocus()
+
+  userEvent.tab()
+
   expect(radio).toHaveFocus()
 })
 
@@ -190,6 +211,10 @@ test('should respect tab index order, then DOM order', () => {
   userEvent.tab()
 
   expect(radio).toHaveFocus()
+
+  userEvent.tab()
+
+  expect(document.body).toHaveFocus()
 
   userEvent.tab()
 

--- a/src/tab.js
+++ b/src/tab.js
@@ -3,6 +3,22 @@ import {getActiveElement, FOCUSABLE_SELECTOR} from './utils'
 import {focus} from './focus'
 import {blur} from './blur'
 
+function getNextElement(currentIndex, shift, elements, focusTrap) {
+  if (focusTrap === document && currentIndex === 0 && shift) {
+    return document.body
+  } else if (
+    focusTrap === document &&
+    currentIndex === elements.length - 1 &&
+    !shift
+  ) {
+    return document.body
+  } else {
+    const nextIndex = shift ? currentIndex - 1 : currentIndex + 1
+    const defaultIndex = shift ? elements.length - 1 : 0
+    return elements[nextIndex] || elements[defaultIndex]
+  }
+}
+
 function tab({shift = false, focusTrap} = {}) {
   const previousElement = getActiveElement(focusTrap?.ownerDocument ?? document)
 
@@ -57,10 +73,7 @@ function tab({shift = false, focusTrap} = {}) {
     el => el === el.ownerDocument.activeElement,
   )
 
-  const nextIndex = shift ? index - 1 : index + 1
-  const defaultIndex = shift ? prunedElements.length - 1 : 0
-
-  const nextElement = prunedElements[nextIndex] || prunedElements[defaultIndex]
+  const nextElement = getNextElement(index, shift, prunedElements, focusTrap)
 
   const shiftKeyInit = {
     key: 'Shift',


### PR DESCRIPTION
Resolves https://github.com/testing-library/user-event/issues/365

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add `document.body` to the cycled elements in tab sequence

<!-- Why are these changes necessary? -->

**Why**: The browser allows the active element to be `document.body` when the next selected element is outside the page tab sequence. When the active element is the body (e.g. initial state) then the next reasonable selected element is the first element in the page tab sequence. 

<!-- How were these changes implemented? -->

**How**: 

- Consolidate logic around getting the next element to focus
- If the current active element is on the edges of the page tab sequence then focus the `document.body` accordingly

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

1. I was assuming that invoking `document.body.focus` would be undesirable -- opting for just `previousElement.blur` as a means of setting active element to the `body`. However, it seems that `document.body.focus` is working well enough. Do we want to add this kind of logic?

1. All tests pass when [not mutating `tabindex` for `tab`](https://github.com/testing-library/user-event/blob/f4eae9cf3c4bb5765dcdb7ce7f7652ae16e2f9a7/src/tab.js#L93-L96). Do we want to clean that up in this PR? Or is there some version of jsdom this is intended to support?