### PR TITLE
Added listbox options support in selectOptions

### DIFF
--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -66,9 +66,9 @@ function setupListbox() {
       name="listbox"
       aria-labelledby="button"
     >
-      <li role="option" aria-selected="false">1</li>
-      <li role="option" aria-selected="false">2</li>
-      <li role="option" aria-selected="false">3</li>
+      <li id="1" role="option" aria-selected="false">1</li>
+      <li id="2" role="option" aria-selected="false">2</li>
+      <li id="3" role="option" aria-selected="false">3</li>
     </ul>
   `
   document.body.append(wrapper)
@@ -117,6 +117,12 @@ function addEventListener(el, type, listener, options) {
 function getElementValue(element) {
   if (element.tagName === 'SELECT' && element.multiple) {
     return JSON.stringify(Array.from(element.selectedOptions).map(o => o.value))
+  } else if (element.getAttribute('role') === 'listbox') {
+    return JSON.stringify(
+      element.querySelector('[aria-selected="true"]')?.innerHTML,
+    )
+  } else if (element.getAttribute('role') === 'option') {
+    return JSON.stringify(element.innerHTML)
   } else if (
     element.type === 'checkbox' ||
     element.type === 'radio' ||
@@ -140,6 +146,9 @@ function getElementDisplayName(element) {
     value ? `[value=${value}]` : null,
     hasChecked ? `[checked=${element.checked}]` : null,
     element.tagName === 'OPTION' ? `[selected=${element.selected}]` : null,
+    element.getAttribute('role') === 'option'
+      ? `[aria-selected=${element.getAttribute('aria-selected')}]`
+      : null,
   ]
     .filter(Boolean)
     .join('')

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -66,9 +66,9 @@ function setupListbox() {
       name="listbox"
       aria-labelledby="button"
     >
-      <option role="option" aria-selected="false">1</option>
-      <option role="option" aria-selected="false">2</option>
-      <option role="option" aria-selected="false">3</option>
+      <li role="option" aria-selected="false">1</li>
+      <li role="option" aria-selected="false">2</li>
+      <li role="option" aria-selected="false">3</li>
     </ul>
   `
   document.body.append(wrapper)

--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -55,6 +55,32 @@ function setupSelect({
   }
 }
 
+function setupListbox() {
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = `
+    <button id="button" aria-haspopup="listbox">
+      Some label
+    </button>
+    <ul
+      role="listbox"
+      name="listbox"
+      aria-labelledby="button"
+    >
+      <option role="option" aria-selected="false">1</option>
+      <option role="option" aria-selected="false">2</option>
+      <option role="option" aria-selected="false">3</option>
+    </ul>
+  `
+  document.body.append(wrapper)
+  const listbox = wrapper.querySelector('[role="listbox"]')
+  const options = Array.from(wrapper.querySelectorAll('[role="option"]'))
+  return {
+    ...addListeners(listbox),
+    listbox,
+    options,
+  }
+}
+
 const eventLabelGetters = {
   KeyboardEvent(event) {
     return [
@@ -278,4 +304,4 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-export {setup, setupSelect, addEventListener, addListeners}
+export {setup, setupSelect, setupListbox, addEventListener, addListeners}

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -46,28 +46,28 @@ test('fires correct events on listBox select', () => {
     ul - pointerup
     ul - mouseup: Left (0)
     ul - click: Left (0)
-    option[value="2"][selected=false] - pointerover
+    li[value=0] - pointerover
     ul - pointerenter
-    option[value="2"][selected=false] - mouseover: Left (0)
+    li[value=0] - mouseover: Left (0)
     ul - mouseenter: Left (0)
-    option[value="2"][selected=false] - pointermove
-    option[value="2"][selected=false] - mousemove: Left (0)
-    option[value="2"][selected=false] - pointerover
+    li[value=0] - pointermove
+    li[value=0] - mousemove: Left (0)
+    li[value=0] - pointerover
     ul - pointerenter
-    option[value="2"][selected=false] - mouseover: Left (0)
+    li[value=0] - mouseover: Left (0)
     ul - mouseenter: Left (0)
-    option[value="2"][selected=false] - pointermove
-    option[value="2"][selected=false] - mousemove: Left (0)
-    option[value="2"][selected=false] - pointerdown
-    option[value="2"][selected=false] - mousedown: Left (0)
-    option[value="2"][selected=false] - pointerup
-    option[value="2"][selected=false] - mouseup: Left (0)
-    option[value="2"][selected=false] - click: Left (0)
-    option[value="2"][selected=false] - pointermove
-    option[value="2"][selected=false] - mousemove: Left (0)
-    option[value="2"][selected=false] - pointerout
+    li[value=0] - pointermove
+    li[value=0] - mousemove: Left (0)
+    li[value=0] - pointerdown
+    li[value=0] - mousedown: Left (0)
+    li[value=0] - pointerup
+    li[value=0] - mouseup: Left (0)
+    li[value=0] - click: Left (0)
+    li[value=0] - pointermove
+    li[value=0] - mousemove: Left (0)
+    li[value=0] - pointerout
     ul - pointerleave
-    option[value="2"][selected=false] - mouseout: Left (0)
+    li[value=0] - mouseout: Left (0)
     ul - mouseleave: Left (0)
   `)
   const [o1, o2, o3] = options

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -1,5 +1,5 @@
 import userEvent from '../'
-import {setupSelect, addListeners} from './helpers/utils'
+import {setupSelect, addListeners, setupListbox} from './helpers/utils'
 
 test('fires correct events', () => {
   const {select, options, getEventSnapshot} = setupSelect()
@@ -27,6 +27,53 @@ test('fires correct events', () => {
   expect(o1.selected).toBe(false)
   expect(o2.selected).toBe(true)
   expect(o3.selected).toBe(false)
+})
+
+test('fires correct events on listBox select', () => {
+  const {listbox, options, getEventSnapshot} = setupListbox()
+  userEvent.selectOptions(listbox, '2')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: ul
+
+    ul - pointerover
+    ul - pointerenter
+    ul - mouseover: Left (0)
+    ul - mouseenter: Left (0)
+    ul - pointermove
+    ul - mousemove: Left (0)
+    ul - pointerdown
+    ul - mousedown: Left (0)
+    ul - pointerup
+    ul - mouseup: Left (0)
+    ul - click: Left (0)
+    option[value="2"][selected=false] - pointerover
+    ul - pointerenter
+    option[value="2"][selected=false] - mouseover: Left (0)
+    ul - mouseenter: Left (0)
+    option[value="2"][selected=false] - pointermove
+    option[value="2"][selected=false] - mousemove: Left (0)
+    option[value="2"][selected=false] - pointerover
+    ul - pointerenter
+    option[value="2"][selected=false] - mouseover: Left (0)
+    ul - mouseenter: Left (0)
+    option[value="2"][selected=false] - pointermove
+    option[value="2"][selected=false] - mousemove: Left (0)
+    option[value="2"][selected=false] - pointerdown
+    option[value="2"][selected=false] - mousedown: Left (0)
+    option[value="2"][selected=false] - pointerup
+    option[value="2"][selected=false] - mouseup: Left (0)
+    option[value="2"][selected=false] - click: Left (0)
+    option[value="2"][selected=false] - pointermove
+    option[value="2"][selected=false] - mousemove: Left (0)
+    option[value="2"][selected=false] - pointerout
+    ul - pointerleave
+    option[value="2"][selected=false] - mouseout: Left (0)
+    ul - mouseleave: Left (0)
+  `)
+  const [o1, o2, o3] = options
+  expect(o1).toHaveAttribute('aria-selected', 'false')
+  expect(o2).toHaveAttribute('aria-selected', 'true')
+  expect(o3).toHaveAttribute('aria-selected', 'false')
 })
 
 test('fires correct events on multi-selects', () => {
@@ -77,6 +124,15 @@ test('sets the selected prop on the selected option using option html elements',
   expect(o1.selected).toBe(true)
   expect(o2.selected).toBe(false)
   expect(o3.selected).toBe(false)
+})
+
+test('sets the selected prop on the selected listbox option using option html elements', () => {
+  const {listbox, options} = setupListbox()
+  const [o1, o2, o3] = options
+  userEvent.selectOptions(listbox, o1)
+  expect(o1).toHaveAttribute('aria-selected', 'true')
+  expect(o2).toHaveAttribute('aria-selected', 'false')
+  expect(o3).toHaveAttribute('aria-selected', 'false')
 })
 
 test('a previously focused input gets blurred', () => {

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -33,7 +33,7 @@ test('fires correct events on listBox select', () => {
   const {listbox, options, getEventSnapshot} = setupListbox()
   userEvent.selectOptions(listbox, '2')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: ul
+    Events fired on: ul[value="2"]
 
     ul - pointerover
     ul - pointerenter
@@ -46,29 +46,29 @@ test('fires correct events on listBox select', () => {
     ul - pointerup
     ul - mouseup: Left (0)
     ul - click: Left (0)
-    li[value=0] - pointerover
-    ul - pointerenter
-    li[value=0] - mouseover: Left (0)
-    ul - mouseenter: Left (0)
-    li[value=0] - pointermove
-    li[value=0] - mousemove: Left (0)
-    li[value=0] - pointerover
-    ul - pointerenter
-    li[value=0] - mouseover: Left (0)
-    ul - mouseenter: Left (0)
-    li[value=0] - pointermove
-    li[value=0] - mousemove: Left (0)
-    li[value=0] - pointerdown
-    li[value=0] - mousedown: Left (0)
-    li[value=0] - pointerup
-    li[value=0] - mouseup: Left (0)
-    li[value=0] - click: Left (0)
-    li[value=0] - pointermove
-    li[value=0] - mousemove: Left (0)
-    li[value=0] - pointerout
-    ul - pointerleave
-    li[value=0] - mouseout: Left (0)
-    ul - mouseleave: Left (0)
+    li#2[value="2"][aria-selected=true] - pointerover
+    ul[value="2"] - pointerenter
+    li#2[value="2"][aria-selected=true] - mouseover: Left (0)
+    ul[value="2"] - mouseenter: Left (0)
+    li#2[value="2"][aria-selected=true] - pointermove
+    li#2[value="2"][aria-selected=true] - mousemove: Left (0)
+    li#2[value="2"][aria-selected=true] - pointerover
+    ul[value="2"] - pointerenter
+    li#2[value="2"][aria-selected=true] - mouseover: Left (0)
+    ul[value="2"] - mouseenter: Left (0)
+    li#2[value="2"][aria-selected=true] - pointermove
+    li#2[value="2"][aria-selected=true] - mousemove: Left (0)
+    li#2[value="2"][aria-selected=true] - pointerdown
+    li#2[value="2"][aria-selected=true] - mousedown: Left (0)
+    li#2[value="2"][aria-selected=true] - pointerup
+    li#2[value="2"][aria-selected=true] - mouseup: Left (0)
+    li#2[value="2"][aria-selected=true] - click: Left (0)
+    li#2[value="2"][aria-selected=true] - pointermove
+    li#2[value="2"][aria-selected=true] - mousemove: Left (0)
+    li#2[value="2"][aria-selected=true] - pointerout
+    ul[value="2"] - pointerleave
+    li#2[value="2"][aria-selected=true] - mouseout: Left (0)
+    ul[value="2"] - mouseleave: Left (0)
   `)
   const [o1, o2, o3] = options
   expect(o1).toHaveAttribute('aria-selected', 'false')

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -10,7 +10,9 @@ function selectOptionsBase(newValue, select, values, init) {
     )
   }
   const valArray = Array.isArray(values) ? values : [values]
-  const allOptions = Array.from(select.querySelectorAll('option'))
+  const allOptions = Array.from(
+    select.querySelectorAll('option, [role="option"]'),
+  )
   const selectedOptions = valArray
     .map(val => {
       if (allOptions.includes(val)) {

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -65,7 +65,8 @@ function selectOptionsBase(newValue, select, values, init) {
 
   function selectOption(option) {
     if (option.getAttribute('role') === 'option') {
-      option['aria-selected'] = newValue
+      option?.setAttribute?.('aria-selected', newValue)
+
       hover(option, init)
       click(option, init)
       unhover(option, init)

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -1,6 +1,7 @@
 import {createEvent, getConfig, fireEvent} from '@testing-library/dom'
 import {click} from './click'
 import {focus} from './focus'
+import {hover, unhover} from './hover'
 
 function selectOptionsBase(newValue, select, values, init) {
   if (!newValue && !select.multiple) {
@@ -18,7 +19,9 @@ function selectOptionsBase(newValue, select, values, init) {
       if (allOptions.includes(val)) {
         return val
       } else {
-        const matchingOption = allOptions.find(o => o.value === val)
+        const matchingOption = allOptions.find(
+          o => o.value === val || o.innerHTML === val,
+        )
         if (matchingOption) {
           return matchingOption
         } else {
@@ -61,17 +64,24 @@ function selectOptionsBase(newValue, select, values, init) {
   }
 
   function selectOption(option) {
-    option.selected = newValue
-    fireEvent(
-      select,
-      createEvent('input', select, {
-        bubbles: true,
-        cancelable: false,
-        composed: true,
-        ...init,
-      }),
-    )
-    fireEvent.change(select, init)
+    if (option.getAttribute('role') === 'option') {
+      option['aria-selected'] = newValue
+      hover(option, init)
+      click(option, init)
+      unhover(option, init)
+    } else {
+      option.selected = newValue
+      fireEvent(
+        select,
+        createEvent('input', select, {
+          bubbles: true,
+          cancelable: false,
+          composed: true,
+          ...init,
+        }),
+      )
+      fireEvent.change(select, init)
+    }
   }
 }
 


### PR DESCRIPTION
**What**:

Added a few behaviors when selecting a `listbox` option to `selectOptions` 

**Why**:

After adding the `role="option"` selector it was missing those behaviors to work as expected

**How**:

Added those behaviors listed in [this comment](https://github.com/testing-library/user-event/issues/469#issuecomment-713528494) according to [w3](https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Typings N/A
- [x] Ready to be merged
