### PR TITLE
Feature: Implement cursor navigation with navigation keys

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -715,3 +715,77 @@ test('should give error if we are trying to call type on an invalid element', as
     `"the current element is of type BODY and doesn't have a valid value"`,
   )
 })
+
+test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
+  const {element, getEventSnapshot} = setup('<input />')
+  userEvent.type(element, 'Brea{arrowleft}k{arrowright}fast')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="Brekafast"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: B (66)
+    input[value=""] - keypress: B (66)
+    input[value="B"] - input
+      "{CURSOR}" -> "B{CURSOR}"
+    input[value="B"] - keyup: B (66)
+    input[value="B"] - keydown: r (114)
+    input[value="B"] - keypress: r (114)
+    input[value="Br"] - input
+      "B{CURSOR}" -> "Br{CURSOR}"
+    input[value="Br"] - keyup: r (114)
+    input[value="Br"] - keydown: e (101)
+    input[value="Br"] - keypress: e (101)
+    input[value="Bre"] - input
+      "Br{CURSOR}" -> "Bre{CURSOR}"
+    input[value="Bre"] - keyup: e (101)
+    input[value="Bre"] - keydown: a (97)
+    input[value="Bre"] - keypress: a (97)
+    input[value="Brea"] - input
+      "Bre{CURSOR}" -> "Brea{CURSOR}"
+    input[value="Brea"] - keyup: a (97)
+    input[value="Brea"] - keydown: ArrowLeft (37)
+    input[value="Brea"] - select
+    input[value="Brea"] - keyup: ArrowLeft (37)
+    input[value="Brea"] - keydown: k (107)
+    input[value="Brea"] - keypress: k (107)
+    input[value="Breka"] - input
+      "Bre{CURSOR}a" -> "Breka{CURSOR}"
+    input[value="Breka"] - select
+    input[value="Breka"] - keyup: k (107)
+    input[value="Breka"] - keydown: ArrowRight (39)
+    input[value="Breka"] - select
+    input[value="Breka"] - keyup: ArrowRight (39)
+    input[value="Breka"] - keydown: f (102)
+    input[value="Breka"] - keypress: f (102)
+    input[value="Brekaf"] - input
+      "Breka{CURSOR}" -> "Brekaf{CURSOR}"
+    input[value="Brekaf"] - keyup: f (102)
+    input[value="Brekaf"] - keydown: a (97)
+    input[value="Brekaf"] - keypress: a (97)
+    input[value="Brekafa"] - input
+      "Brekaf{CURSOR}" -> "Brekafa{CURSOR}"
+    input[value="Brekafa"] - keyup: a (97)
+    input[value="Brekafa"] - keydown: s (115)
+    input[value="Brekafa"] - keypress: s (115)
+    input[value="Brekafas"] - input
+      "Brekafa{CURSOR}" -> "Brekafas{CURSOR}"
+    input[value="Brekafas"] - keyup: s (115)
+    input[value="Brekafas"] - keydown: t (116)
+    input[value="Brekafas"] - keypress: t (116)
+    input[value="Brekafast"] - input
+      "Brekafas{CURSOR}" -> "Brekafast{CURSOR}"
+    input[value="Brekafast"] - keyup: t (116)
+  `)
+})

--- a/src/keys/navigation-key.js
+++ b/src/keys/navigation-key.js
@@ -1,0 +1,58 @@
+import {fireEvent} from '@testing-library/dom'
+
+import {setSelectionRangeIfNecessary} from '../utils'
+
+const keys = {
+  ArrowLeft: {
+    keyCode: 37,
+  },
+  ArrowRight: {
+    keyCode: 39,
+  },
+}
+
+function getSelectionRange(currentElement, key) {
+  switch (key) {
+    case 'ArrowLeft':
+      return {
+        selectionStart: currentElement().selectionStart - 1,
+        selectionEnd: currentElement().selectionEnd - 1,
+      }
+    case 'ArrowRight':
+      return {
+        selectionStart: currentElement().selectionStart + 1,
+        selectionEnd: currentElement().selectionEnd + 1,
+      }
+    default:
+      return {}
+  }
+}
+
+function navigationKey(currentElement, key) {
+  const event = {
+    key,
+    keyCode: keys[key].keyCode,
+    which: keys[key].keyCode,
+  }
+
+  return ({eventOverrides}) => {
+    fireEvent.keyDown(currentElement(), {
+      ...event,
+      ...eventOverrides,
+    })
+
+    const range = getSelectionRange(currentElement, key)
+    setSelectionRangeIfNecessary(
+      currentElement(),
+      range.selectionStart,
+      range.selectionEnd,
+    )
+
+    fireEvent.keyUp(currentElement(), {
+      ...event,
+      ...eventOverrides,
+    })
+  }
+}
+
+export {navigationKey}

--- a/src/type.js
+++ b/src/type.js
@@ -10,6 +10,7 @@ import {
   setSelectionRangeIfNecessary,
 } from './utils'
 import {click} from './click'
+import {navigationKey} from './keys/navigation-key'
 
 function wait(time) {
   return new Promise(resolve => setTimeout(() => resolve(), time))
@@ -365,6 +366,8 @@ function getEventCallbackMap({
       keyCode: 93,
       modifierProperty: 'metaKey',
     }),
+    '{arrowleft}': navigationKey(currentElement, 'ArrowLeft'),
+    '{arrowright}': navigationKey(currentElement, 'ArrowRight'),
     '{enter}': ({eventOverrides}) => {
       const key = 'Enter'
       const keyCode = 13


### PR DESCRIPTION
Note: WIP! I am running into a few problems and would like advice.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Implements [navigation keys](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Navigation_keys) support in `type` method:

- Arrows
- Home and end
- Page up and down

**Why**:

It is reasonable for a user to use keyboard navigation while interacting with an interactive element. An interactive element could be an input (where a user would type into) or an accessible UI with keyboard support (no typing but it handles key events).

**How**:

- Handles new key events while typing: e.g. `Brek{arrowleft}a{arrowright}fast` -> `Breakfast`
- Handles new key events with modifier while typing: e.g. `Breakfast{shift}{arrowleft}{/shift}` -> `Breakfas{selection}t{/selection}`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->


