### PR TITLE
fix: do not wrap the whole function in the event wrapper

### DIFF
--- a/src/blur.js
+++ b/src/blur.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, isFocusable, wrapInEventWrapper} from './utils'
+import {getActiveElement, isFocusable, eventWrapper} from './utils'
 
 function blur(element, init) {
   if (!isFocusable(element)) return
@@ -7,10 +7,8 @@ function blur(element, init) {
   const wasActive = getActiveElement(element.ownerDocument) === element
   if (!wasActive) return
 
-  element.blur()
+  eventWrapper(() => element.blur())
   fireEvent.focusOut(element, init)
 }
-
-blur = wrapInEventWrapper(blur)
 
 export {blur}

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,5 +1,4 @@
 import {type} from './type'
-import {wrapInEventWrapper} from './utils'
 
 function clear(element) {
   if (element.tagName !== 'INPUT' && element.tagName !== 'TEXTAREA') {
@@ -27,7 +26,5 @@ function clear(element) {
     element.type = elementType
   }
 }
-
-clear = wrapInEventWrapper(clear)
 
 export {clear}

--- a/src/click.js
+++ b/src/click.js
@@ -2,7 +2,6 @@ import {fireEvent} from '@testing-library/dom'
 import {
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
-  wrapInEventWrapper,
 } from './utils'
 import {hover} from './hover'
 import {blur} from './blur'
@@ -103,8 +102,5 @@ function dblClick(element, init) {
   click(element, init, {skipHover: true, clickCount: 1})
   fireEvent.dblClick(element, getMouseEventOptions('dblclick', init, 2))
 }
-
-click = wrapInEventWrapper(click)
-dblClick = wrapInEventWrapper(dblClick)
 
 export {click, dblClick}

--- a/src/focus.js
+++ b/src/focus.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, isFocusable, wrapInEventWrapper} from './utils'
+import {getActiveElement, isFocusable, eventWrapper} from './utils'
 
 function focus(element, init) {
   if (!isFocusable(element)) return
@@ -7,9 +7,8 @@ function focus(element, init) {
   const isAlreadyActive = getActiveElement(element.ownerDocument) === element
   if (isAlreadyActive) return
 
-  element.focus()
+  eventWrapper(() => element.focus())
   fireEvent.focusIn(element, init)
 }
-focus = wrapInEventWrapper(focus)
 
 export {focus}

--- a/src/hover.js
+++ b/src/hover.js
@@ -2,7 +2,6 @@ import {fireEvent} from '@testing-library/dom'
 import {
   isLabelWithInternallyDisabledControl,
   getMouseEventOptions,
-  wrapInEventWrapper,
 } from './utils'
 
 function hover(element, init) {
@@ -34,8 +33,5 @@ function unhover(element, init) {
     fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
   }
 }
-
-hover = wrapInEventWrapper(hover)
-unhover = wrapInEventWrapper(unhover)
 
 export {hover, unhover}

--- a/src/paste.js
+++ b/src/paste.js
@@ -2,7 +2,7 @@ import {fireEvent} from '@testing-library/dom'
 import {
   setSelectionRangeIfNecessary,
   calculateNewValue,
-  wrapInEventWrapper,
+  eventWrapper,
 } from './utils'
 
 function paste(
@@ -17,7 +17,7 @@ function paste(
       `the current element is of type ${element.tagName} and doesn't have a valid value`,
     )
   }
-  element.focus()
+  eventWrapper(() => element.focus())
 
   // by default, a new element has it's selection start and end at 0
   // but most of the time when people call "paste", they expect it to paste
@@ -53,6 +53,5 @@ function paste(
     })
   }
 }
-paste = wrapInEventWrapper(paste)
 
 export {paste}

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -1,5 +1,4 @@
 import {createEvent, getConfig, fireEvent} from '@testing-library/dom'
-import {wrapInEventWrapper} from './utils'
 import {click} from './click'
 import {focus} from './focus'
 
@@ -74,7 +73,7 @@ function selectOptionsBase(newValue, select, values, init) {
   }
 }
 
-const selectOptions = wrapInEventWrapper(selectOptionsBase.bind(null, true))
-const deselectOptions = wrapInEventWrapper(selectOptionsBase.bind(null, false))
+const selectOptions = selectOptionsBase.bind(null, true)
+const deselectOptions = selectOptionsBase.bind(null, false)
 
 export {selectOptions, deselectOptions}

--- a/src/tab.js
+++ b/src/tab.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, FOCUSABLE_SELECTOR, wrapInEventWrapper} from './utils'
+import {getActiveElement, FOCUSABLE_SELECTOR} from './utils'
 import {focus} from './focus'
 import {blur} from './blur'
 
@@ -112,7 +112,6 @@ function tab({shift = false, focusTrap} = {}) {
     fireEvent.keyUp(keyUpTarget, {...shiftKeyInit, shiftKey: false})
   }
 }
-tab = wrapInEventWrapper(tab)
 
 export {tab}
 

--- a/src/type.js
+++ b/src/type.js
@@ -27,9 +27,7 @@ async function type(element, text, {delay = 0, ...options} = {}) {
       result = await typeImpl(element, text, {delay, ...options})
     })
   } else {
-    getDOMTestingLibraryConfig().eventWrapper(() => {
-      result = typeImpl(element, text, {delay, ...options})
-    })
+    result = typeImpl(element, text, {delay, ...options})
   }
   return result
 }

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,5 +1,4 @@
 import {fireEvent, createEvent} from '@testing-library/dom'
-import {wrapInEventWrapper} from './utils'
 import {click} from './click'
 import {blur} from './blur'
 import {focus} from './focus'
@@ -48,6 +47,5 @@ function upload(element, fileOrFiles, init) {
     ...init,
   })
 }
-upload = wrapInEventWrapper(upload)
 
 export {upload}

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,17 +171,12 @@ function isFocusable(element) {
   )
 }
 
-function wrapInEventWrapper(fn) {
-  function wrapper(...args) {
-    let result
-    getConfig().eventWrapper(() => {
-      result = fn(...args)
-    })
-    return result
-  }
-  // give it a helpful name for debugging
-  Object.defineProperty(wrapper, 'name', {value: `${fn.name}Wrapper`})
-  return wrapper
+function eventWrapper(cb) {
+  let result
+  getConfig().eventWrapper(() => {
+    result = cb()
+  })
+  return result
 }
 
 export {
@@ -192,5 +187,5 @@ export {
   getActiveElement,
   calculateNewValue,
   setSelectionRangeIfNecessary,
-  wrapInEventWrapper,
+  eventWrapper,
 }


### PR DESCRIPTION
**What**: do not wrap the whole function in the event wrapper

**Why**: Closes #387

**How**: Remove the `wrapInEventWrapper` utility and use a simple event wrapper instead.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

~- [ ] Documentation N/A~
~- [ ] Tests N/A~
~- [ ] Typings N/A~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
