### PR TITLE
fix: ensure all events are fired in the eventWrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rules": {
       "jsx-a11y/click-events-have-key-events": "off",
       "jsx-a11y/tabindex-no-positive": "off",
+      "no-func-assign": "off",
       "no-return-assign": "off",
       "react/prop-types": "off",
       "testing-library/no-dom-import": "off"

--- a/src/blur.js
+++ b/src/blur.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, isFocusable} from './utils'
+import {getActiveElement, isFocusable, wrapInEventWrapper} from './utils'
 
 function blur(element, init) {
   if (!isFocusable(element)) return
@@ -10,5 +10,7 @@ function blur(element, init) {
   element.blur()
   fireEvent.focusOut(element, init)
 }
+
+blur = wrapInEventWrapper(blur)
 
 export {blur}

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,4 +1,5 @@
 import {type} from './type'
+import {wrapInEventWrapper} from './utils'
 
 function clear(element) {
   if (element.tagName !== 'INPUT' && element.tagName !== 'TEXTAREA') {
@@ -26,5 +27,7 @@ function clear(element) {
     element.type = elementType
   }
 }
+
+clear = wrapInEventWrapper(clear)
 
 export {clear}

--- a/src/click.js
+++ b/src/click.js
@@ -2,6 +2,7 @@ import {fireEvent} from '@testing-library/dom'
 import {
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
+  wrapInEventWrapper,
 } from './utils'
 import {hover} from './hover'
 import {blur} from './blur'
@@ -102,5 +103,8 @@ function dblClick(element, init) {
   click(element, init, {skipHover: true, clickCount: 1})
   fireEvent.dblClick(element, getMouseEventOptions('dblclick', init, 2))
 }
+
+click = wrapInEventWrapper(click)
+dblClick = wrapInEventWrapper(dblClick)
 
 export {click, dblClick}

--- a/src/focus.js
+++ b/src/focus.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, isFocusable} from './utils'
+import {getActiveElement, isFocusable, wrapInEventWrapper} from './utils'
 
 function focus(element, init) {
   if (!isFocusable(element)) return
@@ -10,5 +10,6 @@ function focus(element, init) {
   element.focus()
   fireEvent.focusIn(element, init)
 }
+focus = wrapInEventWrapper(focus)
 
 export {focus}

--- a/src/hover.js
+++ b/src/hover.js
@@ -2,6 +2,7 @@ import {fireEvent} from '@testing-library/dom'
 import {
   isLabelWithInternallyDisabledControl,
   getMouseEventOptions,
+  wrapInEventWrapper,
 } from './utils'
 
 function hover(element, init) {
@@ -33,5 +34,8 @@ function unhover(element, init) {
     fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
   }
 }
+
+hover = wrapInEventWrapper(hover)
+unhover = wrapInEventWrapper(unhover)
 
 export {hover, unhover}

--- a/src/paste.js
+++ b/src/paste.js
@@ -1,5 +1,9 @@
 import {fireEvent} from '@testing-library/dom'
-import {setSelectionRangeIfNecessary, calculateNewValue} from './utils'
+import {
+  setSelectionRangeIfNecessary,
+  calculateNewValue,
+  wrapInEventWrapper,
+} from './utils'
 
 function paste(
   element,
@@ -49,5 +53,6 @@ function paste(
     })
   }
 }
+paste = wrapInEventWrapper(paste)
 
 export {paste}

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -1,4 +1,5 @@
 import {createEvent, getConfig, fireEvent} from '@testing-library/dom'
+import {wrapInEventWrapper} from './utils'
 import {click} from './click'
 import {focus} from './focus'
 
@@ -73,7 +74,7 @@ function selectOptionsBase(newValue, select, values, init) {
   }
 }
 
-const selectOptions = selectOptionsBase.bind(null, true)
-const deselectOptions = selectOptionsBase.bind(null, false)
+const selectOptions = wrapInEventWrapper(selectOptionsBase.bind(null, true))
+const deselectOptions = wrapInEventWrapper(selectOptionsBase.bind(null, false))
 
 export {selectOptions, deselectOptions}

--- a/src/tab.js
+++ b/src/tab.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, FOCUSABLE_SELECTOR} from './utils'
+import {getActiveElement, FOCUSABLE_SELECTOR, wrapInEventWrapper} from './utils'
 import {focus} from './focus'
 import {blur} from './blur'
 
@@ -112,6 +112,7 @@ function tab({shift = false, focusTrap} = {}) {
     fireEvent.keyUp(keyUpTarget, {...shiftKeyInit, shiftKey: false})
   }
 }
+tab = wrapInEventWrapper(tab)
 
 export {tab}
 

--- a/src/type.js
+++ b/src/type.js
@@ -3,10 +3,12 @@ import {
   fireEvent,
   getConfig as getDOMTestingLibraryConfig,
 } from '@testing-library/dom'
+
 import {
   getActiveElement,
   calculateNewValue,
   setSelectionRangeIfNecessary,
+  wrapInEventWrapper,
 } from './utils'
 import {click} from './click'
 
@@ -528,6 +530,7 @@ function getEventCallbackMap({
     }
   }
 }
+type = wrapInEventWrapper(type)
 
 export {type}
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,4 +1,5 @@
 import {fireEvent, createEvent} from '@testing-library/dom'
+import {wrapInEventWrapper} from './utils'
 import {click} from './click'
 import {blur} from './blur'
 import {focus} from './focus'
@@ -47,5 +48,6 @@ function upload(element, fileOrFiles, init) {
     ...init,
   })
 }
+upload = wrapInEventWrapper(upload)
 
 export {upload}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import {getConfig} from '@testing-library/dom'
+
 function isMousePressEvent(event) {
   return (
     event === 'mousedown' ||
@@ -169,6 +171,19 @@ function isFocusable(element) {
   )
 }
 
+function wrapInEventWrapper(fn) {
+  function wrapper(...args) {
+    let result
+    getConfig().eventWrapper(() => {
+      result = fn(...args)
+    })
+    return result
+  }
+  // give it a helpful name for debugging
+  Object.defineProperty(wrapper, 'name', {value: `${fn.name}Wrapper`})
+  return wrapper
+}
+
 export {
   FOCUSABLE_SELECTOR,
   isFocusable,
@@ -177,4 +192,5 @@ export {
   getActiveElement,
   calculateNewValue,
   setSelectionRangeIfNecessary,
+  wrapInEventWrapper,
 }


### PR DESCRIPTION
**What**: ensure all events are fired in the eventWrapper

**Why**: Closes #384

**How**: create a helper function to make it easier to wrap all functions in the eventWrapper

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

~- [ ] Documentation~ N/A
~- [ ] Tests~ N/A
~- [ ] Typings~ N/A
- [x] Ready to be merged