### PR TITLE
Implement key press functionality from a user perspective

### DIFF
--- a/src/__tests__/key-press.js
+++ b/src/__tests__/key-press.js
@@ -1,0 +1,264 @@
+import userEvent from '../'
+import {setup} from './helpers/utils'
+
+test('presses arrow keys on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown')
+  userEvent.keyPress('ArrowLeft')
+  userEvent.keyPress('ArrowRight')
+  userEvent.keyPress('ArrowUp')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: ArrowDown (0)
+    div - keyup: ArrowDown (0)
+    div - keydown: ArrowLeft (0)
+    div - keyup: ArrowLeft (0)
+    div - keydown: ArrowRight (0)
+    div - keyup: ArrowRight (0)
+    div - keydown: ArrowUp (0)
+    div - keyup: ArrowUp (0)
+  `)
+})
+
+test('presses home and end keys on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('Home')
+  userEvent.keyPress('End')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Home (0)
+    div - keyup: Home (0)
+    div - keydown: End (0)
+    div - keyup: End (0)
+  `)
+})
+
+test('presses page up and page down keys on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('PageUp')
+  userEvent.keyPress('PageDown')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: PageUp (0)
+    div - keyup: PageUp (0)
+    div - keydown: PageDown (0)
+    div - keyup: PageDown (0)
+  `)
+})
+
+test('presses printable characters on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('A')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: A (0)
+    div - keypress: A (0)
+    div - keyup: A (0)
+  `)
+})
+
+test('presses key with alt modifier on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown', {alt: true})
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Alt (0)
+    div - keydown: ArrowDown (0) {alt}
+    div - keyup: ArrowDown (0) {alt}
+    div - keyup: Alt (0)
+  `)
+})
+
+test('presses key with ctrl modifier on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown', {ctrl: true})
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Ctrl (0)
+    div - keydown: ArrowDown (0) {ctrl}
+    div - keyup: ArrowDown (0) {ctrl}
+    div - keyup: Ctrl (0)
+  `)
+})
+
+test('presses key with meta modifier on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown', {meta: true})
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Meta (0)
+    div - keydown: ArrowDown (0) {meta}
+    div - keyup: ArrowDown (0) {meta}
+    div - keyup: Meta (0)
+  `)
+})
+
+test('presses key with shift modifier on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown', {shift: true})
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Shift (0)
+    div - keydown: ArrowDown (0) {shift}
+    div - keyup: ArrowDown (0) {shift}
+    div - keyup: Shift (0)
+  `)
+})
+
+test('presses key with all modifiers on active element', () => {
+  const {element, getEventSnapshot} = setup('<div tabindex="0"/>')
+  userEvent.click(element)
+  userEvent.keyPress('ArrowDown', {
+    alt: true,
+    ctrl: true,
+    meta: true,
+    shift: true,
+  })
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: Alt (0)
+    div - keydown: Ctrl (0)
+    div - keydown: Meta (0)
+    div - keydown: Shift (0)
+    div - keydown: ArrowDown (0) {alt}{shift}{meta}{ctrl}
+    div - keyup: ArrowDown (0) {alt}{shift}{meta}{ctrl}
+    div - keyup: Shift (0)
+    div - keyup: Meta (0)
+    div - keyup: Ctrl (0)
+    div - keyup: Alt (0)
+  `)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {hover, unhover} from './hover'
 import {upload} from './upload'
 import {selectOptions, deselectOptions} from './select-options'
 import {paste} from './paste'
+import {keyPress} from './key-press'
 
 const userEvent = {
   click,
@@ -19,6 +20,7 @@ const userEvent = {
   selectOptions,
   deselectOptions,
   paste,
+  keyPress,
 }
 
 export default userEvent

--- a/src/key-press.js
+++ b/src/key-press.js
@@ -1,0 +1,36 @@
+import {fireEvent} from '@testing-library/dom'
+import {getActiveElement} from './utils'
+
+function isPrintableCharacter(key) {
+  return key.length === 1
+}
+
+function keyPress(
+  key,
+  {alt = false, ctrl = false, meta = false, shift = false} = {},
+) {
+  const activeElement = getActiveElement(document)
+
+  const event = {
+    key,
+    altKey: alt,
+    ctrlKey: ctrl,
+    metaKey: meta,
+    shiftKey: shift,
+  }
+
+  if (alt) fireEvent.keyDown(activeElement, {key: 'Alt'})
+  if (ctrl) fireEvent.keyDown(activeElement, {key: 'Ctrl'})
+  if (meta) fireEvent.keyDown(activeElement, {key: 'Meta'})
+  if (shift) fireEvent.keyDown(activeElement, {key: 'Shift'})
+
+  fireEvent.keyDown(activeElement, event)
+  if (isPrintableCharacter(key)) fireEvent.keyPress(activeElement, event)
+  fireEvent.keyUp(activeElement, event)
+
+  if (shift) fireEvent.keyUp(activeElement, {key: 'Shift'})
+  if (meta) fireEvent.keyUp(activeElement, {key: 'Meta'})
+  if (ctrl) fireEvent.keyUp(activeElement, {key: 'Ctrl'})
+  if (alt) fireEvent.keyUp(activeElement, {key: 'Alt'})
+}
+export {keyPress}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Implement user interaction of pressing a single key with some modifiers

<!-- Why are these changes necessary? -->

**Why**: This is especially useful for testing accessibility interactions (keyboard interactions) on UI elements.

<!-- How were these changes implemented? -->

**How**: 

- Interaction is solely on the active element because a user will always be on _some_ element
- Any key is "pressable" given the key name
- The 4 popular modifiers (alt, ctrl, meta, shift) are implemented and fired around the pressed key
  - Looks like there might be more key to implement but I think we can work on these in the future

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Closes https://github.com/testing-library/user-event/issues/354

A couple of notes:

- The event is always fired on the active element since a user will always perform an interaction on the active element
- Event `which` key is not implement because [it is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which)
- Event `code` / `keyCode` key is not implement because it can vary on type of key (`KeyA`, `Digit1`, `AltLeft`, etc), opting for a more simple interface