### PR TITLE
chore: disable testing-library/no-dom-import eslint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
       "jsx-a11y/click-events-have-key-events": "off",
       "jsx-a11y/tabindex-no-positive": "off",
       "no-return-assign": "off",
-      "react/prop-types": "off"
+      "react/prop-types": "off",
+      "testing-library/no-dom-import": "off"
     },
     "overrides": [
       {


### PR DESCRIPTION
**What**:
This PR disables the `testing-library/no-dom-import` eslint rule for the project.

**Why**:

The project currently imports directly from `@testing-library/dom` which causes the linter to throw and fail the pre-commit hook which makes it impossible to commit without bypassing the commit hook. This was @kentcdodds's suggested solution [here](https://github.com/testing-library/user-event/issues/380#issuecomment-649155263).

**How**:

Updated `package.json` to turn this specific rule off.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Typings N/A
- [x] Ready to be merged
