### PR TITLE
fix(tab): tab order on radio and tabindex=-1

### DIFF
--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -432,6 +432,71 @@ test('should respect radio groups', () => {
   expect(firstRight).toHaveFocus()
 })
 
+it('should respect the correct sequence when elements in the same radiogroup are not consecutive', () => {
+  setup(`
+    <div>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <button  data-testid="element">Right Button</button>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+      />
+    </div>
+  `)
+
+  const [leftRadio, centralButton, rightRadio] = document.querySelectorAll(
+    '[data-testid="element"]',
+  )
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab()
+  expect(centralButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(rightRadio).toHaveFocus()
+})
+
+it('should respect the correct sequence when non focusable radio has the focus', () => {
+  setup(`
+    <div>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+      />
+      <button  data-testid="element">Right Button</button>
+    </div>
+  `)
+
+  const [leftRadio, rightRadio, rightButton] = document.querySelectorAll(
+    '[data-testid="element"]',
+  )
+
+  userEvent.click(rightRadio)
+
+  expect(rightRadio).toBeChecked()
+
+  focus(leftRadio)
+
+  userEvent.tab()
+  expect(rightButton).toHaveFocus()
+})
+
 it('should respect the correct sequence when radio group is beetwen other elements', () => {
   setup(`
     <div>

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -423,16 +423,60 @@ test('should respect radio groups', () => {
   )
 
   userEvent.tab()
-
   expect(firstLeft).toHaveFocus()
 
   userEvent.tab()
-
   expect(secondRight).toHaveFocus()
 
   userEvent.tab({shift: true})
-
   expect(firstRight).toHaveFocus()
+})
+
+it('should respect the correct sequence when radio group is beetwen other elements', () => {
+  setup(`
+    <div>
+      <button  data-testid="element">Left Button</button>
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_left"
+      />
+      <input
+        data-testid="element"
+        type="radio"
+        name="first"
+        value="radio_right"
+        
+      />
+      <button  data-testid="element">Right Button</button>
+    </div>
+  `)
+
+  const [
+    leftButton,
+    leftRadio,
+    rightRadio,
+    rightButton,
+  ] = document.querySelectorAll('[data-testid="element"]')
+
+  userEvent.tab()
+  expect(leftButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab({shift: true})
+  expect(leftButton).toHaveFocus()
+
+  userEvent.tab()
+  expect(leftRadio).toHaveFocus()
+
+  userEvent.tab()
+  expect(rightButton).toHaveFocus()
+
+  userEvent.tab({shift: true})
+  expect(rightRadio).toHaveFocus()
 })
 
 test('calls FocusEvents with relatedTarget', () => {

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -245,13 +245,13 @@ test('should suport a mix of elements with/without tab index', () => {
 })
 
 test('ignore tabindex when active element has tabindex="-1"', () => {
-  setup(`
+  const {element} = setup(`
     <input tabindex='1'/>
     <input tabindex='0'/>
     <input tabindex='-1'/>
     <input tabindex='2'/>
   `)
-  const [inputA, inputB, inputC, inputD] = document.body.lastChild.children
+  const [inputA, inputB, inputC, inputD] = element.parentElement.children
 
   inputB.focus()
   userEvent.tab()

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -409,7 +409,7 @@ test('should keep focus on the document if there are no enabled, focusable eleme
 })
 
 test('skip consecutive radios of same group', () => {
-  setup(`
+  const {element} = setup(`
     <input/>
     <input type="radio" name="radio1"/>
     <input type="radio" name="radio1"/>
@@ -428,7 +428,7 @@ test('skip consecutive radios of same group', () => {
     radioD,
     radioE,
     inputC,
-  ] = document.body.lastChild.children
+  ] = element.parentElement.children
 
   inputA.focus()
 
@@ -458,7 +458,7 @@ test('skip consecutive radios of same group', () => {
 })
 
 test('skip unchecked radios if that group has a checked one', () => {
-  setup(`
+  const {element} = setup(`
     <input/>
     <input type="radio" name="radio"/>
     <input/>
@@ -475,7 +475,7 @@ test('skip unchecked radios if that group has a checked one', () => {
     inputC,
     ,
     inputD,
-  ] = document.body.lastChild.children
+  ] = element.parentElement.children
 
   inputA.focus()
 
@@ -490,15 +490,14 @@ test('skip unchecked radios if that group has a checked one', () => {
 })
 
 test('tab from active radio when another one is checked', () => {
-  setup(`
+  const {element} = setup(`
     <input/>
     <input type="radio" name="radio" checked/>
     <input/>
     <input type="radio" name="radio"/>
     <input/>
   `)
-
-  const [, , , radioB, inputC] = document.body.lastChild.children
+  const [, , , radioB, inputC] = element.parentElement.children
 
   radioB.focus()
 

--- a/src/tab.js
+++ b/src/tab.js
@@ -61,7 +61,7 @@ function tab({shift = false, focusTrap} = {}) {
   orderedElements.forEach(el => {
     // For radio groups keep only the active radio
     // If there is no active radio, keep only the checked radio
-    // If there is no checked radio, keep only the first / last (with shift) of consecutive elements
+    // If there is no checked radio, treat like everything else
     if (el.type === 'radio' && el.name) {
       // If the active element is part of the group, add only that
       if (
@@ -87,15 +87,6 @@ function tab({shift = false, focusTrap} = {}) {
 
       // If we already found the checked one, skip
       if (checkedRadio[el.name]) {
-        return
-      }
-
-      // For consecutive radios only keep the one we need in that tab direction
-      const lastEl = prunedElements[prunedElements.length]
-      if (lastEl && lastEl.type === el.type && lastEl.name === el.name) {
-        if (shift) {
-          prunedElements[prunedElements.length] = el
-        }
         return
       }
     }

--- a/src/tab.js
+++ b/src/tab.js
@@ -46,8 +46,6 @@ function tab({shift = false, focusTrap} = {}) {
     })
     .map(({el}) => el)
 
-  if (shift) orderedElements.reverse()
-
   // keep only the checked or first element in each radio group
   const prunedElements = []
   for (const el of orderedElements) {
@@ -55,10 +53,16 @@ function tab({shift = false, focusTrap} = {}) {
       const replacedIndex = prunedElements.findIndex(
         ({name}) => name === el.name,
       )
-
       if (replacedIndex === -1) {
         prunedElements.push(el)
       } else if (el.checked) {
+        prunedElements.splice(replacedIndex, 1)
+        prunedElements.push(el)
+      } else if (
+        shift &&
+        !prunedElements[replacedIndex].checked &&
+        el.ownerDocument.activeElement !== prunedElements[replacedIndex]
+      ) {
         prunedElements.splice(replacedIndex, 1)
         prunedElements.push(el)
       }
@@ -67,12 +71,9 @@ function tab({shift = false, focusTrap} = {}) {
     }
   }
 
-  if (shift) prunedElements.reverse()
-
   const index = prunedElements.findIndex(
     el => el === el.ownerDocument.activeElement,
   )
-
   const nextElement = getNextElement(index, shift, prunedElements, focusTrap)
 
   const shiftKeyInit = {


### PR DESCRIPTION
fix #441 
replaces #443 

**What**:

`tab()` did not produce the same tab order as the browser does.

**How**:

Reimplemented how the tab sequence is determined.
* Never dismiss activeElement for tab sequence
* Keep DOM order (ignore tabindex) if activeElement has `tabindex="-1"`
* Reimplemented which radio elements to prune from tab order:
   * For radio groups keep only the active radio
   * If there is no active radio, keep only the checked radio

**Checklist**:
* [x] Tests
* [x] Ready to be merged
