### PR TITLE
fix(type): only return Promise with delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/testing-library/user-event#readme",
   "files": [
     "dist",
-    "typings"
+    "typings/index.d.ts"
   ],
   "scripts": {
     "build": "kcd-scripts build",
@@ -35,7 +35,8 @@
     "test": "kcd-scripts test",
     "test:debug": "kcd-scripts --inspect-brk test --runInBand",
     "test:update": "npm test -- --updateSnapshot --coverage",
-    "validate": "kcd-scripts validate"
+    "validate": "kcd-scripts validate",
+    "typecheck": "tsc --project typings"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.2"
@@ -45,7 +46,8 @@
     "@testing-library/jest-dom": "^5.11.1",
     "is-ci": "^2.0.0",
     "jest-serializer-ansi": "^1.0.3",
-    "kcd-scripts": "^6.2.3"
+    "kcd-scripts": "^6.2.3",
+    "typescript": "^4.0.5"
   },
   "peerDependencies": {
     "@testing-library/dom": ">=7.21.4"

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -53,11 +53,11 @@ declare const userEvent: {
     files: FilesArgument,
     init?: UploadInitArgument,
   ) => void
-  type: (
+  type: <T extends ITypeOpts>(
     element: TargetElement,
     text: string,
-    userOpts?: ITypeOpts,
-  ) => Promise<void>
+    userOpts?: T,
+  ) => T extends {delay: number} ? Promise<void> : void
   tab: (userOpts?: ITabUserOptions) => void
   paste: (
     element: TargetElement,

--- a/typings/test.ts
+++ b/typings/test.ts
@@ -1,0 +1,8 @@
+import userEvent, {TargetElement} from '.'
+
+declare const element: TargetElement
+type NotVoid = string | number | boolean | object | null
+
+userEvent.type(element, 'foo', {delay: 1}) as Promise<void>
+// @ts-expect-error No delay returns void
+userEvent.type(element, 'foo') as NotVoid

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "lib": ["dom"],
+    "noEmit": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The TypeScript type for the `type` function will now only return a `Promise` when given a `delay` option.

<!-- Why are these changes necessary? -->

**Why**: #480

<!-- How were these changes implemented? -->

**How**: Updated type declaration and added basic type tests.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
