### PR TITLE
Also fire pointer/mouseEnter/-Leave on parents

### DIFF
--- a/src/__tests__/click.js
+++ b/src/__tests__/click.js
@@ -184,7 +184,9 @@ test('should blur the previous element', () => {
     Events fired on: div
 
     input[name="b"][value=""] - pointerover
+    div - pointerenter
     input[name="b"][value=""] - mouseover: Left (0)
+    div - mouseenter: Left (0)
     input[name="b"][value=""] - pointermove
     input[name="b"][value=""] - mousemove: Left (0)
     input[name="b"][value=""] - pointerdown
@@ -222,7 +224,9 @@ test('should not blur the previous element when mousedown prevents default', () 
     Events fired on: div
 
     input[name="b"][value=""] - pointerover
+    div - pointerenter
     input[name="b"][value=""] - mouseover: Left (0)
+    div - mouseenter: Left (0)
     input[name="b"][value=""] - pointermove
     input[name="b"][value=""] - mousemove: Left (0)
     input[name="b"][value=""] - pointerdown

--- a/src/__tests__/hover.js
+++ b/src/__tests__/hover.js
@@ -1,5 +1,5 @@
 import userEvent from '../'
-import {setup} from './helpers/utils'
+import {addEventListener, setup} from './helpers/utils'
 
 test('hover', () => {
   const {element, getEventSnapshot} = setup('<button />')
@@ -37,4 +37,88 @@ test('no events fired on labels that contain disabled controls', () => {
   expect(getEventSnapshot()).toMatchInlineSnapshot(
     `No events were fired on: label`,
   )
+})
+
+test('fires non-bubbling events on parents for hover', () => {
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = '<div><button></button></div>'
+  document.body.append(wrapper)
+
+  const calls = []
+  function addListeners(el) {
+    for (const event of [
+      'mouseenter',
+      'mouseover',
+      'mouseleave',
+      'mouseout',
+      'pointerenter',
+      'pointerover',
+      'pointerleave',
+      'pointerout',
+    ]) {
+      addEventListener(el, event, () => {
+        calls.push(`${el.tagName}: ${event}`)
+      })
+    }
+  }
+  const div = wrapper.firstChild
+  const button = div.firstChild
+
+  addListeners(div)
+  addListeners(button)
+
+  userEvent.hover(button)
+
+  expect(calls.join('\n')).toMatchInlineSnapshot(`
+    "BUTTON: pointerover
+    DIV: pointerover
+    DIV: pointerenter
+    BUTTON: pointerenter
+    BUTTON: mouseover
+    DIV: mouseover
+    DIV: mouseenter
+    BUTTON: mouseenter"
+  `)
+})
+
+test('fires non-bubbling events on parents for unhover', () => {
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = '<div><button></button></div>'
+  document.body.append(wrapper)
+
+  const calls = []
+  function addListeners(el) {
+    for (const event of [
+      'mouseenter',
+      'mouseover',
+      'mouseleave',
+      'mouseout',
+      'pointerenter',
+      'pointerover',
+      'pointerleave',
+      'pointerout',
+    ]) {
+      addEventListener(el, event, () => {
+        calls.push(`${el.tagName}: ${event}`)
+      })
+    }
+  }
+  const div = wrapper.firstChild
+  const button = div.firstChild
+
+  addListeners(div)
+  addListeners(button)
+
+  userEvent.unhover(button)
+
+  expect(calls.join('\n')).toMatchInlineSnapshot(`
+    "BUTTON: pointerout
+    DIV: pointerout
+    BUTTON: pointerleave
+    DIV: pointerleave
+    BUTTON: mouseout
+    DIV: mouseout
+    BUTTON: mouseleave
+    DIV: mouseleave"
+  `)
 })

--- a/src/__tests__/hover.js
+++ b/src/__tests__/hover.js
@@ -40,9 +40,12 @@ test('no events fired on labels that contain disabled controls', () => {
 })
 
 test('fires non-bubbling events on parents for hover', () => {
-  const wrapper = document.createElement('div')
-  wrapper.innerHTML = '<div><button></button></div>'
-  document.body.append(wrapper)
+  // Doesn't use getEventSnapshot() because:
+  // 1) We're asserting the events of both elements (not what bubbles to the outer div)
+  // 2) We're asserting the order of these events in a single list as they're
+  //     interleaved across two elements.
+  const {element: div} = setup('<div><button></button></div>')
+  const button = div.firstChild
 
   const calls = []
   function addListeners(el) {
@@ -61,9 +64,6 @@ test('fires non-bubbling events on parents for hover', () => {
       })
     }
   }
-  const div = wrapper.firstChild
-  const button = div.firstChild
-
   addListeners(div)
   addListeners(button)
 
@@ -82,9 +82,12 @@ test('fires non-bubbling events on parents for hover', () => {
 })
 
 test('fires non-bubbling events on parents for unhover', () => {
-  const wrapper = document.createElement('div')
-  wrapper.innerHTML = '<div><button></button></div>'
-  document.body.append(wrapper)
+  // Doesn't use getEventSnapshot() because:
+  // 1) We're asserting the events of both elements (not what bubbles to the outer div)
+  // 2) We're asserting the order of these events in a single list as they're
+  //     interleaved across two elements.
+  const {element: div} = setup('<div><button></button></div>')
+  const button = div.firstChild
 
   const calls = []
   function addListeners(el) {
@@ -103,9 +106,6 @@ test('fires non-bubbling events on parents for unhover', () => {
       })
     }
   }
-  const div = wrapper.firstChild
-  const button = div.firstChild
-
   addListeners(div)
   addListeners(button)
 

--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -51,7 +51,9 @@ test('should fire the correct events with label', () => {
     Events fired on: form
 
     label[for="element"] - pointerover
+    form - pointerenter
     label[for="element"] - mouseover: Left (0)
+    form - mouseenter: Left (0)
     label[for="element"] - pointermove
     label[for="element"] - mousemove: Left (0)
     label[for="element"] - pointerdown

--- a/src/hover.js
+++ b/src/hover.js
@@ -4,14 +4,30 @@ import {
   getMouseEventOptions,
 } from './utils'
 
+// includes `element`
+function getParentElements(element) {
+  const parentElements = [element]
+  let currentElement = element
+  while ((currentElement = currentElement.parentElement) != null) {
+    parentElements.push(currentElement)
+  }
+  return parentElements
+}
+
 function hover(element, init) {
   if (isLabelWithInternallyDisabledControl(element)) return
 
+  const parentElements = getParentElements(element).reverse()
+
   fireEvent.pointerOver(element, init)
-  fireEvent.pointerEnter(element, init)
+  for (const el of parentElements) {
+    fireEvent.pointerEnter(el, init)
+  }
   if (!element.disabled) {
     fireEvent.mouseOver(element, getMouseEventOptions('mouseover', init))
-    fireEvent.mouseEnter(element, getMouseEventOptions('mouseenter', init))
+    for (const el of parentElements) {
+      fireEvent.mouseEnter(el, getMouseEventOptions('mouseenter', init))
+    }
   }
   fireEvent.pointerMove(element, init)
   if (!element.disabled) {
@@ -22,15 +38,21 @@ function hover(element, init) {
 function unhover(element, init) {
   if (isLabelWithInternallyDisabledControl(element)) return
 
+  const parentElements = getParentElements(element)
+
   fireEvent.pointerMove(element, init)
   if (!element.disabled) {
     fireEvent.mouseMove(element, getMouseEventOptions('mousemove', init))
   }
   fireEvent.pointerOut(element, init)
-  fireEvent.pointerLeave(element, init)
+  for (const el of parentElements) {
+    fireEvent.pointerLeave(el, init)
+  }
   if (!element.disabled) {
     fireEvent.mouseOut(element, getMouseEventOptions('mouseout', init))
-    fireEvent.mouseLeave(element, getMouseEventOptions('mouseleave', init))
+    for (const el of parentElements) {
+      fireEvent.mouseLeave(el, getMouseEventOptions('mouseleave', init))
+    }
   }
 }
 


### PR DESCRIPTION
**What**:

pointerEnter/mouseEnter and pointerLeave/mouseLeave don't bubble but are called for every parent (with `e.target` being set to the parent).

https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event

<!-- Why are these changes necessary? -->

**Why**:

React normalizes this behaviour but it's not compatible with the native DOM/Preact.

<!-- How were these changes implemented? -->

**How**:

For hover/unhover, fire these events for all parent elements as well.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] Typings N/A
- [X] Ready to be merged