### PR TITLE
Fix FocusEvents #431

### DIFF
--- a/src/__tests__/click.js
+++ b/src/__tests__/click.js
@@ -419,3 +419,22 @@ test('fires mouse events with custom buttons property', () => {
     click - button=1; buttons=4; detail=1
   `)
 })
+
+test('calls FocusEvents with relatedTarget', () => {
+  const {element} = setup('<div><input/><input/></div>')
+
+  const element0 = element.children[0]
+  const element1 = element.children[1]
+  element0.focus()
+  const events0 = addListeners(element0)
+  const events1 = addListeners(element1)
+
+  userEvent.click(element1)
+
+  expect(events0.getEvents().find(e => e.type === 'blur').relatedTarget).toBe(
+    element1,
+  )
+  expect(events1.getEvents().find(e => e.type === 'focus').relatedTarget).toBe(
+    element0,
+  )
+})

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -434,3 +434,22 @@ test('should respect radio groups', () => {
 
   expect(firstRight).toHaveFocus()
 })
+
+test('calls FocusEvents with relatedTarget', () => {
+  const {element} = setup('<div><input/><input/></div>')
+
+  const element0 = element.children[0]
+  const element1 = element.children[1]
+  element0.focus()
+  const events0 = addListeners(element0)
+  const events1 = addListeners(element1)
+
+  userEvent.tab()
+
+  expect(events0.getEvents().find(e => e.type === 'blur').relatedTarget).toBe(
+    element1,
+  )
+  expect(events1.getEvents().find(e => e.type === 'focus').relatedTarget).toBe(
+    element0,
+  )
+})

--- a/src/click.js
+++ b/src/click.js
@@ -2,6 +2,7 @@ import {fireEvent} from '@testing-library/dom'
 import {
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
+  isFocusable,
 } from './utils'
 import {hover} from './hover'
 import {blur} from './blur'
@@ -60,10 +61,15 @@ function clickElement(element, init, {clickCount}) {
       element,
       getMouseEventOptions('mousedown', init, clickCount),
     )
-    const shouldFocus = element.ownerDocument.activeElement !== element
-    if (continueDefaultHandling) {
-      if (previousElement) blur(previousElement, init)
-      if (shouldFocus) focus(element, init)
+    if (
+      continueDefaultHandling &&
+      element !== element.ownerDocument.activeElement
+    ) {
+      if (previousElement && !isFocusable(element)) {
+        blur(previousElement, init)
+      } else {
+        focus(element, init)
+      }
     }
   }
   fireEvent.pointerUp(element, init)

--- a/src/tab.js
+++ b/src/tab.js
@@ -94,16 +94,17 @@ function tab({shift = false, focusTrap} = {}) {
     // preventDefault on the shift key makes no difference
     if (shift) fireEvent.keyDown(previousElement, {...shiftKeyInit})
     continueToTab = fireEvent.keyDown(previousElement, {...tabKeyInit})
-    if (continueToTab) {
-      blur(previousElement)
-    }
   }
 
   const keyUpTarget =
     !continueToTab && previousElement ? previousElement : nextElement
 
   if (continueToTab) {
-    focus(nextElement)
+    if (nextElement === document.body) {
+      blur(previousElement)
+    } else {
+      focus(nextElement)
+    }
   }
 
   fireEvent.keyUp(keyUpTarget, {...tabKeyInit})


### PR DESCRIPTION
`click()` and `tab()` didn't trigger FocusEvents like the browser does.

Previous implementation called `blur()` on the active element thus removing focus from that element and decoupling the `blur` and `focus`.
Focus therefore moved `previousElement -> document -> nextElement` instead of `previousElement -> nextElement`

`element.focus()` already triggers `blur` and `focusout` events on the previously active element.
`blur()` only needs to be called when `element.focus()` is skipped.

**Checklist**:

- [x] Tests
- [x] Ready to be merged
