### PR TITLE
docs: Remove duplicated content on special chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,47 +521,6 @@ test('should paste text in input', () => {
 You can use the `eventInit` if what you're pasting should have `clipboardData`
 (like `files`).
 
-### `specialChars`
-
-A handful set of special characters used in [type](#typeelement-text-options)
-method.
-
-| Key        | Character      |
-| ---------- | -------------- |
-| arrowLeft  | `{arrowleft}`  |
-| arrowRight | `{arrowright}` |
-| arrowDown  | `{arrowdown}`  |
-| arrowUp    | `{arrowup}`    |
-| enter      | `{enter}`      |
-| escape     | `{esc}`        |
-| delete     | `{del}`        |
-| backspace  | `{backspace}`  |
-| selectAll  | `{selectall}`  |
-| space      | `{space}`      |
-| whitespace | `' '`          |
-
-Usage example:
-
-```jsx
-import React from 'react'
-import {render, screen} from '@testing-library/react'
-import userEvent, {specialChars} from '@testing-library/user-event'
-
-test('delete characters within the selectedRange', () => {
-  render(
-    <div>
-      <label htmlFor="my-input">Example:</label>
-      <input id="my-input" type="text" value="This is a bad example" />
-    </div>,
-  )
-  const input = screen.getByLabelText(/example/i)
-  input.setSelectionRange(10, 13)
-  userEvent.type(input, `${specialChars.backspace}good`)
-
-  expect(input).toHaveValue('This is a good example')
-})
-```
-
 ## Issues
 
 _Looking to contribute? Look for the [Good First Issue][good-first-issue]


### PR DESCRIPTION
**What**:

The content on special chars that can be used in `type` method is already covered [above](https://github.com/testing-library/user-event#special-characters).

**Checklist**:

- [X] Documentation
- [ ] Tests N/A
- [ ] Typings N/A
- [ ] Ready to be merged N/A