### PR TITLE
Skip certain events on {enter} when default behavior is prevented

### DIFF
--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -443,7 +443,7 @@ test('{enter} on a button', () => {
   `)
 })
 
-test('{enter} with preventDefault on a button', () => {
+test('{enter} on a button when keydown calls prevent default', () => {
   const {element, getEventSnapshot} = setup('<button />', {
     eventHandlers: {
       keyDown: e => e.preventDefault(),
@@ -469,6 +469,37 @@ test('{enter} with preventDefault on a button', () => {
     button - mouseup: Left (0)
     button - click: Left (0)
     button - keydown: Enter (13)
+    button - keyup: Enter (13)
+  `)
+})
+
+test('{enter} on a button when keypress calls prevent default', () => {
+  const {element, getEventSnapshot} = setup('<button />', {
+    eventHandlers: {
+      keyPress: e => e.preventDefault(),
+    },
+  })
+
+  userEvent.type(element, '{enter}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: button
+
+    button - pointerover
+    button - pointerenter
+    button - mouseover: Left (0)
+    button - mouseenter: Left (0)
+    button - pointermove
+    button - mousemove: Left (0)
+    button - pointerdown
+    button - mousedown: Left (0)
+    button - focus
+    button - focusin
+    button - pointerup
+    button - mouseup: Left (0)
+    button - click: Left (0)
+    button - keydown: Enter (13)
+    button - keypress: Enter (13)
     button - keyup: Enter (13)
   `)
 })
@@ -735,6 +766,63 @@ test('{enter} on a textarea', () => {
     textarea[value="\\n"] - input
       "{CURSOR}" -> "\\n{CURSOR}"
     textarea[value="\\n"] - keyup: Enter (13)
+  `)
+})
+
+test('{enter} on a textarea when keydown calls prevent default', () => {
+  const {element, getEventSnapshot} = setup('<textarea></textarea>', {
+    eventHandlers: {keyDown: e => e.preventDefault()},
+  })
+
+  userEvent.type(element, '{enter}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: textarea[value=""]
+
+    textarea[value=""] - pointerover
+    textarea[value=""] - pointerenter
+    textarea[value=""] - mouseover: Left (0)
+    textarea[value=""] - mouseenter: Left (0)
+    textarea[value=""] - pointermove
+    textarea[value=""] - mousemove: Left (0)
+    textarea[value=""] - pointerdown
+    textarea[value=""] - mousedown: Left (0)
+    textarea[value=""] - focus
+    textarea[value=""] - focusin
+    textarea[value=""] - pointerup
+    textarea[value=""] - mouseup: Left (0)
+    textarea[value=""] - click: Left (0)
+    textarea[value=""] - keydown: Enter (13)
+    textarea[value=""] - keyup: Enter (13)
+  `)
+})
+
+test('{enter} on a textarea when keypress calls prevent default', () => {
+  const {element, getEventSnapshot} = setup('<textarea></textarea>', {
+    eventHandlers: {keyPress: e => e.preventDefault()},
+  })
+
+  userEvent.type(element, '{enter}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: textarea[value=""]
+
+    textarea[value=""] - pointerover
+    textarea[value=""] - pointerenter
+    textarea[value=""] - mouseover: Left (0)
+    textarea[value=""] - mouseenter: Left (0)
+    textarea[value=""] - pointermove
+    textarea[value=""] - mousemove: Left (0)
+    textarea[value=""] - pointerdown
+    textarea[value=""] - mousedown: Left (0)
+    textarea[value=""] - focus
+    textarea[value=""] - focusin
+    textarea[value=""] - pointerup
+    textarea[value=""] - mouseup: Left (0)
+    textarea[value=""] - click: Left (0)
+    textarea[value=""] - keydown: Enter (13)
+    textarea[value=""] - keypress: Enter (13)
+    textarea[value=""] - keyup: Enter (13)
   `)
 })
 

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -910,6 +910,42 @@ test('should submit a form with one input element', () => {
   expect(handleSubmit).toHaveBeenCalledTimes(1)
 })
 
+test('should not submit a form with when keydown calls prevent default', () => {
+  const handleSubmit = jest.fn()
+
+  const {element} = setup(
+    `
+    <form>
+      <input type='text'/>
+    </form>
+  `,
+    {
+      eventHandlers: {submit: handleSubmit, keyDown: e => e.preventDefault()},
+    },
+  )
+  userEvent.type(element.querySelector('input'), '{enter}')
+
+  expect(handleSubmit).not.toHaveBeenCalled()
+})
+
+test('should not submit a form with when keypress calls prevent default', () => {
+  const handleSubmit = jest.fn()
+
+  const {element} = setup(
+    `
+    <form>
+      <input type='text'/>
+    </form>
+  `,
+    {
+      eventHandlers: {submit: handleSubmit, keyPress: e => e.preventDefault()},
+    },
+  )
+  userEvent.type(element.querySelector('input'), '{enter}')
+
+  expect(handleSubmit).not.toHaveBeenCalled()
+})
+
 test('should not submit a form with multiple input when ENTER is pressed on one of it', () => {
   const handleSubmit = jest.fn()
   const {element} = setup(

--- a/src/type.js
+++ b/src/type.js
@@ -489,44 +489,47 @@ function handleEnter({currentElement, eventOverrides}) {
   })
 
   if (keyDownDefaultNotPrevented) {
-    fireEvent.keyPress(currentElement(), {
+    const keyPressDefaultNotPrevented = fireEvent.keyPress(currentElement(), {
       key,
       keyCode,
       charCode: keyCode,
       ...eventOverrides,
     })
-    if (isClickable(currentElement())) {
-      fireEvent.click(currentElement(), {
-        ...eventOverrides,
-      })
+
+    if (keyPressDefaultNotPrevented) {
+      if (isClickable(currentElement())) {
+        fireEvent.click(currentElement(), {
+          ...eventOverrides,
+        })
+      }
+
+      if (currentElement().tagName === 'TEXTAREA') {
+        const {newValue, newSelectionStart} = calculateNewValue(
+          '\n',
+          currentElement(),
+        )
+        fireEvent.input(currentElement(), {
+          target: {value: newValue},
+          inputType: 'insertLineBreak',
+          ...eventOverrides,
+        })
+        setSelectionRange({
+          currentElement,
+          newValue,
+          newSelectionStart,
+        })
+      }
+
+      if (
+        currentElement().tagName === 'INPUT' &&
+        currentElement().form &&
+        (currentElement().form.querySelectorAll('input').length === 1 ||
+          currentElement().form.querySelector('input[type="submit"]') ||
+          currentElement().form.querySelector('button[type="submit"]'))
+      ) {
+        fireEvent.submit(currentElement().form)
+      }
     }
-  }
-
-  if (currentElement().tagName === 'TEXTAREA') {
-    const {newValue, newSelectionStart} = calculateNewValue(
-      '\n',
-      currentElement(),
-    )
-    fireEvent.input(currentElement(), {
-      target: {value: newValue},
-      inputType: 'insertLineBreak',
-      ...eventOverrides,
-    })
-    setSelectionRange({
-      currentElement,
-      newValue,
-      newSelectionStart,
-    })
-  }
-
-  if (
-    currentElement().tagName === 'INPUT' &&
-    currentElement().form &&
-    (currentElement().form.querySelectorAll('input').length === 1 ||
-      currentElement().form.querySelector('input[type="submit"]') ||
-      currentElement().form.querySelector('button[type="submit"]'))
-  ) {
-    fireEvent.submit(currentElement().form)
   }
 
   fireEvent.keyUp(currentElement(), {


### PR DESCRIPTION
**What**:

When using `{enter}`:
- Skips element click when keydown/keypress is prevented
- Skips `'\n'` input when keydown/keypress is prevented 
- Skips form submission when keydown/keypress is prevented 

**Why**:

user-event does not properly emulate browser behavior when using `preventDefault()` with `{enter}`.

Here is a sandbox with a couple tests that should pass but do not: 

https://codesandbox.io/s/user-event-issue-with-enter-and-preventdefault-sr3i7?file=/src/__tests__/App.test.js

**How**:

- Moved event logic inside `keyDownDefaultNotPrevented` and `keyPressDefaultNotPrevented` if statements so it is skipped with `preventDefault()`
- Added tests to confirm this behavior

Not a huge fan of the additional level of nesting in  `handleEnter`, but also didn't think this was a large enough change to warrant any refactoring so I left it be.

**Checklist**:

- [x] Tests
- [x] Ready to be merged