### PR TITLE
Fix leading number being trimmed on point type

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -641,11 +641,11 @@ test('can type "-" into number inputs', () => {
 // https://github.com/testing-library/user-event/issues/336
 test('can type "." into number inputs', () => {
   const {element, getEventSnapshot} = setup('<input type="number" />')
-  userEvent.type(element, '0.3')
-  expect(element).toHaveValue(0.3)
+  userEvent.type(element, '3.3')
+  expect(element).toHaveValue(3.3)
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: input[value=".3"]
+    Events fired on: input[value="3.3"]
 
     input[value=""] - pointerover
     input[value=""] - pointerenter
@@ -660,21 +660,21 @@ test('can type "." into number inputs', () => {
     input[value=""] - pointerup
     input[value=""] - mouseup: Left (0)
     input[value=""] - click: Left (0)
-    input[value=""] - keydown: 0 (48)
-    input[value=""] - keypress: 0 (48)
-    input[value="0"] - input
-      "{CURSOR}" -> "{CURSOR}0"
-    input[value="0"] - keyup: 0 (48)
-    input[value="0"] - keydown: . (46)
-    input[value="0"] - keypress: . (46)
+    input[value=""] - keydown: 3 (51)
+    input[value=""] - keypress: 3 (51)
+    input[value="3"] - input
+      "{CURSOR}" -> "{CURSOR}3"
+    input[value="3"] - keyup: 3 (51)
+    input[value="3"] - keydown: . (46)
+    input[value="3"] - keypress: . (46)
     input[value=""] - input
-      "{CURSOR}0" -> "{CURSOR}"
+      "{CURSOR}3" -> "{CURSOR}"
     input[value=""] - keyup: . (46)
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
-    input[value=".3"] - input
-      "{CURSOR}" -> "{CURSOR}.3"
-    input[value=".3"] - keyup: 3 (51)
+    input[value="3.3"] - input
+      "{CURSOR}" -> "{CURSOR}3.3"
+    input[value="3.3"] - keyup: 3 (51)
   `)
 })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

It solves #360.

<!-- Why are these changes necessary? -->

**How**:

In the actual code handling the point, I concatenate the input's previous value.
I tried to keep the changes as little as possible once I'm not used to neither to the events nor to the lib.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
