### PR TITLE
Add else block to setSelectionRange check

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -61,12 +61,19 @@ async function typeImpl(
     // The reason we have to do this at all is because it actually *is*
     // programmatically changed by fireEvent.input, so we have to simulate the
     // browser's default behavior
-    if (currentValue() === newValue) {
+    const value = currentValue()
+
+    if (value === newValue) {
       setSelectionRangeIfNecessary(
         currentElement(),
         newSelectionStart,
         newSelectionStart,
       )
+    } else {
+      // If the currentValue is different than the expected newValue and we *can*
+      // change the selection range, than we should set it to the length of the
+      // currentValue to ensure that the browser behavior is mimicked.
+      setSelectionRangeIfNecessary(currentElement(), value.length, value.length)
     }
   }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This fixes #369 

<!-- Why are these changes necessary? -->

**Why**:
Without this change, when a value is changed programatically  as part of a React onChange event, the selectionRange stays at (0, 0) causing the values to be typed in reverse order.

**How**:
Added an else block to the `setSelectionRange` function that is part of `type`. The conditional already existed to check to see if the value changed programatically and my else adds logic to move the selection range to the end of the input to mimic the behavior of the browser.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [ ] Tests 
- [ ] Typings (N/A)
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I attempted to replicate my failing react testing here by using the same format function and setting `event.target.value` when the input event fired. However, the test passed without my change. This leads me to believe that it is a symptom of how the value of an input is controlled by React. To confirm this fixed my issue I had to do the following:

1. `npm run build`
2. Copy the contents of `dist/type.js` to my React project's `node_modules/@testing-library/user-event/dist/type.js` file.
