### PR TITLE
fix: update onChange/input events fired on selected option

### DIFF
--- a/src/__tests__/deselect-options.js
+++ b/src/__tests__/deselect-options.js
@@ -55,6 +55,8 @@ test('blurs previously focused element', () => {
     select[name="select"][value=[]] - focusin
     option[value="1"][selected=false] - pointerup
     option[value="1"][selected=false] - mouseup: Left (0)
+    select[name="select"][value=[]] - input
+    select[name="select"][value=[]] - change
     option[value="1"][selected=false] - click: Left (0)
   `)
 })

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -133,3 +133,19 @@ test('does not select anything if options are disabled', () => {
   expect(o2.selected).toBe(false)
   expect(o3.selected).toBe(false)
 })
+
+test('should call onChange bubbling up the event when a new option is selected', () => {
+  const {select, form} = setupSelect({multiple: true})
+  const onChangeSelect = jest.fn()
+  const onChangeForm = jest.fn()
+  select.addEventListener('change', onChangeSelect)
+  form.addEventListener('change', onChangeForm)
+
+  expect(onChangeSelect.mock.calls).toHaveLength(0)
+  expect(onChangeForm.mock.calls).toHaveLength(0)
+
+  userEvent.selectOptions(select, ['1'])
+
+  expect(onChangeForm.mock.calls).toHaveLength(1)
+  expect(onChangeSelect.mock.calls).toHaveLength(1)
+})

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -134,18 +134,26 @@ test('does not select anything if options are disabled', () => {
   expect(o3.selected).toBe(false)
 })
 
-test('should call onChange bubbling up the event when a new option is selected', () => {
+test('should call onChange/input bubbling up the event when a new option is selected', () => {
   const {select, form} = setupSelect({multiple: true})
   const onChangeSelect = jest.fn()
   const onChangeForm = jest.fn()
+  const onInputSelect = jest.fn()
+  const onInputForm = jest.fn()
   select.addEventListener('change', onChangeSelect)
+  select.addEventListener('input', onInputSelect)
   form.addEventListener('change', onChangeForm)
+  form.addEventListener('input', onInputForm)
 
   expect(onChangeSelect.mock.calls).toHaveLength(0)
   expect(onChangeForm.mock.calls).toHaveLength(0)
+  expect(onInputSelect.mock.calls).toHaveLength(0)
+  expect(onInputForm.mock.calls).toHaveLength(0)
 
   userEvent.selectOptions(select, ['1'])
 
   expect(onChangeForm.mock.calls).toHaveLength(1)
   expect(onChangeSelect.mock.calls).toHaveLength(1)
+  expect(onInputSelect.mock.calls).toHaveLength(1)
+  expect(onInputForm.mock.calls).toHaveLength(1)
 })

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -140,20 +140,22 @@ test('should call onChange/input bubbling up the event when a new option is sele
   const onChangeForm = jest.fn()
   const onInputSelect = jest.fn()
   const onInputForm = jest.fn()
-  select.addEventListener('change', onChangeSelect)
-  select.addEventListener('input', onInputSelect)
-  form.addEventListener('change', onChangeForm)
-  form.addEventListener('input', onInputForm)
+  addListeners(select, {
+    eventHandlers: {change: onChangeSelect, input: onInputSelect},
+  })
+  addListeners(form, {
+    eventHandlers: {change: onChangeForm, input: onInputForm},
+  })
 
-  expect(onChangeSelect.mock.calls).toHaveLength(0)
-  expect(onChangeForm.mock.calls).toHaveLength(0)
-  expect(onInputSelect.mock.calls).toHaveLength(0)
-  expect(onInputForm.mock.calls).toHaveLength(0)
+  expect(onChangeSelect).toHaveBeenCalledTimes(0)
+  expect(onChangeForm).toHaveBeenCalledTimes(0)
+  expect(onInputSelect).toHaveBeenCalledTimes(0)
+  expect(onInputForm).toHaveBeenCalledTimes(0)
 
   userEvent.selectOptions(select, ['1'])
 
-  expect(onChangeForm.mock.calls).toHaveLength(1)
-  expect(onChangeSelect.mock.calls).toHaveLength(1)
-  expect(onInputSelect.mock.calls).toHaveLength(1)
-  expect(onInputForm.mock.calls).toHaveLength(1)
+  expect(onChangeForm).toHaveBeenCalledTimes(1)
+  expect(onChangeSelect).toHaveBeenCalledTimes(1)
+  expect(onInputSelect).toHaveBeenCalledTimes(1)
+  expect(onInputForm).toHaveBeenCalledTimes(1)
 })

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -60,8 +60,16 @@ function selectOptionsBase(newValue, select, values, init) {
 
   function selectOption(option) {
     option.selected = newValue
-    fireEvent(select, createEvent('input', select, init))
-    fireEvent(select, createEvent('change', select, init))
+    fireEvent(
+      select,
+      createEvent('input', select, {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        ...init,
+      }),
+    )
+    fireEvent.change(select, init)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

fix #358 
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR will fix the issue that events (onChage/input) are not fired on ancestors.
This issue was related to a problem with React because it fires event on bubbling phase. 
As we can see from the images below 

the change event is an `Event` of type `change` 
![image](https://user-images.githubusercontent.com/5365582/85199807-a1868980-b2f2-11ea-829c-2f87e261f1fe.png)

the input event is an `Event` of type `input`
![image](https://user-images.githubusercontent.com/5365582/85199837-c11db200-b2f2-11ea-8dc7-9acf01ab862f.png)

Both events are of a generic event type. 

**Why**:

Because in particular with React the change event is fired but the onChange listener didn't work

**How**:

By calling 
```
fireEvent(
  select,
  createEvent('input', select, {
    bubbles: true,
    cancelable: false,
    composed: true,
    ...init,
  }),
)
fireEvent.change(select, init)
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
