### PR TITLE
fix: isClickable now specifies element.ownerDocument.defaultView as container for HTMLInputElement

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,7 @@ function supportsMaxLength(element) {
 
 function getSelectionRange(element) {
   if (isContentEditable(element)) {
-    const range = document.getSelection().getRangeAt(0)
+    const range = element.ownerDocument.getSelection().getRangeAt(0)
 
     return {selectionStart: range.startOffset, selectionEnd: range.endOffset}
   }
@@ -206,12 +206,12 @@ function setSelectionRangeIfNecessary(
     selectionEnd !== newSelectionStart
   ) {
     if (isContentEditable(element)) {
-      const range = document.createRange()
+      const range = element.ownerDocument.createRange()
       range.selectNodeContents(element)
       range.setStart(element.firstChild, newSelectionStart)
       range.setEnd(element.firstChild, newSelectionEnd)
-      document.getSelection().removeAllRanges()
-      document.getSelection().addRange(range)
+      element.ownerDocument.getSelection().removeAllRanges()
+      element.ownerDocument.getSelection().addRange(range)
     } else {
       element.setSelectionRange(newSelectionStart, newSelectionEnd)
     }
@@ -248,7 +248,7 @@ const CLICKABLE_INPUT_TYPES = [
 function isClickable(element) {
   return (
     element.tagName === 'BUTTON' ||
-    (element instanceof HTMLInputElement &&
+    (element instanceof element.ownerDocument.defaultView.HTMLInputElement &&
       CLICKABLE_INPUT_TYPES.includes(element.type))
   )
 }


### PR DESCRIPTION
**What**:

- Fixes `instanceof` expression in `isClickable`
- Changed global `document` references in utils.js file to `element.ownerDocument`

**Why**:

There's a bug where userEvent.type fails due to a reference error.

**How**:

The changes were made as requested in this issue: https://github.com/testing-library/user-event/issues/434 by Kent.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

All the tests passed locally and the issue I was running into seem to resolve itself when I attempted to yarn link. I'm not a regular contributor and I have absolutely no idea what's going on here for the most part so feel free to ask me to make any necessary changes to the commit, pr, or issue.
