### PR TITLE
docs: add {arrowleft} and {arrowright} special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,18 +186,20 @@ to `await`!
 
 The following special character strings are supported:
 
-| Text string   | Key       | Modifier   | Notes                                                                                                                                                               |
-| ------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{enter}`     | Enter     | N/A        | Will insert a newline character (`<textarea />` only).                                                                                                              |
-| `{space}`     | `' '`     | N/A        |                                                                                                                                                                     |
-| `{esc}`       | Escape    | N/A        |                                                                                                                                                                     |
-| `{backspace}` | Backspace | N/A        | Will delete the previous character (or the characters within the `selectedRange`, see example below).                                                               |
-| `{del}`       | Delete    | N/A        | Will delete the next character (or the characters within the `selectedRange`, see example below)                                                                    |
-| `{selectall}` | N/A       | N/A        | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
-| `{shift}`     | Shift     | `shiftKey` | Does **not** capitalize following characters.                                                                                                                       |
-| `{ctrl}`      | Control   | `ctrlKey`  |                                                                                                                                                                     |
-| `{alt}`       | Alt       | `altKey`   |                                                                                                                                                                     |
-| `{meta}`      | OS        | `metaKey`  |                                                                                                                                                                     |
+| Text string    | Key        | Modifier   | Notes                                                                                                                                                               |
+| -------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{enter}`      | Enter      | N/A        | Will insert a newline character (`<textarea />` only).                                                                                                              |
+| `{space}`      | `' '`      | N/A        |                                                                                                                                                                     |
+| `{esc}`        | Escape     | N/A        |                                                                                                                                                                     |
+| `{backspace}`  | Backspace  | N/A        | Will delete the previous character (or the characters within the `selectedRange`, see example below).                                                               |
+| `{del}`        | Delete     | N/A        | Will delete the next character (or the characters within the `selectedRange`, see example below)                                                                    |
+| `{selectall}`  | N/A        | N/A        | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
+| `{arrowleft}`  | ArrowLeft  | N/A        |                                                                                                                                                                     |
+| `{arrowright}` | ArrowRight | N/A        |                                                                                                                                                                     |
+| `{shift}`      | Shift      | `shiftKey` | Does **not** capitalize following characters.                                                                                                                       |
+| `{ctrl}`       | Control    | `ctrlKey`  |                                                                                                                                                                     |
+| `{alt}`        | Alt        | `altKey`   |                                                                                                                                                                     |
+| `{meta}`       | OS         | `metaKey`  |                                                                                                                                                                     |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Documenting the new `{arrowleft}` and `{arrowright}` special characters introduced in #404.

<!-- Why are these changes necessary? -->

**Why**:

The feature was released in [12.2.0](https://github.com/testing-library/user-event/releases/tag/v12.2.0) but not documented. This PR fixes it.

<!-- How were these changes implemented? -->

**How**:

I added the new special characters to the README. Since they're not meta characters, I added them before the list of meta characters instead of at the end of the list, for proper grouping.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
