### PR TITLE
docs: add type with selectionRange example

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ The following special character strings are supported:
 | `{enter}`     | Enter     | N/A        | Will insert a newline character (`<textarea />` only).                                                                                                              |
 | `{space}`     | `' '`     | N/A        |                                                                                                                                                                     |
 | `{esc}`       | Escape    | N/A        |                                                                                                                                                                     |
-| `{backspace}` | Backspace | N/A        | Will delete the previous character (or the characters within the `selectedRange`).                                                                                  |
-| `{del}`       | Delete    | N/A        | Will delete the next character (or the characters within the `selectedRange`)                                                                                       |
+| `{backspace}` | Backspace | N/A        | Will delete the previous character (or the characters within the `selectedRange`, see example below).                                                               |
+| `{del}`       | Delete    | N/A        | Will delete the next character (or the characters within the `selectedRange`, see example below)                                                                    |
 | `{selectall}` | N/A       | N/A        | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
 | `{shift}`     | Shift     | `shiftKey` | Does **not** capitalize following characters.                                                                                                                       |
 | `{ctrl}`      | Control   | `ctrlKey`  |                                                                                                                                                                     |
@@ -208,6 +208,28 @@ The following special character strings are supported:
 > in that we do not simulate the behavior that happens with modifier key
 > combinations as different operating systems function differently in this
 > regard.
+
+An example of an usage with a selection range:
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('delete characters within the selectedRange', () => {
+  render(
+    <div>
+      <label htmlFor="my-input">Example:</label>
+      <input id="my-input" type="text" value="This is an example" />
+    </div>,
+  )
+  const input = screen.getByLabelText(/example/i)
+  input.setSelectionRange(11, 16)
+  userEvent.type(input, '{backspace}')
+
+  expect(input).toHaveValue('This is an le')
+})
+```
 
 ### `upload(element, file, [{ clickInit, changeInit }])`
 
@@ -560,6 +582,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -220,14 +220,14 @@ test('delete characters within the selectedRange', () => {
   render(
     <div>
       <label htmlFor="my-input">Example:</label>
-      <input id="my-input" type="text" value="This is an example" />
+      <input id="my-input" type="text" value="This is a bad example" />
     </div>,
   )
   const input = screen.getByLabelText(/example/i)
-  input.setSelectionRange(11, 16)
-  userEvent.type(input, '{backspace}')
+  input.setSelectionRange(10, 13)
+  userEvent.type(input, '{backspace}good')
 
-  expect(input).toHaveValue('This is an le')
+  expect(input).toHaveValue('This is a good example')
 })
 ```
 


### PR DESCRIPTION
**What**:
 
It closes #413 

**Why**:

**How**:

Added a custom example to show how the user can use the `type` method with a selectedRange.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [ ] Tests N/A
- [ ] Typings N/A
- [X] Ready to be merged
