### PR TITLE
fix(type): ignore maxlength based on input type

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -322,6 +322,45 @@ test('honors maxlength with existing text', () => {
   `)
 })
 
+test('honors maxlength on textarea', () => {
+  const {element, getEventSnapshot} = setup(
+    '<textarea maxlength="2">12</textarea>',
+  )
+
+  userEvent.type(element, '3')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: textarea[value="12"]
+
+    textarea[value="12"] - pointerover
+    textarea[value="12"] - pointerenter
+    textarea[value="12"] - mouseover: Left (0)
+    textarea[value="12"] - mouseenter: Left (0)
+    textarea[value="12"] - pointermove
+    textarea[value="12"] - mousemove: Left (0)
+    textarea[value="12"] - pointerdown
+    textarea[value="12"] - mousedown: Left (0)
+    textarea[value="12"] - focus
+    textarea[value="12"] - focusin
+    textarea[value="12"] - pointerup
+    textarea[value="12"] - mouseup: Left (0)
+    textarea[value="12"] - click: Left (0)
+    textarea[value="12"] - select
+    textarea[value="12"] - keydown: 3 (51)
+    textarea[value="12"] - keypress: 3 (51)
+    textarea[value="12"] - keyup: 3 (51)
+  `)
+})
+
+// https://github.com/testing-library/user-event/issues/418
+test('ignores maxlength on input[type=number]', () => {
+  const {element} = setup(`<input maxlength="2" type="number" value="12" />`)
+
+  userEvent.type(element, '3')
+
+  expect(element).toHaveValue(123)
+})
+
 test('should fire events on the currently focused element', () => {
   const {element} = setup(`<div><input /><input /></div>`, {
     eventHandlers: {keyDown: handleKeyDown},

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,22 @@ function getActiveElement(document) {
   }
 }
 
+function supportsMaxLength(element) {
+  if (element.tagName === 'TEXTAREA') return true
+
+  if (element.tagName === 'INPUT') {
+    const type = element.getAttribute('type')
+
+    // Missing value default is "text"
+    if (!type) return true
+
+    // https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
+    if (type.match(/email|password|search|telephone|text|url/)) return true
+  }
+
+  return false
+}
+
 function calculateNewValue(newEntry, element) {
   const {selectionStart, selectionEnd, value} = element
 
@@ -126,7 +142,7 @@ function calculateNewValue(newEntry, element) {
     newSelectionStart = firstPart.length
   }
 
-  if (maxLength < 0) {
+  if (!supportsMaxLength(element) || maxLength < 0) {
     return {newValue, newSelectionStart}
   } else {
     return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
Ignore the `maxlength` attribute on `input` elements if the provided `type` is not meant to support it.

**Why**:

<!-- How were these changes implemented? -->
Closes #418 

**How**:

<!-- Have you done all of these things?  -->
Before calculating the new value for the control, confirm that the element is an `input` whose type is one that supports the maxlength attribute, or that the element is a `textarea`. Add a test for the `textarea` case and `input[type=number]`, addressing the original bug report.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~Documentation~ N/A? (Happy to update any relevant docs!)
- [x] Tests
- [ ] ~Typings~ N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->