### PR TITLE
Feature: Implement cursor navigation with navigation keys

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1025,9 +1025,9 @@ test('should not type inside a contenteditable=false div', () => {
 
 test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
   const {element, getEventSnapshot} = setup('<input />')
-  userEvent.type(element, 'Brea{arrowleft}k{arrowright}fast')
+  userEvent.type(element, 'b{arrowleft}a{arrowright}c')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: input[value="Brekafast"]
+    Events fired on: input[value="abc"]
 
     input[value=""] - pointerover
     input[value=""] - pointerenter
@@ -1042,57 +1042,27 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
     input[value=""] - pointerup
     input[value=""] - mouseup: Left (0)
     input[value=""] - click: Left (0)
-    input[value=""] - keydown: B (66)
-    input[value=""] - keypress: B (66)
-    input[value="B"] - input
-      "{CURSOR}" -> "B{CURSOR}"
-    input[value="B"] - keyup: B (66)
-    input[value="B"] - keydown: r (114)
-    input[value="B"] - keypress: r (114)
-    input[value="Br"] - input
-      "B{CURSOR}" -> "Br{CURSOR}"
-    input[value="Br"] - keyup: r (114)
-    input[value="Br"] - keydown: e (101)
-    input[value="Br"] - keypress: e (101)
-    input[value="Bre"] - input
-      "Br{CURSOR}" -> "Bre{CURSOR}"
-    input[value="Bre"] - keyup: e (101)
-    input[value="Bre"] - keydown: a (97)
-    input[value="Bre"] - keypress: a (97)
-    input[value="Brea"] - input
-      "Bre{CURSOR}" -> "Brea{CURSOR}"
-    input[value="Brea"] - keyup: a (97)
-    input[value="Brea"] - keydown: ArrowLeft (37)
-    input[value="Brea"] - select
-    input[value="Brea"] - keyup: ArrowLeft (37)
-    input[value="Brea"] - keydown: k (107)
-    input[value="Brea"] - keypress: k (107)
-    input[value="Breka"] - input
-      "Bre{CURSOR}a" -> "Breka{CURSOR}"
-    input[value="Breka"] - select
-    input[value="Breka"] - keyup: k (107)
-    input[value="Breka"] - keydown: ArrowRight (39)
-    input[value="Breka"] - select
-    input[value="Breka"] - keyup: ArrowRight (39)
-    input[value="Breka"] - keydown: f (102)
-    input[value="Breka"] - keypress: f (102)
-    input[value="Brekaf"] - input
-      "Breka{CURSOR}" -> "Brekaf{CURSOR}"
-    input[value="Brekaf"] - keyup: f (102)
-    input[value="Brekaf"] - keydown: a (97)
-    input[value="Brekaf"] - keypress: a (97)
-    input[value="Brekafa"] - input
-      "Brekaf{CURSOR}" -> "Brekafa{CURSOR}"
-    input[value="Brekafa"] - keyup: a (97)
-    input[value="Brekafa"] - keydown: s (115)
-    input[value="Brekafa"] - keypress: s (115)
-    input[value="Brekafas"] - input
-      "Brekafa{CURSOR}" -> "Brekafas{CURSOR}"
-    input[value="Brekafas"] - keyup: s (115)
-    input[value="Brekafas"] - keydown: t (116)
-    input[value="Brekafas"] - keypress: t (116)
-    input[value="Brekafast"] - input
-      "Brekafas{CURSOR}" -> "Brekafast{CURSOR}"
-    input[value="Brekafast"] - keyup: t (116)
+    input[value=""] - keydown: b (98)
+    input[value=""] - keypress: b (98)
+    input[value="b"] - input
+      "{CURSOR}" -> "b{CURSOR}"
+    input[value="b"] - keyup: b (98)
+    input[value="b"] - keydown: ArrowLeft (37)
+    input[value="b"] - select
+    input[value="b"] - keyup: ArrowLeft (37)
+    input[value="b"] - keydown: a (97)
+    input[value="b"] - keypress: a (97)
+    input[value="ab"] - input
+      "{CURSOR}b" -> "ab{CURSOR}"
+    input[value="ab"] - select
+    input[value="ab"] - keyup: a (97)
+    input[value="ab"] - keydown: ArrowRight (39)
+    input[value="ab"] - select
+    input[value="ab"] - keyup: ArrowRight (39)
+    input[value="ab"] - keydown: c (99)
+    input[value="ab"] - keypress: c (99)
+    input[value="abc"] - input
+      "ab{CURSOR}" -> "abc{CURSOR}"
+    input[value="abc"] - keyup: c (99)
   `)
 })

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1022,3 +1022,77 @@ test('should not type inside a contenteditable=false div', () => {
     div - click: Left (0)
   `)
 })
+
+test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
+  const {element, getEventSnapshot} = setup('<input />')
+  userEvent.type(element, 'Brea{arrowleft}k{arrowright}fast')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="Brekafast"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: B (66)
+    input[value=""] - keypress: B (66)
+    input[value="B"] - input
+      "{CURSOR}" -> "B{CURSOR}"
+    input[value="B"] - keyup: B (66)
+    input[value="B"] - keydown: r (114)
+    input[value="B"] - keypress: r (114)
+    input[value="Br"] - input
+      "B{CURSOR}" -> "Br{CURSOR}"
+    input[value="Br"] - keyup: r (114)
+    input[value="Br"] - keydown: e (101)
+    input[value="Br"] - keypress: e (101)
+    input[value="Bre"] - input
+      "Br{CURSOR}" -> "Bre{CURSOR}"
+    input[value="Bre"] - keyup: e (101)
+    input[value="Bre"] - keydown: a (97)
+    input[value="Bre"] - keypress: a (97)
+    input[value="Brea"] - input
+      "Bre{CURSOR}" -> "Brea{CURSOR}"
+    input[value="Brea"] - keyup: a (97)
+    input[value="Brea"] - keydown: ArrowLeft (37)
+    input[value="Brea"] - select
+    input[value="Brea"] - keyup: ArrowLeft (37)
+    input[value="Brea"] - keydown: k (107)
+    input[value="Brea"] - keypress: k (107)
+    input[value="Breka"] - input
+      "Bre{CURSOR}a" -> "Breka{CURSOR}"
+    input[value="Breka"] - select
+    input[value="Breka"] - keyup: k (107)
+    input[value="Breka"] - keydown: ArrowRight (39)
+    input[value="Breka"] - select
+    input[value="Breka"] - keyup: ArrowRight (39)
+    input[value="Breka"] - keydown: f (102)
+    input[value="Breka"] - keypress: f (102)
+    input[value="Brekaf"] - input
+      "Breka{CURSOR}" -> "Brekaf{CURSOR}"
+    input[value="Brekaf"] - keyup: f (102)
+    input[value="Brekaf"] - keydown: a (97)
+    input[value="Brekaf"] - keypress: a (97)
+    input[value="Brekafa"] - input
+      "Brekaf{CURSOR}" -> "Brekafa{CURSOR}"
+    input[value="Brekafa"] - keyup: a (97)
+    input[value="Brekafa"] - keydown: s (115)
+    input[value="Brekafa"] - keypress: s (115)
+    input[value="Brekafas"] - input
+      "Brekafa{CURSOR}" -> "Brekafas{CURSOR}"
+    input[value="Brekafas"] - keyup: s (115)
+    input[value="Brekafas"] - keydown: t (116)
+    input[value="Brekafas"] - keypress: t (116)
+    input[value="Brekafast"] - input
+      "Brekafas{CURSOR}" -> "Brekafast{CURSOR}"
+    input[value="Brekafast"] - keyup: t (116)
+  `)
+})

--- a/src/keys/navigation-key.js
+++ b/src/keys/navigation-key.js
@@ -1,0 +1,58 @@
+import {fireEvent} from '@testing-library/dom'
+
+import {setSelectionRangeIfNecessary} from '../utils'
+
+const keys = {
+  ArrowLeft: {
+    keyCode: 37,
+  },
+  ArrowRight: {
+    keyCode: 39,
+  },
+}
+
+function getSelectionRange(currentElement, key) {
+  switch (key) {
+    case 'ArrowLeft':
+      return {
+        selectionStart: currentElement().selectionStart - 1,
+        selectionEnd: currentElement().selectionEnd - 1,
+      }
+    case 'ArrowRight':
+      return {
+        selectionStart: currentElement().selectionStart + 1,
+        selectionEnd: currentElement().selectionEnd + 1,
+      }
+    default:
+      return {}
+  }
+}
+
+function navigationKey(key) {
+  const event = {
+    key,
+    keyCode: keys[key].keyCode,
+    which: keys[key].keyCode,
+  }
+
+  return ({currentElement, eventOverrides}) => {
+    fireEvent.keyDown(currentElement(), {
+      ...event,
+      ...eventOverrides,
+    })
+
+    const range = getSelectionRange(currentElement, key)
+    setSelectionRangeIfNecessary(
+      currentElement(),
+      range.selectionStart,
+      range.selectionEnd,
+    )
+
+    fireEvent.keyUp(currentElement(), {
+      ...event,
+      ...eventOverrides,
+    })
+  }
+}
+
+export {navigationKey}

--- a/src/keys/navigation-key.js
+++ b/src/keys/navigation-key.js
@@ -12,19 +12,11 @@ const keys = {
 }
 
 function getSelectionRange(currentElement, key) {
-  switch (key) {
-    case 'ArrowLeft':
-      return {
-        selectionStart: currentElement().selectionStart - 1,
-        selectionEnd: currentElement().selectionEnd - 1,
-      }
-    case 'ArrowRight':
-      return {
-        selectionStart: currentElement().selectionStart + 1,
-        selectionEnd: currentElement().selectionEnd + 1,
-      }
-    default:
-      return {}
+  const {selectionStart, selectionEnd} = currentElement()
+  const cursorChange = Number(key in keys) * (key === 'ArrowLeft' ? -1 : 1)
+  return {
+    selectionStart: selectionStart + cursorChange,
+    selectionEnd: selectionEnd + cursorChange,
   }
 }
 

--- a/src/type.js
+++ b/src/type.js
@@ -15,6 +15,7 @@ import {
   isContentEditable,
 } from './utils'
 import {click} from './click'
+import {navigationKey} from './keys/navigation-key'
 
 const modifierCallbackMap = {
   ...createModifierCallbackEntries({
@@ -44,6 +45,8 @@ const modifierCallbackMap = {
 }
 
 const specialCharCallbackMap = {
+  '{arrowleft}': navigationKey('ArrowLeft'),
+  '{arrowright}': navigationKey( 'ArrowRight'),
   '{enter}': handleEnter,
   '{esc}': handleEsc,
   '{del}': handleDel,

--- a/src/type.js
+++ b/src/type.js
@@ -46,7 +46,7 @@ const modifierCallbackMap = {
 
 const specialCharCallbackMap = {
   '{arrowleft}': navigationKey('ArrowLeft'),
-  '{arrowright}': navigationKey( 'ArrowRight'),
+  '{arrowright}': navigationKey('ArrowRight'),
   '{enter}': handleEnter,
   '{esc}': handleEsc,
   '{del}': handleDel,


### PR DESCRIPTION
Note: WIP! I am running into a few problems and would like advice.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Implements [navigation keys](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Navigation_keys) support in `type` method:

- Arrows
- Home and end
- Page up and down

**Why**:

It is reasonable for a user to use keyboard navigation while interacting with an interactive element. An interactive element could be an input (where a user would type into) or an accessible UI with keyboard support (no typing but it handles key events).

**How**:

- Handles new key events while typing: e.g. `Brek{arrowleft}a{arrowright}fast` -> `Breakfast`
- Handles new key events with modifier while typing: e.g. `Breakfast{shift}{arrowleft}{/shift}` -> `Breakfas{selection}t{/selection}`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Typings
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Closes: https://github.com/testing-library/user-event/issues/354