### PR TITLE
fix: add message if type/paste function is called with an invalid element

### DIFF
--- a/src/__tests__/paste.js
+++ b/src/__tests__/paste.js
@@ -94,3 +94,12 @@ test('should replace selected text all at once', () => {
   userEvent.paste(element, 'friend')
   expect(element).toHaveValue('hello friend')
 })
+
+test('should give error if we are trying to call paste on an invalid element', () => {
+  const {element} = setup('<div  />')
+  expect(() =>
+    userEvent.paste(element, "I'm only a div :("),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"the current element is of type DIV and doesn't have a valid value"`,
+  )
+})

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -706,3 +706,12 @@ test('typing an invalid input value', () => {
   // but the badInput should actually be "true" if the user types "3-3"
   expect(element.validity.badInput).toBe(false)
 })
+
+test('should give error if we are trying to call type on an invalid element', async () => {
+  const {element} = setup('<div  />')
+  await expect(() =>
+    userEvent.type(element, "I'm only a div :("),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"the current element is of type BODY and doesn't have a valid value"`,
+  )
+})

--- a/src/paste.js
+++ b/src/paste.js
@@ -8,7 +8,11 @@ function paste(
   {initialSelectionStart, initialSelectionEnd} = {},
 ) {
   if (element.disabled) return
-
+  if (typeof element.value === 'undefined') {
+    throw new TypeError(
+      `the current element is of type ${element.tagName} and doesn't have a valid value`,
+    )
+  }
   element.focus()
 
   // by default, a new element has it's selection start and end at 0
@@ -30,7 +34,11 @@ function paste(
   fireEvent.paste(element, init)
 
   if (!element.readOnly) {
-    const {newValue, newSelectionStart} = calculateNewValue(text, element)
+    const {newValue, newSelectionStart} = calculateNewValue(
+      text,
+      element,
+      element.value,
+    )
     fireEvent.input(element, {
       inputType: 'insertFromPaste',
       target: {value: newValue},

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,11 +94,7 @@ function getActiveElement(document) {
 
 function calculateNewValue(newEntry, element) {
   const {selectionStart, selectionEnd, value} = element
-  if (typeof value === 'undefined') {
-    throw new TypeError(
-      `the current element is of type ${element.tagName} and doesn't have a valid value`,
-    )
-  }
+
   // can't use .maxLength property because of a jsdom bug:
   // https://github.com/jsdom/jsdom/issues/2927
   const maxLength = Number(element.getAttribute('maxlength') ?? -1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,11 @@ function getActiveElement(document) {
 
 function calculateNewValue(newEntry, element) {
   const {selectionStart, selectionEnd, value} = element
+  if (typeof value === 'undefined') {
+    throw new Error(
+      `the current element is of type ${element.tagName} and doesn't have a valid value`,
+    )
+  }
   // can't use .maxLength property because of a jsdom bug:
   // https://github.com/jsdom/jsdom/issues/2927
   const maxLength = Number(element.getAttribute('maxlength') ?? -1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,7 +95,7 @@ function getActiveElement(document) {
 function calculateNewValue(newEntry, element) {
   const {selectionStart, selectionEnd, value} = element
   if (typeof value === 'undefined') {
-    throw new Error(
+    throw new TypeError(
       `the current element is of type ${element.tagName} and doesn't have a valid value`,
     )
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I have thrown a new `TypeError` if the user calls `userEvent.type` or `userEvent.paste` with an element that has no value. 
This PR is part of issue #356.

**Why**:

Because as it was before the PR the error was not very helpful

![image](https://user-images.githubusercontent.com/5365582/85226672-0fa57c00-b3d9-11ea-8d4f-84c7830cac6c.png)


**How**:

By checking if the currentElement has value property. 
The message thrown is like this `the current element is of type BODY and doesn't have a valid value`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
