### PR TITLE
Support arrowup and arrowdown events

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,13 @@ The following special character strings are supported:
 | `{selectall}`  | N/A        | N/A                | Selects all the text of the element. Note that this will only work for elements that support selection ranges (so, not `email`, `password`, `number`, among others) |
 | `{arrowleft}`  | ArrowLeft  | N/A                |                                                                                                                                                                     |
 | `{arrowright}` | ArrowRight | N/A                |                                                                                                                                                                     |
+| `{arrowup}`    | ArrowUp    | N/A                |                                                                                                                                                                     |
+| `{arrowdown}`  | ArrowDown  | N/A                |                                                                                                                                                                     |
 | `{shift}`      | Shift      | `shiftKey`         | Does **not** capitalize following characters.                                                                                                                       |
 | `{ctrl}`       | Control    | `ctrlKey`          |                                                                                                                                                                     |
 | `{alt}`        | Alt        | `altKey`           |                                                                                                                                                                     |
 | `{meta}`       | OS         | `metaKey`          |                                                                                                                                                                     |
-| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                                                                                             |
+| `{capslock}`   | CapsLock   | `modifierCapsLock` | Fires both keydown and keyup when used (simulates a user clicking their "Caps Lock" button to enable caps lock).                                                    |
 
 > **A note about modifiers:** Modifier keys (`{shift}`, `{ctrl}`, `{alt}`,
 > `{meta}`) will activate their corresponding event modifiers for the duration
@@ -610,6 +612,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1066,3 +1066,59 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
     input[value="abc"] - keyup: c (99)
   `)
 })
+
+test('{arrowdown} fires keyup/keydown events', () => {
+  const {element} = setup('<input />')
+  const handleKeyDown = jest.fn()
+  const handleKeyUp = jest.fn()
+
+  addListeners(element, {
+    eventHandlers: {
+      keyDown: handleKeyDown,
+      keyUp: handleKeyUp,
+    },
+  })
+
+  userEvent.type(element, '{arrowdown}')
+
+  expect(handleKeyDown).toHaveBeenCalledWith(
+    expect.objectContaining({
+      key: 'ArrowDown',
+      keyCode: 40,
+    }),
+  )
+  expect(handleKeyUp).toHaveBeenCalledWith(
+    expect.objectContaining({
+      key: 'ArrowDown',
+      keyCode: 40,
+    }),
+  )
+})
+
+test('{arrowup} fires keyup/keydown events', () => {
+  const {element} = setup('<input />')
+  const handleKeyDown = jest.fn()
+  const handleKeyUp = jest.fn()
+
+  addListeners(element, {
+    eventHandlers: {
+      keyDown: handleKeyDown,
+      keyUp: handleKeyUp,
+    },
+  })
+
+  userEvent.type(element, '{arrowup}')
+
+  expect(handleKeyDown).toHaveBeenCalledWith(
+    expect.objectContaining({
+      key: 'ArrowUp',
+      keyCode: 38,
+    }),
+  )
+  expect(handleKeyUp).toHaveBeenCalledWith(
+    expect.objectContaining({
+      key: 'ArrowUp',
+      keyCode: 38,
+    }),
+  )
+})

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1068,57 +1068,53 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
 })
 
 test('{arrowdown} fires keyup/keydown events', () => {
-  const {element} = setup('<input />')
-  const handleKeyDown = jest.fn()
-  const handleKeyUp = jest.fn()
-
-  addListeners(element, {
-    eventHandlers: {
-      keyDown: handleKeyDown,
-      keyUp: handleKeyUp,
-    },
-  })
+  const {element, getEventSnapshot} = setup('<input />')
 
   userEvent.type(element, '{arrowdown}')
 
-  expect(handleKeyDown).toHaveBeenCalledWith(
-    expect.objectContaining({
-      key: 'ArrowDown',
-      keyCode: 40,
-    }),
-  )
-  expect(handleKeyUp).toHaveBeenCalledWith(
-    expect.objectContaining({
-      key: 'ArrowDown',
-      keyCode: 40,
-    }),
-  )
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value=""]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: ArrowDown (40)
+    input[value=""] - keyup: ArrowDown (40)
+  `)
 })
 
 test('{arrowup} fires keyup/keydown events', () => {
-  const {element} = setup('<input />')
-  const handleKeyDown = jest.fn()
-  const handleKeyUp = jest.fn()
-
-  addListeners(element, {
-    eventHandlers: {
-      keyDown: handleKeyDown,
-      keyUp: handleKeyUp,
-    },
-  })
+  const {element, getEventSnapshot} = setup('<input />')
 
   userEvent.type(element, '{arrowup}')
 
-  expect(handleKeyDown).toHaveBeenCalledWith(
-    expect.objectContaining({
-      key: 'ArrowUp',
-      keyCode: 38,
-    }),
-  )
-  expect(handleKeyUp).toHaveBeenCalledWith(
-    expect.objectContaining({
-      key: 'ArrowUp',
-      keyCode: 38,
-    }),
-  )
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value=""]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: ArrowUp (38)
+    input[value=""] - keyup: ArrowUp (38)
+  `)
 })

--- a/src/type.js
+++ b/src/type.js
@@ -88,6 +88,8 @@ const modifierCallbackMap = {
 const specialCharCallbackMap = {
   '{arrowleft}': navigationKey('ArrowLeft'),
   '{arrowright}': navigationKey('ArrowRight'),
+  '{arrowdown}': handleArrowDown,
+  '{arrowup}': handleArrowUp,
   '{enter}': handleEnter,
   '{esc}': handleEsc,
   '{del}': handleDel,
@@ -709,6 +711,44 @@ function handleSpaceOnClickable({currentElement, eventOverrides}) {
       ...eventOverrides,
     })
   }
+}
+
+function handleArrowDown({currentElement, eventOverrides}) {
+  const key = 'ArrowDown'
+  const keyCode = 40
+
+  fireEvent.keyDown(currentElement(), {
+    key,
+    keyCode,
+    which: keyCode,
+    ...eventOverrides,
+  })
+
+  fireEvent.keyUp(currentElement(), {
+    key,
+    keyCode,
+    which: keyCode,
+    ...eventOverrides,
+  })
+}
+
+function handleArrowUp({currentElement, eventOverrides}) {
+  const key = 'ArrowUp'
+  const keyCode = 38
+
+  fireEvent.keyDown(currentElement(), {
+    key,
+    keyCode,
+    which: keyCode,
+    ...eventOverrides,
+  })
+
+  fireEvent.keyUp(currentElement(), {
+    key,
+    keyCode,
+    which: keyCode,
+    ...eventOverrides,
+  })
 }
 
 export {type}


### PR DESCRIPTION
**What**:

These changes add support for the arrow up and down keys to `userEvent.type`.

**Why**:

Arrow up and down keys are used for various accessibility reasons and are part of regular user actions.

**How**:

I added two functions, `handleArrowDown` and `handleArrowUp`, and tied those into the existing special character map.

**Checklist**:

- [x] Documentation
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged

Unless something unexpected comes up, this is probably ready for merging immediately.

Closes #503 
