### PR TITLE
feat(type): add time input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ change the state of the checkbox.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [API](#api)
   - [`click(element, eventInit, options)`](#clickelement-eventinit-options)
@@ -251,8 +250,16 @@ import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 test('types into the input', () => {
-  render(<input type="time" data-testid="time" />)
-  const input = screen.getByTestId('time')
+  render(
+    <>
+      <label for="time">Enter a time</label>
+      <input
+        type="time"
+        id="time"
+      />
+    </>
+  )
+  const input = screen.getByLabelText(/enter a time/i)
   userEvent.type(input, '13:58')
   expect(input.value).toBe('13:58')
 })

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ change the state of the checkbox.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
 - [API](#api)
   - [`click(element, eventInit, options)`](#clickelement-eventinit-options)
@@ -89,15 +90,14 @@ import userEvent from '@testing-library/user-event'
 
 // or
 
-const { default: userEvent } = require('@testing-library/user-event')
+const {default: userEvent} = require('@testing-library/user-event')
 ```
 
 ## API
 
 Note: All userEvent methods are synchronous with one exception: when `delay`
-with `userEvent.type` as described below). We also discourage using
-`userEvent` inside `before/after` blocks at all, for important reasons
-described in
+with `userEvent.type` as described below). We also discourage using `userEvent`
+inside `before/after` blocks at all, for important reasons described in
 ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
 
 ### `click(element, eventInit, options)`
@@ -237,6 +237,24 @@ test('delete characters within the selectedRange', () => {
   userEvent.type(input, '{backspace}good')
 
   expect(input).toHaveValue('This is a good example')
+})
+```
+
+#### <input type="time" /> support
+
+The following is an example of usage of this library with
+`<input type="time" />`
+
+```jsx
+import React from 'react
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+test('types into the input', () => {
+  render(<input type="time" data-testid="time" />)
+  const input = screen.getByTestId('time')
+  userEvent.type(input, '13:58')
+  expect(input.value).toBe('13:58')
 })
 ```
 
@@ -609,6 +627,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1066,3 +1066,274 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
     input[value="abc"] - keyup: c (99)
   `)
 })
+
+test('can type into an input with type `time`', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '0105')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+  Events fired on: input[value="01:05"]
+  
+  input[value=""] - pointerover
+  input[value=""] - pointerenter
+  input[value=""] - mouseover: Left (0)
+  input[value=""] - mouseenter: Left (0)
+  input[value=""] - pointermove
+  input[value=""] - mousemove: Left (0)
+  input[value=""] - pointerdown
+  input[value=""] - mousedown: Left (0)
+  input[value=""] - focus
+  input[value=""] - focusin
+  input[value=""] - pointerup
+  input[value=""] - mouseup: Left (0)
+  input[value=""] - click: Left (0)
+  input[value=""] - keydown: 0 (48)
+  input[value=""] - keypress: 0 (48)
+  input[value=""] - keyup: 0 (48)
+  input[value=""] - keydown: 1 (49)
+  input[value=""] - keypress: 1 (49)
+  input[value=""] - keyup: 1 (49)
+  input[value=""] - keydown: 0 (48)
+  input[value=""] - keypress: 0 (48)
+  input[value="01:00"] - input
+    "{CURSOR}" -> "{CURSOR}01:00"
+  input[value="01:00"] - change
+  input[value="01:00"] - keyup: 0 (48)
+  input[value="01:00"] - keydown: 5 (53)
+  input[value="01:00"] - keypress: 5 (53)
+  input[value="01:05"] - input
+    "{CURSOR}01:00" -> "{CURSOR}01:05"
+  input[value="01:05"] - change
+  input[value="01:05"] - keyup: 5 (53)
+  `)
+  expect(element.value).toBe('01:05')
+})
+
+test('can type more a number higher than 60 minutes into an input `time` and they are converted into 59 minutes', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '2390')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="23:59"]
+    
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 2 (50)
+    input[value=""] - keypress: 2 (50)
+    input[value=""] - keyup: 2 (50)
+    input[value=""] - keydown: 3 (51)
+    input[value=""] - keypress: 3 (51)
+    input[value=""] - keyup: 3 (51)
+    input[value=""] - keydown: 9 (57)
+    input[value=""] - keypress: 9 (57)
+    input[value="23:09"] - input
+      "{CURSOR}" -> "{CURSOR}23:09"
+    input[value="23:09"] - change
+    input[value="23:09"] - keyup: 9 (57)
+    input[value="23:09"] - keydown: 0 (48)
+    input[value="23:09"] - keypress: 0 (48)
+    input[value="23:59"] - input
+      "{CURSOR}23:09" -> "{CURSOR}23:59"
+    input[value="23:59"] - change
+    input[value="23:59"] - keyup: 0 (48)
+  `)
+
+  expect(element.value).toBe('23:59')
+})
+
+test('can type letters into an input `time` and they are ignored', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '1a6bc36abd')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="16:36"]
+    
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 1 (49)
+    input[value=""] - keypress: 1 (49)
+    input[value=""] - keyup: 1 (49)
+    input[value=""] - keydown: a (97)
+    input[value=""] - keypress: a (97)
+    input[value=""] - keyup: a (97)
+    input[value=""] - keydown: 6 (54)
+    input[value=""] - keypress: 6 (54)
+    input[value=""] - keyup: 6 (54)
+    input[value=""] - keydown: b (98)
+    input[value=""] - keypress: b (98)
+    input[value=""] - keyup: b (98)
+    input[value=""] - keydown: c (99)
+    input[value=""] - keypress: c (99)
+    input[value=""] - keyup: c (99)
+    input[value=""] - keydown: 3 (51)
+    input[value=""] - keypress: 3 (51)
+    input[value="16:03"] - input
+      "{CURSOR}" -> "{CURSOR}16:03"
+    input[value="16:03"] - change
+    input[value="16:03"] - keyup: 3 (51)
+    input[value="16:03"] - keydown: 6 (54)
+    input[value="16:03"] - keypress: 6 (54)
+    input[value="16:36"] - input
+      "{CURSOR}16:03" -> "{CURSOR}16:36"
+    input[value="16:36"] - change
+    input[value="16:36"] - keyup: 6 (54)
+    input[value="16:36"] - keydown: a (97)
+    input[value="16:36"] - keypress: a (97)
+    input[value="16:36"] - keyup: a (97)
+    input[value="16:36"] - keydown: b (98)
+    input[value="16:36"] - keypress: b (98)
+    input[value="16:36"] - keyup: b (98)
+    input[value="16:36"] - keydown: d (100)
+    input[value="16:36"] - keypress: d (100)
+    input[value="16:36"] - keyup: d (100)
+  `)
+
+  expect(element.value).toBe('16:36')
+})
+
+test('can type a digit bigger in the hours section, bigger than 2 and it shows the time correctly', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '925')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="09:25"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 9 (57)
+    input[value=""] - keypress: 9 (57)
+    input[value=""] - keyup: 9 (57)
+    input[value=""] - keydown: 2 (50)
+    input[value=""] - keypress: 2 (50)
+    input[value="09:02"] - input
+      "{CURSOR}" -> "{CURSOR}09:02"
+    input[value="09:02"] - change
+    input[value="09:02"] - keyup: 2 (50)
+    input[value="09:02"] - keydown: 5 (53)
+    input[value="09:02"] - keypress: 5 (53)
+    input[value="09:25"] - input
+      "{CURSOR}09:02" -> "{CURSOR}09:25"
+    input[value="09:25"] - change
+    input[value="09:25"] - keyup: 5 (53)
+  `)
+
+  expect(element.value).toBe('09:25')
+})
+
+test('can type two digits in the hours section, equals to 24 and it shows the hours as 23', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '2452')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="23:52"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 2 (50)
+    input[value=""] - keypress: 2 (50)
+    input[value=""] - keyup: 2 (50)
+    input[value=""] - keydown: 4 (52)
+    input[value=""] - keypress: 4 (52)
+    input[value=""] - keyup: 4 (52)
+    input[value=""] - keydown: 5 (53)
+    input[value=""] - keypress: 5 (53)
+    input[value="23:05"] - input
+      "{CURSOR}" -> "{CURSOR}23:05"
+    input[value="23:05"] - change
+    input[value="23:05"] - keyup: 5 (53)
+    input[value="23:05"] - keydown: 2 (50)
+    input[value="23:05"] - keypress: 2 (50)
+    input[value="23:52"] - input
+      "{CURSOR}23:05" -> "{CURSOR}23:52"
+    input[value="23:52"] - change
+    input[value="23:52"] - keyup: 2 (50)
+  `)
+
+  expect(element.value).toBe('23:52')
+})
+
+test('can type two digits in the hours section, bigger than 24 and less than 30, and it shows the hours as 23', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '2752')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="23:52"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 2 (50)
+    input[value=""] - keypress: 2 (50)
+    input[value=""] - keyup: 2 (50)
+    input[value=""] - keydown: 7 (55)
+    input[value=""] - keypress: 7 (55)
+    input[value=""] - keyup: 7 (55)
+    input[value=""] - keydown: 5 (53)
+    input[value=""] - keypress: 5 (53)
+    input[value="23:05"] - input
+      "{CURSOR}" -> "{CURSOR}23:05"
+    input[value="23:05"] - change
+    input[value="23:05"] - keyup: 5 (53)
+    input[value="23:05"] - keydown: 2 (50)
+    input[value="23:05"] - keypress: 2 (50)
+    input[value="23:52"] - input
+      "{CURSOR}23:05" -> "{CURSOR}23:52"
+    input[value="23:52"] - change
+    input[value="23:52"] - keyup: 2 (50)
+  `)
+
+  expect(element.value).toBe('23:52')
+})

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1069,6 +1069,50 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
 
 test('can type into an input with type `time`', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
+  userEvent.type(element, '01:05')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+  Events fired on: input[value="01:05"]
+  
+  input[value=""] - pointerover
+  input[value=""] - pointerenter
+  input[value=""] - mouseover: Left (0)
+  input[value=""] - mouseenter: Left (0)
+  input[value=""] - pointermove
+  input[value=""] - mousemove: Left (0)
+  input[value=""] - pointerdown
+  input[value=""] - mousedown: Left (0)
+  input[value=""] - focus
+  input[value=""] - focusin
+  input[value=""] - pointerup
+  input[value=""] - mouseup: Left (0)
+  input[value=""] - click: Left (0)
+  input[value=""] - keydown: 0 (48)
+  input[value=""] - keypress: 0 (48)
+  input[value=""] - keyup: 0 (48)
+  input[value=""] - keydown: 1 (49)
+  input[value=""] - keypress: 1 (49)
+  input[value=""] - keyup: 1 (49)
+  input[value=""] - keydown: : (58)
+  input[value=""] - keypress: : (58)
+  input[value=""] - keyup: : (58)
+  input[value=""] - keydown: 0 (48)
+  input[value=""] - keypress: 0 (48)
+  input[value="01:00"] - input
+    "{CURSOR}" -> "{CURSOR}01:00"
+  input[value="01:00"] - change
+  input[value="01:00"] - keyup: 0 (48)
+  input[value="01:00"] - keydown: 5 (53)
+  input[value="01:00"] - keypress: 5 (53)
+  input[value="01:05"] - input
+    "{CURSOR}01:00" -> "{CURSOR}01:05"
+  input[value="01:05"] - change
+  input[value="01:05"] - keyup: 5 (53)
+  `)
+  expect(element.value).toBe('01:05')
+})
+
+test('can type into an input with type `time` without ":"', () => {
+  const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '0105')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
   Events fired on: input[value="01:05"]
@@ -1110,7 +1154,7 @@ test('can type into an input with type `time`', () => {
 
 test('can type more a number higher than 60 minutes into an input `time` and they are converted into 59 minutes', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
-  userEvent.type(element, '2390')
+  userEvent.type(element, '23:90')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="23:59"]
@@ -1134,6 +1178,9 @@ test('can type more a number higher than 60 minutes into an input `time` and the
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
     input[value=""] - keyup: 3 (51)
+    input[value=""] - keydown: : (58)
+    input[value=""] - keypress: : (58)
+    input[value=""] - keyup: : (58)
     input[value=""] - keydown: 9 (57)
     input[value=""] - keypress: 9 (57)
     input[value="23:09"] - input
@@ -1214,7 +1261,7 @@ test('can type letters into an input `time` and they are ignored', () => {
 
 test('can type a digit bigger in the hours section, bigger than 2 and it shows the time correctly', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
-  userEvent.type(element, '925')
+  userEvent.type(element, '9:25')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="09:25"]
@@ -1235,6 +1282,9 @@ test('can type a digit bigger in the hours section, bigger than 2 and it shows t
     input[value=""] - keydown: 9 (57)
     input[value=""] - keypress: 9 (57)
     input[value=""] - keyup: 9 (57)
+    input[value=""] - keydown: : (58)
+    input[value=""] - keypress: : (58)
+    input[value=""] - keyup: : (58)
     input[value=""] - keydown: 2 (50)
     input[value=""] - keypress: 2 (50)
     input[value="09:02"] - input
@@ -1254,7 +1304,7 @@ test('can type a digit bigger in the hours section, bigger than 2 and it shows t
 
 test('can type two digits in the hours section, equals to 24 and it shows the hours as 23', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
-  userEvent.type(element, '2452')
+  userEvent.type(element, '24:52')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="23:52"]
@@ -1278,6 +1328,9 @@ test('can type two digits in the hours section, equals to 24 and it shows the ho
     input[value=""] - keydown: 4 (52)
     input[value=""] - keypress: 4 (52)
     input[value=""] - keyup: 4 (52)
+    input[value=""] - keydown: : (58)
+    input[value=""] - keypress: : (58)
+    input[value=""] - keyup: : (58)
     input[value=""] - keydown: 5 (53)
     input[value=""] - keypress: 5 (53)
     input[value="23:05"] - input
@@ -1297,7 +1350,7 @@ test('can type two digits in the hours section, equals to 24 and it shows the ho
 
 test('can type two digits in the hours section, bigger than 24 and less than 30, and it shows the hours as 23', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
-  userEvent.type(element, '2752')
+  userEvent.type(element, '27:52')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="23:52"]
@@ -1321,6 +1374,9 @@ test('can type two digits in the hours section, bigger than 24 and less than 30,
     input[value=""] - keydown: 7 (55)
     input[value=""] - keypress: 7 (55)
     input[value=""] - keyup: 7 (55)
+    input[value=""] - keydown: : (58)
+    input[value=""] - keypress: : (58)
+    input[value=""] - keyup: : (58)
     input[value=""] - keydown: 5 (53)
     input[value=""] - keypress: 5 (53)
     input[value="23:05"] - input

--- a/src/type.js
+++ b/src/type.js
@@ -13,7 +13,7 @@ import {
   getSelectionRange,
   getValue,
   isContentEditable,
-  isValidInputTimevalue,
+  isValidInputTimeValue,
   buildTimeValue,
 } from './utils'
 import {click} from './click'
@@ -327,7 +327,7 @@ function typeCharacter(
       }
 
       const timeNewEntry = buildTimeValue(textToBeTyped)
-      if (isValidInputTimevalue(currentElement(), timeNewEntry)) {
+      if (isValidInputTimeValue(currentElement(), timeNewEntry)) {
         newEntry = timeNewEntry
       }
 
@@ -391,7 +391,7 @@ function fireChangeForInputTimeIfValid(
   timeNewEntry,
 ) {
   if (
-    isValidInputTimevalue(currentElement(), timeNewEntry) &&
+    isValidInputTimeValue(currentElement(), timeNewEntry) &&
     prevValue !== timeNewEntry
   ) {
     fireEvent.change(currentElement(), {target: {value: timeNewEntry}})

--- a/src/type.js
+++ b/src/type.js
@@ -13,6 +13,8 @@ import {
   getSelectionRange,
   getValue,
   isContentEditable,
+  isValidInputTimevalue,
+  buildTimeValue,
 } from './utils'
 import {click} from './click'
 import {navigationKey} from './keys/navigation-key'
@@ -324,6 +326,11 @@ function typeCharacter(
         newEntry = textToBeTyped
       }
 
+      const timeNewEntry = buildTimeValue(textToBeTyped)
+      if (isValidInputTimevalue(currentElement(), timeNewEntry)) {
+        newEntry = timeNewEntry
+      }
+
       const inputEvent = fireInputEventIfNeeded({
         ...calculateNewValue(newEntry, currentElement()),
         eventOverrides: {
@@ -338,6 +345,8 @@ function typeCharacter(
       if (isValidDateValue(currentElement(), textToBeTyped)) {
         fireEvent.change(currentElement(), {target: {value: textToBeTyped}})
       }
+
+      fireChangeForInputTimeIfValid(currentElement, prevValue, timeNewEntry)
 
       // typing "-" into a number input will not actually update the value
       // so for the next character we type, the value should be set to
@@ -373,6 +382,19 @@ function typeCharacter(
     prevWasPeriod: nextPrevWasPeriod,
     prevValue,
     typedValue: textToBeTyped,
+  }
+}
+
+function fireChangeForInputTimeIfValid(
+  currentElement,
+  prevValue,
+  timeNewEntry,
+) {
+  if (
+    isValidInputTimevalue(currentElement(), timeNewEntry) &&
+    prevValue !== timeNewEntry
+  ) {
+    fireEvent.change(currentElement(), {target: {value: timeNewEntry}})
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,6 +176,14 @@ function calculateNewValue(newEntry, element) {
     newValue = value
   }
 
+  if (element.type === 'time' && !isValidInputTimevalue(element, newValue)) {
+    if (isValidInputTimevalue(element, newEntry)) {
+      newValue = newEntry
+    } else {
+      newValue = value
+    }
+  }
+
   if (!supportsMaxLength(element) || maxLength < 0) {
     return {newValue, newSelectionStart}
   } else {
@@ -269,6 +277,47 @@ function isValidDateValue(element, value) {
   return clone.value === value
 }
 
+function buildTimeValue(value) {
+  function build(onlyDigitsValue, index) {
+    const hours = onlyDigitsValue.slice(0, index)
+    const validHours = Math.min(parseInt(hours, 10), 23)
+    const minuteCharacters = onlyDigitsValue.slice(index)
+    const parsedMinutes = parseInt(minuteCharacters, 10)
+    const validMinutes = Math.min(parsedMinutes, 59)
+    return `${validHours
+      .toString()
+      .padStart(2, '0')}:${validMinutes.toString().padStart(2, '0')}`
+  }
+
+  const onlyDigitsValue = value.replace(/\D/g, '')
+  if (onlyDigitsValue.length < 2) {
+    return value
+  }
+  const firstDigit = parseInt(onlyDigitsValue[0], 10)
+  const secondDigit = parseInt(onlyDigitsValue[1], 10)
+  if (firstDigit >= 3 || (firstDigit === 2 && secondDigit >= 4)) {
+    let index
+    if (firstDigit >= 3) {
+      index = 1
+    } else {
+      index = 2
+    }
+    return build(onlyDigitsValue, index)
+  }
+  if (value.length === 2) {
+    return value
+  }
+  return build(onlyDigitsValue, 2)
+}
+
+function isValidInputTimevalue(element, timeValue) {
+  if (element.type !== 'time') return false
+
+  const clone = element.cloneNode()
+  clone.value = timeValue
+  return clone.value === timeValue
+}
+
 export {
   FOCUSABLE_SELECTOR,
   isFocusable,
@@ -280,6 +329,8 @@ export {
   setSelectionRangeIfNecessary,
   eventWrapper,
   isValidDateValue,
+  isValidInputTimevalue,
+  buildTimeValue,
   getValue,
   getSelectionRange,
   isContentEditable,

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,8 +176,8 @@ function calculateNewValue(newEntry, element) {
     newValue = value
   }
 
-  if (element.type === 'time' && !isValidInputTimevalue(element, newValue)) {
-    if (isValidInputTimevalue(element, newEntry)) {
+  if (element.type === 'time' && !isValidInputTimeValue(element, newValue)) {
+    if (isValidInputTimeValue(element, newEntry)) {
       newValue = newEntry
     } else {
       newValue = value
@@ -310,7 +310,7 @@ function buildTimeValue(value) {
   return build(onlyDigitsValue, 2)
 }
 
-function isValidInputTimevalue(element, timeValue) {
+function isValidInputTimeValue(element, timeValue) {
   if (element.type !== 'time') return false
 
   const clone = element.cloneNode()
@@ -329,7 +329,7 @@ export {
   setSelectionRangeIfNecessary,
   eventWrapper,
   isValidDateValue,
-  isValidInputTimevalue,
+  isValidInputTimeValue,
   buildTimeValue,
   getValue,
   getSelectionRange,


### PR DESCRIPTION
**What**: Adding support for `<input type="time" />`. Check #484 

**Why**: That type of input does not work. It does with `fireEvent`, though

**How**: Adding the functionality for it. I had to interpret the typed characters to hours and minutes, adding the `:` between both.

**Checklist**:

- [x] Documentation
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged