### PR TITLE
fix: submit form on ENTER pressed

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -758,14 +758,18 @@ test('typing on input type file should not result in an error', () => {
 })
 
 test('should submit a form when ENTER is pressed on input', () => {
-  const {element} = setup(`
+  const handleSubmit = jest.fn()
+  const {element} = setup(
+    `
     <form>
       <input type='text'/>
     </form>
-  `)
-  const onSubmit = jest.fn()
-  element.addEventListener('submit', onSubmit)
+  `,
+    {
+      eventHandlers: {submit: handleSubmit},
+    },
+  )
   userEvent.type(element.querySelector('input'), '{enter}')
 
-  expect(onSubmit).toHaveBeenCalledTimes(1)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
 })

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -756,3 +756,16 @@ test('typing on input type file should not result in an error', () => {
   expect.assertions(0)
   return userEvent.type(element, 'bar').catch(e => expect(e).toBeUndefined())
 })
+
+test('should submit a form when ENTER is pressed on input', () => {
+  const {element} = setup(`
+    <form>
+      <input type='text'/>
+    </form>
+  `)
+  const onSubmit = jest.fn()
+  element.addEventListener('submit', onSubmit)
+  userEvent.type(element.querySelector('input'), '{enter}')
+
+  expect(onSubmit).toHaveBeenCalledTimes(1)
+})

--- a/src/type.js
+++ b/src/type.js
@@ -490,6 +490,10 @@ function handleEnter({currentElement, eventOverrides}) {
     })
   }
 
+  if (currentElement().tagName === 'INPUT' && currentElement().form) {
+    fireEvent.submit(currentElement().form)
+  }
+
   fireEvent.keyUp(currentElement(), {
     key,
     keyCode,


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I have fixed a bug with type function


**Why**: As for the [tweet](https://twitter.com/jacobmparis/status/1280875565885554688) when you run `type` function on an `input` inside a `form` it should `submit` the form if it has a listener. 

<!-- How were these changes implemented? -->

**How**: If the `currentElement` is an input and if it has a form I have fired a `submit` event on form

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
