### PR TITLE
docs: getByTestId doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ import userEvent from '@testing-library/user-event'
 
 test('double click', () => {
   const onChange = jest.fn()
-  render(<input type="checkbox" id="checkbox" onChange={onChange} />)
-  const checkbox = screen.getByTestId('checkbox')
+  render(<input type="checkbox" onChange={onChange} />)
+  const checkbox = screen.getByRole('checkbox')
   userEvent.dblClick(checkbox)
   expect(onChange).toHaveBeenCalledTimes(2)
   expect(checkbox).not.toBeChecked()


### PR DESCRIPTION
**What**:

Hi, it's me again! I also noticed that the second example test code in READE.md doesn't work.

```js
  ✕ double click (24 ms)

  ● double click

    TestingLibraryElementError: Unable to find an element by: [data-testid="checkbox"]

    <body>
      <div>
        <input
          id="checkbox"
          type="checkbox"
        />
      </div>
    </body>

       8 |   const onChange = jest.fn();
       9 |   render(<input type="checkbox" id="checkbox" onChange={onChange} />);
    > 10 |   const checkbox = screen.getByTestId("checkbox");
         |                           ^
      11 |   userEvent.dblClick(checkbox);
      12 | 
```

To fix this, we can add a `data-testid` attribute to the input element but I thought it would be better to query by role because it only renders a single checkbox.

**Checklist**:

- [X] Documentation
- [ ] Tests N/A
- [ ] Typings N/A
- [ ] Ready to be merged N/A