### PR TITLE
feat(specialChars): Create and expose `specialChars` map

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ method.
 | backspace  | `{backspace}`  |
 | selectAll  | `{selectall}`  |
 | space      | `{space}`      |
-| whiteSpace | `' '`          |
+| whitespace | `' '`          |
 
 Usage example:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ change the state of the checkbox.
   - [`hover(element)`](#hoverelement)
   - [`unhover(element)`](#unhoverelement)
   - [`paste(element, text, eventInit, options)`](#pasteelement-text-eventinit-options)
+  - [`specialChars`](#specialchars)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -202,7 +203,7 @@ The following special character strings are supported:
 | `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
 | `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
 | `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
-| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                                                                                             |
+| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                    |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration
@@ -491,6 +492,44 @@ test('should paste text in input', () => {
 You can use the `eventInit` if what you're pasting should have `clipboardData`
 (like `files`).
 
+### `specialChars`
+
+A handful set of special characters used in [type](#type) method.
+
+| Key        | Character      |
+| ---------- | -------------- |
+| arrowLeft  | `{arrowleft}`  |
+| arrowRight | `{arrowright}` |
+| enter      | `{enter}`      |
+| escape     | `{esc}`        |
+| delete     | `{del}`        |
+| backspace  | `{backspace}`  |
+| selectAll  | `{selectall}`  |
+| space      | `{space}`      |
+| whiteSpace | `' '`          |
+
+Usage example:
+
+```jsx
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent, {specialChars} from '@testing-library/user-event'
+
+test('delete characters within the selectedRange', () => {
+  render(
+    <div>
+      <label htmlFor="my-input">Example:</label>
+      <input id="my-input" type="text" value="This is a bad example" />
+    </div>,
+  )
+  const input = screen.getByLabelText(/example/i)
+  input.setSelectionRange(10, 13)
+  userEvent.type(input, `${specialChars.backspace}good`)
+
+  expect(input).toHaveValue('This is a good example')
+})
+```
+
 ## Issues
 
 _Looking to contribute? Look for the [Good First Issue][good-first-issue]
@@ -610,6 +649,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -494,7 +494,8 @@ You can use the `eventInit` if what you're pasting should have `clipboardData`
 
 ### `specialChars`
 
-A handful set of special characters used in [type](#type) method.
+A handful set of special characters used in [type](#typeelement-text-options)
+method.
 
 | Key        | Character      |
 | ---------- | -------------- |

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {click, dblClick} from './click'
-import {type} from './type'
+import {type, specialCharMap} from './type'
 import {clear} from './clear'
 import {tab} from './tab'
 import {hover, unhover} from './hover'
@@ -22,3 +22,5 @@ const userEvent = {
 }
 
 export default userEvent
+
+export {specialCharMap as specialChars}

--- a/src/type.js
+++ b/src/type.js
@@ -94,7 +94,7 @@ const specialCharMap = {
   backspace: '{backspace}',
   selectAll: '{selectall}',
   space: '{space}',
-  whiteSpace: ' ',
+  whitespace: ' ',
 }
 
 const specialCharCallbackMap = {
@@ -106,7 +106,7 @@ const specialCharCallbackMap = {
   [specialCharMap.backspace]: handleBackspace,
   [specialCharMap.selectAll]: handleSelectall,
   [specialCharMap.space]: handleSpace,
-  [specialCharMap.whiteSpace]: handleSpace,
+  [specialCharMap.whitespace]: handleSpace,
 }
 
 function wait(time) {

--- a/src/type.js
+++ b/src/type.js
@@ -85,16 +85,28 @@ const modifierCallbackMap = {
   },
 }
 
+const specialCharMap = {
+  arrowLeft: '{arrowleft}',
+  arrowRight: '{arrowright}',
+  enter: '{enter}',
+  escape: '{esc}',
+  delete: '{del}',
+  backspace: '{backspace}',
+  selectAll: '{selectall}',
+  space: '{space}',
+  whiteSpace: ' ',
+}
+
 const specialCharCallbackMap = {
-  '{arrowleft}': navigationKey('ArrowLeft'),
-  '{arrowright}': navigationKey('ArrowRight'),
-  '{enter}': handleEnter,
-  '{esc}': handleEsc,
-  '{del}': handleDel,
-  '{backspace}': handleBackspace,
-  '{selectall}': handleSelectall,
-  '{space}': handleSpace,
-  ' ': handleSpace,
+  [specialCharMap.arrowLeft]: navigationKey('ArrowLeft'),
+  [specialCharMap.arrowRight]: navigationKey('ArrowRight'),
+  [specialCharMap.enter]: handleEnter,
+  [specialCharMap.escape]: handleEsc,
+  [specialCharMap.delete]: handleDel,
+  [specialCharMap.backspace]: handleBackspace,
+  [specialCharMap.selectAll]: handleSelectall,
+  [specialCharMap.space]: handleSpace,
+  [specialCharMap.whiteSpace]: handleSpace,
 }
 
 function wait(time) {
@@ -711,4 +723,4 @@ function handleSpaceOnClickable({currentElement, eventOverrides}) {
   }
 }
 
-export {type}
+export {type, specialCharMap}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -83,5 +83,5 @@ export enum specialChars {
   backspace = '{backspace}',
   selectAll = '{selectall}',
   space = '{space}',
-  whiteSpace = ' ',
+  whitespace = ' ',
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -73,3 +73,15 @@ declare const userEvent: {
 }
 
 export default userEvent
+
+export enum specialChars {
+  arrowLeft = '{arrowleft}',
+  arrowRight = '{arrowright}',
+  enter = '{enter}',
+  escape = '{esc}',
+  delete = '{del}',
+  backspace = '{backspace}',
+  selectAll = '{selectall}',
+  space = '{space}',
+  whiteSpace = ' ',
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Create and expose `specialChars` map

<!-- Why are these changes necessary? -->

**Why**:
* It can help to avoid typos providing the constant values;
* Instead of creating the set manually in each project again and again, it could be more convenient to use the official, always up-to-date one.

<!-- How were these changes implemented? -->

**How**:
* Create a constant `specialCharMap`
* Link it with `specialCharCallbackMap`
* Export the constant from `src/type.js` and create a named export of the constant called `specialChars` in `src/index.js`
* Add an appropriate enum in `typings/index.d.ts` called `specialChars`
* Add `specialChars` section to `README.md`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [ ] Tests
- [X] Typings
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
P.S.: I've defined enum because `const` is not allowed in `index.d.ts`. If `src/type.js` could be written in TypeScript, it could be possible to use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) syntax instead, so the `specialCharMap` constant could be a single source of truth.
