### PR TITLE
fix(upload): accept File or File[] #529

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -6,16 +6,14 @@ import {focus} from './focus'
 function upload(element, fileOrFiles, init) {
   if (element.disabled) return
 
-  let files
-  let input = element
-
   click(element, init)
-  if (element.tagName === 'LABEL') {
-    files = element.control.multiple ? fileOrFiles : [fileOrFiles]
-    input = element.control
-  } else {
-    files = element.multiple ? fileOrFiles : [fileOrFiles]
-  }
+
+  const input = element.tagName === 'LABEL' ? element.control : element
+
+  const files = (Array.isArray(fileOrFiles)
+    ? fileOrFiles
+    : [fileOrFiles]
+  ).slice(0, input.multiple ? undefined : 1)
 
   // blur fires when the file selector pops up
   blur(element, init)


### PR DESCRIPTION
**What**:

```js
const f = new File(/*...*/)

// these two will be equivalent
userEvent.upload(element, [f])
userEvent.upload(element, f)
```

**Why**:

Previous implementation required the user to provide `File` for single file inputs and `File[]` for multiple file inputs.

**How**:

Convert to an array if it is not.
Truncate to length 1 if input is not multiple.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Typings N/A
- [x] Ready to be merged
