### PR TITLE
docs: toHaveAttribute doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ test('click', () => {
   )
 
   userEvent.click(screen.getByText('Check'))
-  expect(screen.getByLabelText('Check')).toHaveAttribute('checked', true)
+  expect(screen.getByLabelText('Check')).toBeChecked()
 })
 ```
 


### PR DESCRIPTION
**What**:

Hi, I'm new to this project. While just following the README.md, I noticed that the very first example test code doesn't work.

```js
  ✕ click (90 ms)

  ● click

    expect(element).toHaveAttribute("checked", true) // element.getAttribute("checked") === true

    Expected the element to have attribute:
      checked=true
    Received:
      null
```

I realized that using `toBeChecked()` makes the test pass.

**Why**:

I played around with this checkbox on the dev tools on my browser and I noticed that the `checked` attribute doesn't actually get added to the input element when I clicked the checkbox.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [ ] Typings N/A
- [ ] Ready to be merged N/A
