### PR TITLE
feat: 🎸 add ignoreActiveElement option to type

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,16 @@ are typed. By default it's 0. You can use this option if your component has a
 different behavior for fast or slow users. If you do this, you need to make sure
 to `await`!
 
-> To be clear, `userEvent.type` *always* returns a promise, but you *only* need
-> to `await` the promise it returns if you're using the `delay` option. Otherwise
-> everything runs synchronously and you can ignore the promise.
+> To be clear, `userEvent.type` _always_ returns a promise, but you _only_ need
+> to `await` the promise it returns if you're using the `delay` option.
+> Otherwise everything runs synchronously and you can ignore the promise.
 
 `type` will click the element before typing. To disable this, set the
 `skipClick` option to `true`.
+
+`type` will type into the document's active element. To change this behavior and
+type into the `element` regardless of the active element you can set the
+`ignoreActiveElement` option to `true`.
 
 #### Special characters
 
@@ -588,6 +592,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -384,6 +384,25 @@ test('should fire events on the currently focused element', () => {
   expect(input2).toHaveFocus()
 })
 
+test('honors ignoreActiveElement option', () => {
+  const {element} = setup(`<div><input /><input /></div>`, {
+    eventHandlers: {keyDown: handleKeyDown},
+  })
+
+  const input1 = element.children[0]
+  const input2 = element.children[1]
+
+  const text = 'Hello, world!'
+  function handleKeyDown() {
+    input2.focus()
+  }
+
+  userEvent.type(input1, text, {ignoreActiveElement: true})
+
+  expect(input1).toHaveValue('Hello, world!')
+  expect(input2).not.toHaveValue()
+})
+
 test('should replace selected text', () => {
   const {element} = setup('<input value="hello world" />')
   const selectionStart = 'hello world'.search('world')

--- a/src/type.js
+++ b/src/type.js
@@ -83,6 +83,7 @@ async function typeImpl(
     skipAutoClose = false,
     initialSelectionStart,
     initialSelectionEnd,
+    ignoreActiveElement,
   },
 ) {
   if (element.disabled) return
@@ -96,7 +97,10 @@ async function typeImpl(
     document.getSelection().addRange(range)
   }
   // The focused element could change between each event, so get the currently active element each time
-  const currentElement = () => getActiveElement(element.ownerDocument)
+  const currentElement = () =>
+    ignoreActiveElement === true
+      ? element
+      : getActiveElement(element.ownerDocument)
 
   // by default, a new element has it's selection start and end at 0
   // but most of the time when people call "type", they expect it to type

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,6 +5,7 @@ export interface ITypeOpts {
   delay?: number
   initialSelectionStart?: number
   initialSelectionEnd?: number
+  ignoreActiveElement?: boolean
 }
 
 export interface ITabUserOptions {


### PR DESCRIPTION
**What**:

* Adds a `ignoreActiveElement` option to `type`. Causing `type` to type into the `element` passed in instead of the current active element.

**Why**:

* I'm using the library in a browser extension to complete forms on the behalf of users. In my case there is a dialog displaying to users which is always the active element.

**How**:

* in `typeImpl` added the option which if set true will cause `currentElement()` to always return the `element` passed

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Typings  (I'm not strong on typescript if someone could check that change)
- [x] Ready to be merged

Thanks for all the work on this library!