### PR TITLE
fix(tab): respect the correct sequence using shift+tab with radio group

### DIFF
--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -432,6 +432,71 @@ test('should respect radio groups', () => {
   expect(firstRight).toHaveFocus()
 })
 
+it('should respect the correct sequence when elements in the same radiogroup are not consecutive', () => {
+  setup(`
+    <div>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <button  data-testid="element">Right Button</button>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+      />
+    </div>
+  `)
+
+  const [leftRadio, centralButton, rightRadio] = document.querySelectorAll(
+    '[data-testid="element"]',
+  )
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab()
+  expect(centralButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(rightRadio).toHaveFocus()
+})
+
+it('should respect the correct sequence when non focusable radio has the focus', () => {
+  setup(`
+    <div>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+      />
+      <button  data-testid="element">Right Button</button>
+    </div>
+  `)
+
+  const [leftRadio, rightRadio, rightButton] = document.querySelectorAll(
+    '[data-testid="element"]',
+  )
+
+  userEvent.click(rightRadio)
+
+  expect(rightRadio).toBeChecked()
+
+  focus(leftRadio)
+
+  userEvent.tab()
+  expect(rightButton).toHaveFocus()
+})
+
 it('should respect the correct sequence when radio group is beetwen other elements', () => {
   setup(`
     <div>

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -423,16 +423,60 @@ test('should respect radio groups', () => {
   )
 
   userEvent.tab()
-
   expect(firstLeft).toHaveFocus()
 
   userEvent.tab()
-
   expect(secondRight).toHaveFocus()
 
   userEvent.tab({shift: true})
-
   expect(firstRight).toHaveFocus()
+})
+
+it('should respect the correct sequence when radio group is beetwen other elements', () => {
+  setup(`
+    <div>
+      <button  data-testid="element">Left Button</button>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+        
+      />
+      <button  data-testid="element">Right Button</button>
+    </div>
+  `)
+
+  const [
+    leftButton,
+    leftRadio,
+    rightRadio,
+    rightButton,
+  ] = document.querySelectorAll('[data-testid="element"]')
+
+  userEvent.tab()
+  expect(leftButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab({shift: true})
+  expect(leftButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab()
+  expect(rightButton).toHaveFocus()
+
+  userEvent.tab({shift: true})
+  expect(rightRadio).toHaveFocus()
 })
 
 test('calls FocusEvents with relatedTarget', () => {

--- a/src/tab.js
+++ b/src/tab.js
@@ -46,8 +46,6 @@ function tab({shift = false, focusTrap} = {}) {
     })
     .map(({el}) => el)
 
-  if (shift) orderedElements.reverse()
-
   // keep only the checked or first element in each radio group
   const prunedElements = []
   for (const el of orderedElements) {
@@ -55,10 +53,16 @@ function tab({shift = false, focusTrap} = {}) {
       const replacedIndex = prunedElements.findIndex(
         ({name}) => name === el.name,
       )
-
       if (replacedIndex === -1) {
         prunedElements.push(el)
       } else if (el.checked) {
+        prunedElements.splice(replacedIndex, 1)
+        prunedElements.push(el)
+      } else if (
+        shift &&
+        !prunedElements[replacedIndex].checked &&
+        el.ownerDocument.activeElement !== prunedElements[replacedIndex]
+      ) {
         prunedElements.splice(replacedIndex, 1)
         prunedElements.push(el)
       }
@@ -67,12 +71,9 @@ function tab({shift = false, focusTrap} = {}) {
     }
   }
 
-  if (shift) prunedElements.reverse()
-
   const index = prunedElements.findIndex(
     el => el === el.ownerDocument.activeElement,
   )
-
   const nextElement = getNextElement(index, shift, prunedElements, focusTrap)
 
   const shiftKeyInit = {


### PR DESCRIPTION


fix #441 

**What**:

Fix a bug when radio group has no checked element and shift+tab is pressed 

**Why**:

This was an issue 

**How**:

Remove lines that reverse the array of elements and check the correct sequence in the loop

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
