### PR TITLE
Typings: fix paste missing argument

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -61,7 +61,8 @@ declare const userEvent: {
   tab: (userOpts?: ITabUserOptions) => void
   paste: (
     element: TargetElement,
-    init?: {},
+    text: string,
+    init?: MouseEventInit,
     pasteOptions?: {
       initialSelectionStart?: number
       initialSelectionEnd?: number


### PR DESCRIPTION
**What:**

Fix missing `paste` argument in typings. 

**Why:**

Fixes #452

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Typings
- [x] Ready to be merged

