### PR TITLE
Fix 407 type on no value elements

### DIFF
--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -471,6 +471,34 @@ test('{space} on a button', () => {
   `)
 })
 
+test(`' ' on a button is the same as '{space}'`, () => {
+  const {element, getEventSnapshot} = setup('<button />')
+
+  userEvent.type(element, ' ')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: button
+
+    button - pointerover
+    button - pointerenter
+    button - mouseover: Left (0)
+    button - mouseenter: Left (0)
+    button - pointermove
+    button - mousemove: Left (0)
+    button - pointerdown
+    button - mousedown: Left (0)
+    button - focus
+    button - focusin
+    button - pointerup
+    button - mouseup: Left (0)
+    button - click: Left (0)
+    button - keydown: (32)
+    button - keypress: (32)
+    button - keyup: (32)
+    button - click: Left (0)
+  `)
+})
+
 test('{space} with preventDefault keydown on button', () => {
   const {element, getEventSnapshot} = setup('<button />', {
     eventHandlers: {
@@ -497,34 +525,6 @@ test('{space} with preventDefault keydown on button', () => {
     button - mouseup: Left (0)
     button - click: Left (0)
     button - keydown: (32)
-    button - keyup: (32)
-    button - click: Left (0)
-  `)
-})
-
-test(`' ' on a button`, () => {
-  const {element, getEventSnapshot} = setup('<button />')
-
-  userEvent.type(element, ' ')
-
-  expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: button
-
-    button - pointerover
-    button - pointerenter
-    button - mouseover: Left (0)
-    button - mouseenter: Left (0)
-    button - pointermove
-    button - mousemove: Left (0)
-    button - pointerdown
-    button - mousedown: Left (0)
-    button - focus
-    button - focusin
-    button - pointerup
-    button - mouseup: Left (0)
-    button - click: Left (0)
-    button - keydown: (32)
-    button - keypress: (32)
     button - keyup: (32)
     button - click: Left (0)
   `)
@@ -559,7 +559,7 @@ test('{space} on an input', () => {
   `)
 })
 
-test('{enter} on an input type="color"', () => {
+test('{enter} on an input type="color" fires same events as a button', () => {
   const {element, getEventSnapshot} = setup(
     `<input value="#ffffff" type="color" />`,
   )
@@ -589,7 +589,7 @@ test('{enter} on an input type="color"', () => {
   `)
 })
 
-test('{space} on an input type="color"', () => {
+test('{space} on an input type="color" fires same events as a button', () => {
   const {element, getEventSnapshot} = setup(
     `<input value="#ffffff" type="color" />`,
   )
@@ -619,7 +619,7 @@ test('{space} on an input type="color"', () => {
   `)
 })
 
-test('" " on an input type="color"', () => {
+test(`' ' on input type="color" is the same as '{space}'`, () => {
   const {element, getEventSnapshot} = setup(
     `<input value="#ffffff" type="color" />`,
   )

--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -559,6 +559,37 @@ test('{space} with preventDefault keydown on button', () => {
   `)
 })
 
+test('{space} with preventDefault keyup on button', () => {
+  const {element, getEventSnapshot} = setup('<button />', {
+    eventHandlers: {
+      keyUp: e => e.preventDefault(),
+    },
+  })
+
+  userEvent.type(element, '{space}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: button
+
+    button - pointerover
+    button - pointerenter
+    button - mouseover: Left (0)
+    button - mouseenter: Left (0)
+    button - pointermove
+    button - mousemove: Left (0)
+    button - pointerdown
+    button - mousedown: Left (0)
+    button - focus
+    button - focusin
+    button - pointerup
+    button - mouseup: Left (0)
+    button - click: Left (0)
+    button - keydown: (32)
+    button - keypress: (32)
+    button - keyup: (32)
+  `)
+})
+
 test('{space} on an input', () => {
   const {element, getEventSnapshot} = setup(`<input value="" />`)
 

--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -443,6 +443,36 @@ test('{enter} on a button', () => {
   `)
 })
 
+test('{enter} with preventDefault on a button', () => {
+  const {element, getEventSnapshot} = setup('<button />', {
+    eventHandlers: {
+      keyDown: e => e.preventDefault(),
+    },
+  })
+
+  userEvent.type(element, '{enter}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: button
+
+    button - pointerover
+    button - pointerenter
+    button - mouseover: Left (0)
+    button - mouseenter: Left (0)
+    button - pointermove
+    button - mousemove: Left (0)
+    button - pointerdown
+    button - mousedown: Left (0)
+    button - focus
+    button - focusin
+    button - pointerup
+    button - mouseup: Left (0)
+    button - click: Left (0)
+    button - keydown: Enter (13)
+    button - keyup: Enter (13)
+  `)
+})
+
 test('{space} on a button', () => {
   const {element, getEventSnapshot} = setup('<button />')
 
@@ -526,7 +556,6 @@ test('{space} with preventDefault keydown on button', () => {
     button - click: Left (0)
     button - keydown: (32)
     button - keyup: (32)
-    button - click: Left (0)
   `)
 })
 

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -707,13 +707,12 @@ test('typing an invalid input value', () => {
   expect(element.validity.badInput).toBe(false)
 })
 
-test('should give error if we are trying to call type on an invalid element', async () => {
-  const {element} = setup('<div  />')
-  await expect(() =>
-    userEvent.type(element, "I'm only a div :("),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"the current element is of type BODY and doesn't have a valid value"`,
-  )
+test('should not throw error if we are trying to call type on an element without a value', () => {
+  const {element} = setup('<div />')
+  expect.assertions(0)
+  return userEvent
+    .type(element, "I'm only a div :(")
+    .catch(e => expect(e).toBeUndefined())
 })
 
 test('typing on button should not alter its value', () => {
@@ -752,11 +751,8 @@ test('typing on input type submit should not alter its value', () => {
   expect(element).toHaveValue('foo')
 })
 
-test('typing on input type file should not trigger input event', () => {
-  const inputHandler = jest.fn()
-  const {element} = setup('<input type="file" />', {
-    eventHandlers: {input: inputHandler},
-  })
-  userEvent.type(element, 'bar')
-  expect(inputHandler).toHaveBeenCalledTimes(0)
+test('typing on input type file should not result in an error', () => {
+  const {element} = setup('<input type="file" />')
+  expect.assertions(0)
+  return userEvent.type(element, 'bar').catch(e => expect(e).toBeUndefined())
 })

--- a/src/paste.js
+++ b/src/paste.js
@@ -38,11 +38,7 @@ function paste(
   fireEvent.paste(element, init)
 
   if (!element.readOnly) {
-    const {newValue, newSelectionStart} = calculateNewValue(
-      text,
-      element,
-      element.value,
-    )
+    const {newValue, newSelectionStart} = calculateNewValue(text, element)
     fireEvent.input(element, {
       inputType: 'insertFromPaste',
       target: {value: newValue},

--- a/src/type.js
+++ b/src/type.js
@@ -466,12 +466,11 @@ function handleEnter({currentElement, eventOverrides}) {
       charCode: keyCode,
       ...eventOverrides,
     })
-  }
-
-  if (isClickable(currentElement())) {
-    fireEvent.click(currentElement(), {
-      ...eventOverrides,
-    })
+    if (isClickable(currentElement())) {
+      fireEvent.click(currentElement(), {
+        ...eventOverrides,
+      })
+    }
   }
 
   if (currentElement().tagName === 'TEXTAREA') {
@@ -621,9 +620,11 @@ function handleSpaceOnClickable({currentElement, eventOverrides}) {
     ...eventOverrides,
   })
 
-  fireEvent.click(currentElement(), {
-    ...eventOverrides,
-  })
+  if (keyDownDefaultNotPrevented) {
+    fireEvent.click(currentElement(), {
+      ...eventOverrides,
+    })
+  }
 }
 
 export {type}

--- a/src/type.js
+++ b/src/type.js
@@ -613,14 +613,14 @@ function handleSpaceOnClickable({currentElement, eventOverrides}) {
     })
   }
 
-  fireEvent.keyUp(currentElement(), {
+  const keyUpDefaultNotPrevented = fireEvent.keyUp(currentElement(), {
     key,
     keyCode,
     which: keyCode,
     ...eventOverrides,
   })
 
-  if (keyDownDefaultNotPrevented) {
+  if (keyDownDefaultNotPrevented && keyUpDefaultNotPrevented) {
     fireEvent.click(currentElement(), {
       ...eventOverrides,
     })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes #407 

**Why**:

Because typing on focusable elements should be possible without getting an error.

**How**:

Checked if an element has a value prop before handling input and selection on it.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (not needed)
- [x] Tests
- [x] Typings (not needed)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
