### PR TITLE
feat: add capslock to userEvent.type

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,14 @@ import userEvent from '@testing-library/user-event'
 
 // or
 
-const { default: userEvent } = require('@testing-library/user-event')
+const {default: userEvent} = require('@testing-library/user-event')
 ```
 
 ## API
 
 Note: All userEvent methods are synchronous with one exception: when `delay`
-with `userEvent.type` as described below). We also discourage using
-`userEvent` inside `before/after` blocks at all, for important reasons
-described in
+with `userEvent.type` as described below). We also discourage using `userEvent`
+inside `before/after` blocks at all, for important reasons described in
 ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
 
 ### `click(element, eventInit, options)`
@@ -189,20 +188,21 @@ to `await`!
 
 The following special character strings are supported:
 
-| Text string    | Key        | Modifier   | Notes                                                                                                                                                               |
-| -------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{enter}`      | Enter      | N/A        | Will insert a newline character (`<textarea />` only).                                                                                                              |
-| `{space}`      | `' '`      | N/A        |                                                                                                                                                                     |
-| `{esc}`        | Escape     | N/A        |                                                                                                                                                                     |
-| `{backspace}`  | Backspace  | N/A        | Will delete the previous character (or the characters within the `selectedRange`, see example below).                                                               |
-| `{del}`        | Delete     | N/A        | Will delete the next character (or the characters within the `selectedRange`, see example below)                                                                    |
-| `{selectall}`  | N/A        | N/A        | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
-| `{arrowleft}`  | ArrowLeft  | N/A        |                                                                                                                                                                     |
-| `{arrowright}` | ArrowRight | N/A        |                                                                                                                                                                     |
-| `{shift}`      | Shift      | `shiftKey` | Does **not** capitalize following characters.                                                                                                                       |
-| `{ctrl}`       | Control    | `ctrlKey`  |                                                                                                                                                                     |
-| `{alt}`        | Alt        | `altKey`   |                                                                                                                                                                     |
-| `{meta}`       | OS         | `metaKey`  |                                                                                                                                                                     |
+| Text string    | Key        | Modifier           | Notes                                                                                                                                                               |
+| -------------- | ---------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{enter}`      | Enter      | N/A                | Will insert a newline character (`<textarea />` only).                                                                                                              |
+| `{space}`      | `' '`      | N/A                |                                                                                                                                                                     |
+| `{esc}`        | Escape     | N/A                |                                                                                                                                                                     |
+| `{backspace}`  | Backspace  | N/A                | Will delete the previous character (or the characters within the `selectedRange`, see example below).                                                               |
+| `{del}`        | Delete     | N/A                | Will delete the next character (or the characters within the `selectedRange`, see example below)                                                                    |
+| `{selectall}`  | N/A        | N/A                | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
+| `{arrowleft}`  | ArrowLeft  | N/A                |                                                                                                                                                                     |
+| `{arrowright}` | ArrowRight | N/A                |                                                                                                                                                                     |
+| `{shift}`      | Shift      | `shiftKey`         | Does **not** capitalize following characters.                                                                                                                       |
+| `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
+| `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
+| `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
+| `{capslock}`   | CapsLock   | `modifierCapsLock` |                                                                                                                                                                     |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration
@@ -609,6 +609,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following special character strings are supported:
 | `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
 | `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
 | `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
-| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used.                                                                                                                             |
+| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                                                                                             |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following special character strings are supported:
 | `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
 | `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
 | `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
-| `{capslock}`   | CapsLock   | `modifierCapsLock` |                                                                                                                                                                     |
+| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used.                                                                                                                             |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration

--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -375,11 +375,13 @@ test('{capslock}a{/capslock}', () => {
     input[value=""] - mouseup: Left (0)
     input[value=""] - click: Left (0)
     input[value=""] - keydown: CapsLock (20)
+    input[value=""] - keyup: CapsLock (20)
     input[value=""] - keydown: a (97)
     input[value=""] - keypress: a (97)
     input[value="a"] - input
       "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97)
+    input[value="a"] - keydown: CapsLock (20)
     input[value="a"] - keyup: CapsLock (20)
   `)
 })

--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -353,6 +353,37 @@ test('{shift}a{/shift}', () => {
   `)
 })
 
+test('{capslock}a{/capslock}', () => {
+  const {element, getEventSnapshot} = setup('<input />')
+
+  userEvent.type(element, '{capslock}a{/capslock}')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="a"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: CapsLock (20)
+    input[value=""] - keydown: a (97)
+    input[value=""] - keypress: a (97)
+    input[value="a"] - input
+      "{CURSOR}" -> "a{CURSOR}"
+    input[value="a"] - keyup: a (97)
+    input[value="a"] - keyup: CapsLock (20)
+  `)
+})
+
 test('a{enter}', () => {
   const {element, getEventSnapshot} = setup('<input />')
 

--- a/src/type.js
+++ b/src/type.js
@@ -42,6 +42,12 @@ const modifierCallbackMap = {
     keyCode: 93,
     modifierProperty: 'metaKey',
   }),
+  ...createModifierCallbackEntries({
+    name: 'capslock',
+    key: 'CapsLock',
+    keyCode: 20,
+    modifierProperty: 'modifierCapsLock',
+  }),
 }
 
 const specialCharCallbackMap = {

--- a/src/type.js
+++ b/src/type.js
@@ -42,12 +42,47 @@ const modifierCallbackMap = {
     keyCode: 93,
     modifierProperty: 'metaKey',
   }),
-  ...createCapsLockModifierCallbackEntries({
-    name: 'capslock',
-    key: 'CapsLock',
-    keyCode: 20,
-    modifierProperty: 'modifierCapsLock',
-  }),
+  // capslock is inline because of the need to fire both keydown and keyup on use, while preserving the modifier state.
+  '{capslock}': function capslockOn({currentElement, eventOverrides}) {
+    const newEventOverrides = {modifierCapsLock: true}
+
+    fireEvent.keyDown(currentElement(), {
+      key: 'CapsLock',
+      keyCode: 20,
+      which: 20,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+    fireEvent.keyUp(currentElement(), {
+      key: 'CapsLock',
+      keyCode: 20,
+      which: 20,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+
+    return {eventOverrides: newEventOverrides}
+  },
+  '{/capslock}': function capslockOff({currentElement, eventOverrides}) {
+    const newEventOverrides = {modifierCapsLock: false}
+
+    fireEvent.keyDown(currentElement(), {
+      key: 'CapsLock',
+      keyCode: 20,
+      which: 20,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+    fireEvent.keyUp(currentElement(), {
+      key: 'CapsLock',
+      keyCode: 20,
+      which: 20,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+
+    return {eventOverrides: newEventOverrides}
+  },
 }
 
 const specialCharCallbackMap = {
@@ -470,62 +505,6 @@ function createModifierCallbackEntries({name, key, keyCode, modifierProperty}) {
   function close({currentElement, eventOverrides}) {
     const newEventOverrides = {[modifierProperty]: false}
 
-    fireEvent.keyUp(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
-
-    return {eventOverrides: newEventOverrides}
-  }
-  return {
-    [openName]: open,
-    [closeName]: close,
-  }
-}
-
-function createCapsLockModifierCallbackEntries({
-  name,
-  key,
-  keyCode,
-  modifierProperty,
-}) {
-  const openName = `{${name}}`
-  const closeName = `{/${name}}`
-
-  function open({currentElement, eventOverrides}) {
-    const newEventOverrides = {[modifierProperty]: true}
-
-    fireEvent.keyDown(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
-    fireEvent.keyUp(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
-
-    return {eventOverrides: newEventOverrides}
-  }
-  open.closeName = closeName
-  function close({currentElement, eventOverrides}) {
-    const newEventOverrides = {[modifierProperty]: false}
-
-    fireEvent.keyDown(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
     fireEvent.keyUp(currentElement(), {
       key,
       keyCode,

--- a/src/type.js
+++ b/src/type.js
@@ -42,7 +42,7 @@ const modifierCallbackMap = {
     keyCode: 93,
     modifierProperty: 'metaKey',
   }),
-  ...createModifierCallbackEntries({
+  ...createCapsLockModifierCallbackEntries({
     name: 'capslock',
     key: 'CapsLock',
     keyCode: 20,
@@ -455,68 +455,84 @@ function createModifierCallbackEntries({name, key, keyCode, modifierProperty}) {
 
   function open({currentElement, eventOverrides}) {
     const newEventOverrides = {[modifierProperty]: true}
-    switch (key) {
-      case 'CapsLock':
-        fireEvent.keyDown(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        fireEvent.keyUp(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        break
 
-      default:
-        fireEvent.keyDown(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        break
-    }
+    fireEvent.keyDown(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
 
     return {eventOverrides: newEventOverrides}
   }
   open.closeName = closeName
   function close({currentElement, eventOverrides}) {
     const newEventOverrides = {[modifierProperty]: false}
-    switch (key) {
-      case 'CapsLock':
-        fireEvent.keyDown(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        fireEvent.keyUp(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        break
 
-      default:
-        fireEvent.keyUp(currentElement(), {
-          key,
-          keyCode,
-          which: keyCode,
-          ...eventOverrides,
-          ...newEventOverrides,
-        })
-        break
-    }
+    fireEvent.keyUp(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+
+    return {eventOverrides: newEventOverrides}
+  }
+  return {
+    [openName]: open,
+    [closeName]: close,
+  }
+}
+
+function createCapsLockModifierCallbackEntries({
+  name,
+  key,
+  keyCode,
+  modifierProperty,
+}) {
+  const openName = `{${name}}`
+  const closeName = `{/${name}}`
+
+  function open({currentElement, eventOverrides}) {
+    const newEventOverrides = {[modifierProperty]: true}
+
+    fireEvent.keyDown(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+    fireEvent.keyUp(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+
+    return {eventOverrides: newEventOverrides}
+  }
+  open.closeName = closeName
+  function close({currentElement, eventOverrides}) {
+    const newEventOverrides = {[modifierProperty]: false}
+
+    fireEvent.keyDown(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
+    fireEvent.keyUp(currentElement(), {
+      key,
+      keyCode,
+      which: keyCode,
+      ...eventOverrides,
+      ...newEventOverrides,
+    })
 
     return {eventOverrides: newEventOverrides}
   }

--- a/src/type.js
+++ b/src/type.js
@@ -455,28 +455,68 @@ function createModifierCallbackEntries({name, key, keyCode, modifierProperty}) {
 
   function open({currentElement, eventOverrides}) {
     const newEventOverrides = {[modifierProperty]: true}
+    switch (key) {
+      case 'CapsLock':
+        fireEvent.keyDown(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        fireEvent.keyUp(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        break
 
-    fireEvent.keyDown(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
+      default:
+        fireEvent.keyDown(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        break
+    }
 
     return {eventOverrides: newEventOverrides}
   }
   open.closeName = closeName
   function close({currentElement, eventOverrides}) {
     const newEventOverrides = {[modifierProperty]: false}
+    switch (key) {
+      case 'CapsLock':
+        fireEvent.keyDown(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        fireEvent.keyUp(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        break
 
-    fireEvent.keyUp(currentElement(), {
-      key,
-      keyCode,
-      which: keyCode,
-      ...eventOverrides,
-      ...newEventOverrides,
-    })
+      default:
+        fireEvent.keyUp(currentElement(), {
+          key,
+          keyCode,
+          which: keyCode,
+          ...eventOverrides,
+          ...newEventOverrides,
+        })
+        break
+    }
 
     return {eventOverrides: newEventOverrides}
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding CapsLock to the modifier key support so that tests using CapsLock can be implemented.

<!-- Why are these changes necessary? -->

**Why**: When typing and using the CapsLock modifier, we need to be able to write tests that implement the CapsLock key.

<!-- How were these changes implemented? -->

**How**: Added a test to the type-modifiers file, then implemented the suggested changes from Kent C Dodds office hours to the type file.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [N/A] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
