### PR TITLE
fix: React onChange/onInput events not triggering on input type="file" file upload

### DIFF
--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -61,6 +61,8 @@ test('should fire the correct events with label', () => {
     label[for="element"] - click: Left (0)
     input#element[value=""] - click: Left (0)
     input#element[value=""] - focusin
+    input#element[value=""] - input
+    input#element[value=""] - change
   `)
 })
 

--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -1,5 +1,5 @@
 import userEvent from '../'
-import {setup} from './helpers/utils'
+import {setup, addListeners} from './helpers/utils'
 
 test('should fire the correct events for input', () => {
   const file = new File(['hello'], 'hello.png', {type: 'image/png'})
@@ -124,4 +124,38 @@ test('should not upload when is disabled', () => {
   expect(element.files[0]).toBeUndefined()
   expect(element.files.item(0)).toBeNull()
   expect(element.files).toHaveLength(0)
+})
+
+test('should call onChange/input bubbling up the event when a file is selected', () => {
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+
+  const {element: form} = setup(`
+    <form>
+      <input type="file" />
+    </form>
+  `)
+  const input = form.querySelector('input')
+
+  const onChangeInput = jest.fn()
+  const onChangeForm = jest.fn()
+  const onInputInput = jest.fn()
+  const onInputForm = jest.fn()
+  addListeners(input, {
+    eventHandlers: {change: onChangeInput, input: onInputInput},
+  })
+  addListeners(form, {
+    eventHandlers: {change: onChangeForm, input: onInputForm},
+  })
+
+  expect(onChangeInput).toHaveBeenCalledTimes(0)
+  expect(onChangeForm).toHaveBeenCalledTimes(0)
+  expect(onInputInput).toHaveBeenCalledTimes(0)
+  expect(onInputForm).toHaveBeenCalledTimes(0)
+
+  userEvent.upload(input, file)
+
+  expect(onChangeForm).toHaveBeenCalledTimes(1)
+  expect(onChangeInput).toHaveBeenCalledTimes(1)
+  expect(onInputInput).toHaveBeenCalledTimes(1)
+  expect(onInputForm).toHaveBeenCalledTimes(1)
 })

--- a/src/upload.js
+++ b/src/upload.js
@@ -35,17 +35,17 @@ function upload(element, fileOrFiles, init) {
     input,
     createEvent('input', input, {
       target: {files: inputFiles},
+      bubbles: true,
+      cancelable: false,
+      composed: true,
       ...init,
     }),
   )
 
-  fireEvent(
-    input,
-    createEvent('change', input, {
-      target: {files: inputFiles},
-      ...init,
-    }),
-  )
+  fireEvent.change(input, {
+    target: {files: inputFiles},
+    ...init,
+  })
 }
 
 export {upload}


### PR DESCRIPTION
Fixes #380.

**What**:
This PR fixes a bug in the `.upload()` function that's very similar to #370. The cause of the bug and the fix are basically the same.

**Why**:
In React, starting with user-event v12 the `onChange` and `onInput` callbacks stopped working for `<input type="file" />`.

**How**:
Very similar to #370:
- Input event: passing the `bubbles: true` option to the event's options.
- Change event: Use `fireEvent.change` instead of `fireEvent(input, createEvent('change', ...`.

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged

**Notes**:
As I mentioned in the [related issue](#380), we should probably check the rest of the changes in case some other similar functionality broke with the recent changes.