### PR TITLE
fix: improve submit form on ENTER pressed 

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -853,10 +853,9 @@ test('typing on input type file should not result in an error', () => {
   return userEvent.type(element, 'bar').catch(e => expect(e).toBeUndefined())
 })
 
-test('should submit a form with only one input when ENTER is pressed on it', () => {
+test('should submit a form containing multiple text inputs and an input of type submit', () => {
   const handleSubmit = jest.fn()
-  let utils
-  utils = setup(
+  const {element} = setup(
     `
     <form>
       <input type='text'/>
@@ -868,11 +867,15 @@ test('should submit a form with only one input when ENTER is pressed on it', () 
       eventHandlers: {submit: handleSubmit},
     },
   )
-  userEvent.type(utils.element.querySelector('input'), '{enter}')
+  userEvent.type(element.querySelector('input'), '{enter}')
 
   expect(handleSubmit).toHaveBeenCalledTimes(1)
+})
 
-  utils = setup(
+test('should submit a form containing multiple text inputs and a submit button', () => {
+  const handleSubmit = jest.fn()
+
+  const {element} = setup(
     `
     <form>
       <input type='text'/>
@@ -884,11 +887,15 @@ test('should submit a form with only one input when ENTER is pressed on it', () 
       eventHandlers: {submit: handleSubmit},
     },
   )
-  userEvent.type(utils.element.querySelector('input'), '{enter}')
+  userEvent.type(element.querySelector('input'), '{enter}')
 
-  expect(handleSubmit).toHaveBeenCalledTimes(2)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+})
 
-  utils = setup(
+test('should submit a form with one input element', () => {
+  const handleSubmit = jest.fn()
+
+  const {element} = setup(
     `
     <form>
       <input type='text'/>
@@ -898,9 +905,9 @@ test('should submit a form with only one input when ENTER is pressed on it', () 
       eventHandlers: {submit: handleSubmit},
     },
   )
-  userEvent.type(utils.element.querySelector('input'), '{enter}')
+  userEvent.type(element.querySelector('input'), '{enter}')
 
-  expect(handleSubmit).toHaveBeenCalledTimes(3)
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
 })
 
 test('should not submit a form with multiple input when ENTER is pressed on one of it', () => {

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -853,9 +853,42 @@ test('typing on input type file should not result in an error', () => {
   return userEvent.type(element, 'bar').catch(e => expect(e).toBeUndefined())
 })
 
-test('should submit a form when ENTER is pressed on input', () => {
+test('should submit a form with only one input when ENTER is pressed on it', () => {
   const handleSubmit = jest.fn()
-  const {element} = setup(
+  let utils
+  utils = setup(
+    `
+    <form>
+      <input type='text'/>
+      <input type='text'/>
+      <input type='submit' value="submit" />
+    </form>
+  `,
+    {
+      eventHandlers: {submit: handleSubmit},
+    },
+  )
+  userEvent.type(utils.element.querySelector('input'), '{enter}')
+
+  expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+  utils = setup(
+    `
+    <form>
+      <input type='text'/>
+      <input type='text'/>
+      <button type='submit' value="submit" />
+    </form>
+  `,
+    {
+      eventHandlers: {submit: handleSubmit},
+    },
+  )
+  userEvent.type(utils.element.querySelector('input'), '{enter}')
+
+  expect(handleSubmit).toHaveBeenCalledTimes(2)
+
+  utils = setup(
     `
     <form>
       <input type='text'/>
@@ -865,9 +898,27 @@ test('should submit a form when ENTER is pressed on input', () => {
       eventHandlers: {submit: handleSubmit},
     },
   )
+  userEvent.type(utils.element.querySelector('input'), '{enter}')
+
+  expect(handleSubmit).toHaveBeenCalledTimes(3)
+})
+
+test('should not submit a form with multiple input when ENTER is pressed on one of it', () => {
+  const handleSubmit = jest.fn()
+  const {element} = setup(
+    `
+    <form>
+      <input type='text'/>
+      <input type='text'/>
+    </form>
+  `,
+    {
+      eventHandlers: {submit: handleSubmit},
+    },
+  )
   userEvent.type(element.querySelector('input'), '{enter}')
 
-  expect(handleSubmit).toHaveBeenCalledTimes(1)
+  expect(handleSubmit).toHaveBeenCalledTimes(0)
 })
 
 test('should type inside a contenteditable div', () => {

--- a/src/type.js
+++ b/src/type.js
@@ -519,7 +519,13 @@ function handleEnter({currentElement, eventOverrides}) {
     })
   }
 
-  if (currentElement().tagName === 'INPUT' && currentElement().form) {
+  if (
+    currentElement().tagName === 'INPUT' &&
+    currentElement().form &&
+    (currentElement().form.querySelectorAll('input').length === 1 ||
+      currentElement().form.querySelector('input[type="submit"]') ||
+      currentElement().form.querySelector('button[type="submit"]'))
+  ) {
     fireEvent.submit(currentElement().form)
   }
 


### PR DESCRIPTION
Follow up #397 


**What**: improve what I have done in the previous PR

<!-- Why are these changes necessary? -->

**Why**: As suggested by @Jessidhia something was wrong with the current implementation.
A form should be submitted pressing enter in an input only when:
1) A `form` is present
2) The form contains only one input or multiple inputs and a submit button (`input[type="submit"]` or `button[type="submit"]`)


<!-- How were these changes implemented? -->

**How**: Updating the current implementation in the modifier

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
