### PR TITLE
Move @testing-library/dom from peerDependencies to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ change the state of the checkbox.
 With NPM:
 
 ```sh
-npm install @testing-library/user-event @testing-library/dom --save-dev
+npm install @testing-library/user-event --save-dev
 ```
 
 With Yarn:
 
 ```sh
-yarn add @testing-library/user-event @testing-library/dom --dev
+yarn add @testing-library/user-event --dev
 ```
 
 Now simply import it in your tests:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.2"
+    "@babel/runtime": "^7.10.2",
+    "@testing-library/dom": ">=7.21.4"
   },
   "devDependencies": {
     "@testing-library/dom": "^7.21.4",
@@ -46,9 +47,6 @@
     "is-ci": "^2.0.0",
     "jest-serializer-ansi": "^1.0.3",
     "kcd-scripts": "^6.2.3"
-  },
-  "peerDependencies": {
-    "@testing-library/dom": ">=7.21.4"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
Make this package more consistent with others, for example:
https://github.com/testing-library/react-testing-library/blob/master/package.json#L47

I installed this package before the documentation was updated, and just noticed this warning:
`warning " > @testing-library/user-event@12.1.1" has unmet peer dependency "@testing-library/dom@>=7.21.4".`




**How**:

<!-- Have you done all of these things?  -->
`@testing-library/dom` was moved from `peerDependencies` to `dependencies`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
