### PR TITLE
fix: exclude hidden type inputs from focusable selector

### DIFF
--- a/src/__tests__/focus.js
+++ b/src/__tests__/focus.js
@@ -43,6 +43,15 @@ test('no events fired on a disabled focusable input', () => {
   expect(element).not.toHaveFocus()
 })
 
+test('no events fired on a hidden input', () => {
+  const {element, getEventSnapshot} = setup(`<input type="hidden" />`)
+  focus(element)
+  expect(getEventSnapshot()).toMatchInlineSnapshot(
+    `No events were fired on: input[value=""]`,
+  )
+  expect(element).not.toHaveFocus()
+})
+
 test('no events fired if the element is already focused', () => {
   const {element, getEventSnapshot, clearEventCalls} = setup(`<button />`)
   focus(element)

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -288,14 +288,13 @@ test('should not tab to <a> with no href', () => {
 })
 
 test('should not tab to <input> with type="hidden"', () => {
-  setup(`
-    <div>
-      <input data-testid="element" tabIndex="0" type="checkbox" />
-      <input type="hidden">
-      <input data-testid="element" type="text"  />
-    </div>`)
-
-  const [checkbox, text] = document.querySelectorAll('[data-testid="element"]')
+  const {
+    elements: [checkbox, , text],
+  } = setup(`
+    <input tabIndex="0" type="checkbox" />
+    <input type="hidden" />
+    <input type="text" />
+  `)
 
   userEvent.tab()
 

--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -221,7 +221,7 @@ test('should respect tab index order, then DOM order', () => {
   expect(checkbox).toHaveFocus()
 })
 
-test('should suport a mix of elements with/without tab index', () => {
+test('should support a mix of elements with/without tab index', () => {
   setup(`
     <div>
       <input data-testid="element" tabIndex="0" type="checkbox" />
@@ -285,6 +285,25 @@ test('should not tab to <a> with no href', () => {
   userEvent.tab()
 
   expect(link).toHaveFocus()
+})
+
+test('should not tab to <input> with type="hidden"', () => {
+  setup(`
+    <div>
+      <input data-testid="element" tabIndex="0" type="checkbox" />
+      <input type="hidden">
+      <input data-testid="element" type="text"  />
+    </div>`)
+
+  const [checkbox, text] = document.querySelectorAll('[data-testid="element"]')
+
+  userEvent.tab()
+
+  expect(checkbox).toHaveFocus()
+
+  userEvent.tab()
+
+  expect(text).toHaveFocus()
 })
 
 test('should stay within a focus trap', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -219,7 +219,7 @@ function setSelectionRangeIfNecessary(
 }
 
 const FOCUSABLE_SELECTOR = [
-  'input:not([disabled])',
+  'input:not([type=hidden]):not([disabled])',
   'button:not([disabled])',
   'select:not([disabled])',
   'textarea:not([disabled])',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

fix #466 
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: `tab` attempts to focus hidden type inputs

<!-- Why are these changes necessary? -->

**Why**: Hidden-type input elements do not receive tab focus in common browsers, but `tab` fails to exclude them from its tab-able element list which produces incorrect behavior.

<!-- How were these changes implemented? -->

**How**: Update `FOCUSABLE_SELECTOR` to exclude hidden inputs.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
