### PR TITLE
feat: support contenteditable div

### DIFF
--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -1,5 +1,5 @@
 import {eventMap} from '@testing-library/dom/dist/event-map'
-
+import {isContentEditable} from '../../utils'
 // this is pretty helpful:
 // https://codesandbox.io/s/quizzical-worker-eo909
 
@@ -94,7 +94,10 @@ function getElementValue(element) {
   ) {
     // handled separately
     return null
+  } else if (isContentEditable(element)) {
+    return JSON.stringify(element.textContent)
   }
+
   return JSON.stringify(element.value)
 }
 

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -1,5 +1,4 @@
 import {eventMap} from '@testing-library/dom/dist/event-map'
-import {isContentEditable} from '../../utils'
 // this is pretty helpful:
 // https://codesandbox.io/s/quizzical-worker-eo909
 
@@ -94,8 +93,6 @@ function getElementValue(element) {
   ) {
     // handled separately
     return null
-  } else if (isContentEditable(element)) {
-    return JSON.stringify(element.textContent)
   }
 
   return JSON.stringify(element.value)

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -870,7 +870,7 @@ test('should submit a form when ENTER is pressed on input', () => {
   expect(handleSubmit).toHaveBeenCalledTimes(1)
 })
 
-test('should type inside a contenteditable div ', () => {
+test('should type inside a contenteditable div', () => {
   const {element, getEventSnapshot} = setup('<div contenteditable=true></div>')
 
   userEvent.type(element, 'bar')

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -876,33 +876,33 @@ test('should type inside a contenteditable div ', () => {
   userEvent.type(element, 'bar')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: div[value="bar"]
+    Events fired on: div
 
-    div[value=""] - pointerover
-    div[value=""] - pointerenter
-    div[value=""] - mouseover: Left (0)
-    div[value=""] - mouseenter: Left (0)
-    div[value=""] - pointermove
-    div[value=""] - mousemove: Left (0)
-    div[value=""] - pointerdown
-    div[value=""] - mousedown: Left (0)
-    div[value=""] - focus
-    div[value=""] - focusin
-    div[value=""] - pointerup
-    div[value=""] - mouseup: Left (0)
-    div[value=""] - click: Left (0)
-    div[value=""] - keydown: b (98)
-    div[value=""] - keypress: b (98)
-    div[value="b"] - input
-    div[value="b"] - keyup: b (98)
-    div[value="b"] - keydown: a (97)
-    div[value="b"] - keypress: a (97)
-    div[value="ba"] - input
-    div[value="ba"] - keyup: a (97)
-    div[value="ba"] - keydown: r (114)
-    div[value="ba"] - keypress: r (114)
-    div[value="bar"] - input
-    div[value="bar"] - keyup: r (114)
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - focus
+    div - focusin
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+    div - keydown: b (98)
+    div - keypress: b (98)
+    div - input
+    div - keyup: b (98)
+    div - keydown: a (97)
+    div - keypress: a (97)
+    div - input
+    div - keyup: a (97)
+    div - keydown: r (114)
+    div - keypress: r (114)
+    div - input
+    div - keyup: r (114)
   `)
   expect(element).toHaveTextContent('bar')
 })

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -869,3 +869,40 @@ test('should submit a form when ENTER is pressed on input', () => {
 
   expect(handleSubmit).toHaveBeenCalledTimes(1)
 })
+
+test('should type inside a contenteditable div ', () => {
+  const {element, getEventSnapshot} = setup('<div contenteditable=true></div>')
+
+  userEvent.type(element, 'bar')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div[value="bar"]
+
+    div[value=""] - pointerover
+    div[value=""] - pointerenter
+    div[value=""] - mouseover: Left (0)
+    div[value=""] - mouseenter: Left (0)
+    div[value=""] - pointermove
+    div[value=""] - mousemove: Left (0)
+    div[value=""] - pointerdown
+    div[value=""] - mousedown: Left (0)
+    div[value=""] - focus
+    div[value=""] - focusin
+    div[value=""] - pointerup
+    div[value=""] - mouseup: Left (0)
+    div[value=""] - click: Left (0)
+    div[value=""] - keydown: b (98)
+    div[value=""] - keypress: b (98)
+    div[value="b"] - input
+    div[value="b"] - keyup: b (98)
+    div[value="b"] - keydown: a (97)
+    div[value="b"] - keypress: a (97)
+    div[value="ba"] - input
+    div[value="ba"] - keyup: a (97)
+    div[value="ba"] - keydown: r (114)
+    div[value="ba"] - keypress: r (114)
+    div[value="bar"] - input
+    div[value="bar"] - keyup: r (114)
+  `)
+  expect(element).toHaveTextContent('bar')
+})

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -906,3 +906,25 @@ test('should type inside a contenteditable div ', () => {
   `)
   expect(element).toHaveTextContent('bar')
 })
+
+test('should not type inside a contenteditable=false div', () => {
+  const {element, getEventSnapshot} = setup('<div contenteditable=false></div>')
+
+  userEvent.type(element, 'bar')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerover
+    div - pointerenter
+    div - mouseover: Left (0)
+    div - mouseenter: Left (0)
+    div - pointermove
+    div - mousemove: Left (0)
+    div - pointerdown
+    div - mousedown: Left (0)
+    div - pointerup
+    div - mouseup: Left (0)
+    div - click: Left (0)
+  `)
+})

--- a/src/click.js
+++ b/src/click.js
@@ -2,6 +2,7 @@ import {fireEvent} from '@testing-library/dom'
 import {
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
+  isContentEditable,
 } from './utils'
 import {hover} from './hover'
 import {blur} from './blur'
@@ -63,7 +64,10 @@ function clickElement(element, init, {clickCount}) {
     const shouldFocus = element.ownerDocument.activeElement !== element
     if (continueDefaultHandling) {
       if (previousElement) blur(previousElement, init)
-      if (shouldFocus) focus(element, init)
+      if (shouldFocus) {
+        if (element.tagName !== 'DIV' || isContentEditable(element))
+          focus(element, init)
+      }
     }
   }
   fireEvent.pointerUp(element, init)

--- a/src/click.js
+++ b/src/click.js
@@ -2,7 +2,6 @@ import {fireEvent} from '@testing-library/dom'
 import {
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
-  isContentEditable,
 } from './utils'
 import {hover} from './hover'
 import {blur} from './blur'
@@ -64,10 +63,7 @@ function clickElement(element, init, {clickCount}) {
     const shouldFocus = element.ownerDocument.activeElement !== element
     if (continueDefaultHandling) {
       if (previousElement) blur(previousElement, init)
-      if (shouldFocus) {
-        if (element.tagName !== 'DIV' || isContentEditable(element))
-          focus(element, init)
-      }
+      if (shouldFocus) focus(element, init)
     }
   }
   fireEvent.pointerUp(element, init)

--- a/src/type.js
+++ b/src/type.js
@@ -10,6 +10,9 @@ import {
   setSelectionRangeIfNecessary,
   isClickable,
   isValidDateValue,
+  getSelectionRange,
+  getValue,
+  isContentEditable,
 } from './utils'
 import {click} from './click'
 
@@ -86,6 +89,14 @@ async function typeImpl(
 
   if (!skipClick) click(element)
 
+  if (isContentEditable(element)) {
+    if (document.getSelection().rangeCount === 0) {
+      const range = document.createRange()
+      range.setStart(element, 0)
+      range.setEnd(element, 0)
+      document.getSelection().addRange(range)
+    }
+  }
   // The focused element could change between each event, so get the currently active element each time
   const currentElement = () => getActiveElement(element.ownerDocument)
 
@@ -97,12 +108,11 @@ async function typeImpl(
   // the only time it would make sense to pass the initialSelectionStart or
   // initialSelectionEnd is if you have an input with a value and want to
   // explicitely start typing with the cursor at 0. Not super common.
-  const value = currentElement().value
-  if (
-    value != null &&
-    currentElement().selectionStart === 0 &&
-    currentElement().selectionEnd === 0
-  ) {
+  const value = getValue(currentElement())
+
+  const {selectionStart, selectionEnd} = getSelectionRange(element)
+
+  if (value != null && selectionStart === 0 && selectionEnd === 0) {
     setSelectionRangeIfNecessary(
       currentElement(),
       initialSelectionStart ?? value.length,
@@ -222,7 +232,7 @@ function setSelectionRange({currentElement, newValue, newSelectionStart}) {
   // The reason we have to do this at all is because it actually *is*
   // programmatically changed by fireEvent.input, so we have to simulate the
   // browser's default behavior
-  const value = currentElement().value
+  const value = getValue(currentElement())
 
   if (value === newValue) {
     setSelectionRangeIfNecessary(
@@ -244,16 +254,23 @@ function fireInputEventIfNeeded({
   newSelectionStart,
   eventOverrides,
 }) {
-  const prevValue = currentElement().value
+  const prevValue = getValue(currentElement())
   if (
     !currentElement().readOnly &&
     !isClickable(currentElement()) &&
     newValue !== prevValue
   ) {
-    fireEvent.input(currentElement(), {
-      target: {value: newValue},
-      ...eventOverrides,
-    })
+    if (isContentEditable(currentElement())) {
+      fireEvent.input(currentElement(), {
+        target: {textContent: newValue},
+        ...eventOverrides,
+      })
+    } else {
+      fireEvent.input(currentElement(), {
+        target: {value: newValue},
+        ...eventOverrides,
+      })
+    }
 
     setSelectionRange({
       currentElement,
@@ -280,7 +297,6 @@ function typeCharacter(
   const keyCode = char.charCodeAt(0)
   let nextPrevWasMinus, nextPrevWasPeriod
   const textToBeTyped = typedValue + char
-
   const keyDownDefaultNotPrevented = fireEvent.keyDown(currentElement(), {
     key,
     keyCode,
@@ -295,8 +311,7 @@ function typeCharacter(
       charCode: keyCode,
       ...eventOverrides,
     })
-
-    if (currentElement().value != null && keyPressDefaultNotPrevented) {
+    if (getValue(currentElement()) != null && keyPressDefaultNotPrevented) {
       let newEntry = char
       if (prevWasMinus) {
         newEntry = `-${char}`
@@ -330,7 +345,7 @@ function typeCharacter(
       // to typing an invalid character (typing "-a3" results in "-3")
       // same applies for the decimal character.
       if (currentElement().type === 'number') {
-        const newValue = currentElement().value
+        const newValue = getValue(currentElement())
         if (newValue === prevValue && newEntry !== '-') {
           nextPrevWasMinus = prevWasMinus
         } else {
@@ -365,7 +380,8 @@ function typeCharacter(
 // If you, brave soul, decide to so endevor, please increment this count
 // when you inevitably fail: 1
 function calculateNewBackspaceValue(element) {
-  const {selectionStart, selectionEnd, value} = element
+  const {selectionStart, selectionEnd} = getSelectionRange(element)
+  const value = getValue(element)
   let newValue, newSelectionStart
 
   if (selectionStart === null) {
@@ -398,7 +414,8 @@ function calculateNewBackspaceValue(element) {
 }
 
 function calculateNewDeleteValue(element) {
-  const {selectionStart, selectionEnd, value} = element
+  const {selectionStart, selectionEnd} = getSelectionRange(element)
+  const value = getValue(element)
   let newValue
 
   if (selectionStart === null) {
@@ -600,7 +617,14 @@ function handleBackspace({currentElement, eventOverrides}) {
 function handleSelectall({currentElement}) {
   // the user can actually select in several different ways
   // we're not going to choose, so we'll *only* set the selection range
-  currentElement().setSelectionRange(0, currentElement().value.length)
+  if (isContentEditable(currentElement())) {
+    const range = document.createRange()
+    range.selectNodeContents(currentElement())
+    document.getSelection().removeAllRanges()
+    document.getSelection().addRange(range)
+  } else {
+    currentElement().setSelectionRange(0, getValue(currentElement()).length)
+  }
 }
 
 function handleSpace(context) {

--- a/src/type.js
+++ b/src/type.js
@@ -615,16 +615,7 @@ function handleBackspace({currentElement, eventOverrides}) {
 }
 
 function handleSelectall({currentElement}) {
-  // the user can actually select in several different ways
-  // we're not going to choose, so we'll *only* set the selection range
-  if (isContentEditable(currentElement())) {
-    const range = document.createRange()
-    range.selectNodeContents(currentElement())
-    document.getSelection().removeAllRanges()
-    document.getSelection().addRange(range)
-  } else {
-    currentElement().setSelectionRange(0, getValue(currentElement()).length)
-  }
+  currentElement().setSelectionRange(0, getValue(currentElement()).length)
 }
 
 function handleSpace(context) {

--- a/src/type.js
+++ b/src/type.js
@@ -89,13 +89,11 @@ async function typeImpl(
 
   if (!skipClick) click(element)
 
-  if (isContentEditable(element)) {
-    if (document.getSelection().rangeCount === 0) {
-      const range = document.createRange()
-      range.setStart(element, 0)
-      range.setEnd(element, 0)
-      document.getSelection().addRange(range)
-    }
+  if (isContentEditable(element) && document.getSelection().rangeCount === 0) {
+    const range = document.createRange()
+    range.setStart(element, 0)
+    range.setEnd(element, 0)
+    document.getSelection().addRange(range)
   }
   // The focused element could change between each event, so get the currently active element each time
   const currentElement = () => getActiveElement(element.ownerDocument)

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,6 +223,8 @@ const FOCUSABLE_SELECTOR = [
   'button:not([disabled])',
   'select:not([disabled])',
   'textarea:not([disabled])',
+  'div[contenteditable=""]',
+  'div[contenteditable="true"]',
   'a[href]',
   '[tabindex]:not([disabled])',
 ].join(', ')
@@ -230,7 +232,7 @@ const FOCUSABLE_SELECTOR = [
 function isFocusable(element) {
   return (
     !isLabelWithInternallyDisabledControl(element) &&
-    (isContentEditable(element) || element?.matches(FOCUSABLE_SELECTOR))
+    element?.matches(FOCUSABLE_SELECTOR)
   )
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,8 @@ function getSelectionRange(element) {
 function isContentEditable(element) {
   return (
     element.hasAttribute('contenteditable') &&
-    element.getAttribute('contenteditable') == 'true'
+    (element.getAttribute('contenteditable') == 'true' ||
+      element.getAttribute('contenteditable') == '')
   )
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,8 +110,37 @@ function supportsMaxLength(element) {
   return false
 }
 
+function getSelectionRange(element) {
+  if (isContentEditable(element)) {
+    const range = document.getSelection().getRangeAt(0)
+
+    return {selectionStart: range.startOffset, selectionEnd: range.endOffset}
+  }
+
+  return {
+    selectionStart: element.selectionStart,
+    selectionEnd: element.selectionEnd,
+  }
+}
+
+//jsdom is not supporting isContentEditable
+function isContentEditable(element) {
+  return (
+    element.hasAttribute('contenteditable') &&
+    element.getAttribute('contenteditable') == 'true'
+  )
+}
+
+function getValue(element) {
+  if (isContentEditable(element)) {
+    return element.textContent
+  }
+  return element.value
+}
+
 function calculateNewValue(newEntry, element) {
-  const {selectionStart, selectionEnd, value} = element
+  const {selectionStart, selectionEnd} = getSelectionRange(element)
+  const value = getValue(element)
 
   // can't use .maxLength property because of a jsdom bug:
   // https://github.com/jsdom/jsdom/issues/2927
@@ -162,8 +191,12 @@ function setSelectionRangeIfNecessary(
   newSelectionStart,
   newSelectionEnd,
 ) {
-  const {selectionStart, selectionEnd} = element
-  if (!element.setSelectionRange || selectionStart === null) {
+  const {selectionStart, selectionEnd} = getSelectionRange(element)
+
+  if (
+    !isContentEditable(element) &&
+    (!element.setSelectionRange || selectionStart === null)
+  ) {
     // cannot set selection
     return
   }
@@ -171,7 +204,16 @@ function setSelectionRangeIfNecessary(
     selectionStart !== newSelectionStart ||
     selectionEnd !== newSelectionStart
   ) {
-    element.setSelectionRange(newSelectionStart, newSelectionEnd)
+    if (isContentEditable(element)) {
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      range.setStart(element.firstChild, newSelectionStart)
+      range.setEnd(element.firstChild, newSelectionEnd)
+      document.getSelection().removeAllRanges()
+      document.getSelection().addRange(range)
+    } else {
+      element.setSelectionRange(newSelectionStart, newSelectionEnd)
+    }
   }
 }
 
@@ -181,6 +223,8 @@ const FOCUSABLE_SELECTOR = [
   'select:not([disabled])',
   'textarea:not([disabled])',
   'a[href]',
+  'div[contenteditable]',
+  'div[contenteditable=true]',
   '[tabindex]:not([disabled])',
 ].join(', ')
 
@@ -235,4 +279,7 @@ export {
   setSelectionRangeIfNecessary,
   eventWrapper,
   isValidDateValue,
+  getValue,
+  getSelectionRange,
+  isContentEditable,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -224,15 +224,13 @@ const FOCUSABLE_SELECTOR = [
   'select:not([disabled])',
   'textarea:not([disabled])',
   'a[href]',
-  'div[contenteditable]',
-  'div[contenteditable=true]',
   '[tabindex]:not([disabled])',
 ].join(', ')
 
 function isFocusable(element) {
   return (
     !isLabelWithInternallyDisabledControl(element) &&
-    element?.matches(FOCUSABLE_SELECTOR)
+    (isContentEditable(element) || element?.matches(FOCUSABLE_SELECTOR))
   )
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,8 +223,8 @@ const FOCUSABLE_SELECTOR = [
   'button:not([disabled])',
   'select:not([disabled])',
   'textarea:not([disabled])',
-  'div[contenteditable=""]',
-  'div[contenteditable="true"]',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
   'a[href]',
   '[tabindex]:not([disabled])',
 ].join(', ')


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I have added support for content editable

<!-- Why are these changes necessary? -->

**Why**: Because user can't type into it 

<!-- How were these changes implemented? -->

**How**: Triggering the same events as textarea. Div does not have a value but a textContent
 
I didn't update `getEventSnapshot` because there is not selector for textContent
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
