### PR TITLE
Support 'Enter' key press on links

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1121,43 +1121,43 @@ test('can type into an input with type `time`', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '01:05')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-  Events fired on: input[value="01:05"]
-  
-  input[value=""] - pointerover
-  input[value=""] - pointerenter
-  input[value=""] - mouseover: Left (0)
-  input[value=""] - mouseenter: Left (0)
-  input[value=""] - pointermove
-  input[value=""] - mousemove: Left (0)
-  input[value=""] - pointerdown
-  input[value=""] - mousedown: Left (0)
-  input[value=""] - focus
-  input[value=""] - focusin
-  input[value=""] - pointerup
-  input[value=""] - mouseup: Left (0)
-  input[value=""] - click: Left (0)
-  input[value=""] - keydown: 0 (48)
-  input[value=""] - keypress: 0 (48)
-  input[value=""] - keyup: 0 (48)
-  input[value=""] - keydown: 1 (49)
-  input[value=""] - keypress: 1 (49)
-  input[value=""] - keyup: 1 (49)
-  input[value=""] - keydown: : (58)
-  input[value=""] - keypress: : (58)
-  input[value=""] - keyup: : (58)
-  input[value=""] - keydown: 0 (48)
-  input[value=""] - keypress: 0 (48)
-  input[value="01:00"] - input
-    "{CURSOR}" -> "{CURSOR}01:00"
-  input[value="01:00"] - change
-  input[value="01:00"] - keyup: 0 (48)
-  input[value="01:00"] - keydown: 5 (53)
-  input[value="01:00"] - keypress: 5 (53)
-  input[value="01:05"] - input
-    "{CURSOR}01:00" -> "{CURSOR}01:05"
-  input[value="01:05"] - change
-  input[value="01:05"] - keyup: 5 (53)
-  `)
+      Events fired on: input[value="01:05"]
+
+      input[value=""] - pointerover
+      input[value=""] - pointerenter
+      input[value=""] - mouseover: Left (0)
+      input[value=""] - mouseenter: Left (0)
+      input[value=""] - pointermove
+      input[value=""] - mousemove: Left (0)
+      input[value=""] - pointerdown
+      input[value=""] - mousedown: Left (0)
+      input[value=""] - focus
+      input[value=""] - focusin
+      input[value=""] - pointerup
+      input[value=""] - mouseup: Left (0)
+      input[value=""] - click: Left (0)
+      input[value=""] - keydown: 0 (48)
+      input[value=""] - keypress: 0 (48)
+      input[value=""] - keyup: 0 (48)
+      input[value=""] - keydown: 1 (49)
+      input[value=""] - keypress: 1 (49)
+      input[value=""] - keyup: 1 (49)
+      input[value=""] - keydown: : (58)
+      input[value=""] - keypress: : (58)
+      input[value=""] - keyup: : (58)
+      input[value=""] - keydown: 0 (48)
+      input[value=""] - keypress: 0 (48)
+      input[value="01:00"] - input
+        "{CURSOR}" -> "{CURSOR}01:00"
+      input[value="01:00"] - change
+      input[value="01:00"] - keyup: 0 (48)
+      input[value="01:00"] - keydown: 5 (53)
+      input[value="01:00"] - keypress: 5 (53)
+      input[value="01:05"] - input
+        "{CURSOR}01:00" -> "{CURSOR}01:05"
+      input[value="01:05"] - change
+      input[value="01:05"] - keyup: 5 (53)
+    `)
   expect(element).toHaveValue('01:05')
 })
 
@@ -1165,40 +1165,40 @@ test('can type into an input with type `time` without ":"', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '0105')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-  Events fired on: input[value="01:05"]
-  
-  input[value=""] - pointerover
-  input[value=""] - pointerenter
-  input[value=""] - mouseover: Left (0)
-  input[value=""] - mouseenter: Left (0)
-  input[value=""] - pointermove
-  input[value=""] - mousemove: Left (0)
-  input[value=""] - pointerdown
-  input[value=""] - mousedown: Left (0)
-  input[value=""] - focus
-  input[value=""] - focusin
-  input[value=""] - pointerup
-  input[value=""] - mouseup: Left (0)
-  input[value=""] - click: Left (0)
-  input[value=""] - keydown: 0 (48)
-  input[value=""] - keypress: 0 (48)
-  input[value=""] - keyup: 0 (48)
-  input[value=""] - keydown: 1 (49)
-  input[value=""] - keypress: 1 (49)
-  input[value=""] - keyup: 1 (49)
-  input[value=""] - keydown: 0 (48)
-  input[value=""] - keypress: 0 (48)
-  input[value="01:00"] - input
-    "{CURSOR}" -> "{CURSOR}01:00"
-  input[value="01:00"] - change
-  input[value="01:00"] - keyup: 0 (48)
-  input[value="01:00"] - keydown: 5 (53)
-  input[value="01:00"] - keypress: 5 (53)
-  input[value="01:05"] - input
-    "{CURSOR}01:00" -> "{CURSOR}01:05"
-  input[value="01:05"] - change
-  input[value="01:05"] - keyup: 5 (53)
-  `)
+      Events fired on: input[value="01:05"]
+
+      input[value=""] - pointerover
+      input[value=""] - pointerenter
+      input[value=""] - mouseover: Left (0)
+      input[value=""] - mouseenter: Left (0)
+      input[value=""] - pointermove
+      input[value=""] - mousemove: Left (0)
+      input[value=""] - pointerdown
+      input[value=""] - mousedown: Left (0)
+      input[value=""] - focus
+      input[value=""] - focusin
+      input[value=""] - pointerup
+      input[value=""] - mouseup: Left (0)
+      input[value=""] - click: Left (0)
+      input[value=""] - keydown: 0 (48)
+      input[value=""] - keypress: 0 (48)
+      input[value=""] - keyup: 0 (48)
+      input[value=""] - keydown: 1 (49)
+      input[value=""] - keypress: 1 (49)
+      input[value=""] - keyup: 1 (49)
+      input[value=""] - keydown: 0 (48)
+      input[value=""] - keypress: 0 (48)
+      input[value="01:00"] - input
+        "{CURSOR}" -> "{CURSOR}01:00"
+      input[value="01:00"] - change
+      input[value="01:00"] - keyup: 0 (48)
+      input[value="01:00"] - keydown: 5 (53)
+      input[value="01:00"] - keypress: 5 (53)
+      input[value="01:05"] - input
+        "{CURSOR}01:00" -> "{CURSOR}01:05"
+      input[value="01:05"] - change
+      input[value="01:05"] - keyup: 5 (53)
+    `)
   expect(element).toHaveValue('01:05')
 })
 
@@ -1208,7 +1208,7 @@ test('can type more a number higher than 60 minutes into an input `time` and the
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="23:59"]
-    
+
     input[value=""] - pointerover
     input[value=""] - pointerenter
     input[value=""] - mouseover: Left (0)
@@ -1254,7 +1254,7 @@ test('can type letters into an input `time` and they are ignored', () => {
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="16:36"]
-    
+
     input[value=""] - pointerover
     input[value=""] - pointerenter
     input[value=""] - mouseover: Left (0)
@@ -1493,5 +1493,24 @@ test('{arrowup} fires keyup/keydown events', () => {
     input[value=""] - click: Left (0)
     input[value=""] - keydown: ArrowUp (38)
     input[value=""] - keyup: ArrowUp (38)
+  `)
+})
+
+test('{enter} fires click on links', () => {
+  const {element, getEventSnapshot} = setup('<a href="#">link</a>')
+
+  element?.focus()
+
+  userEvent.type(element, '{enter}', {skipClick: true})
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: a
+
+    a - focus
+    a - focusin
+    a - keydown: Enter (13)
+    a - keypress: Enter (13)
+    a - click: Left (0)
+    a - keyup: Enter (13)
   `)
 })

--- a/src/type.js
+++ b/src/type.js
@@ -8,7 +8,7 @@ import {
   getActiveElement,
   calculateNewValue,
   setSelectionRangeIfNecessary,
-  isClickable,
+  isClickableInput,
   isValidDateValue,
   getSelectionRange,
   getValue,
@@ -321,7 +321,7 @@ function fireInputEventIfNeeded({
   const prevValue = getValue(currentElement())
   if (
     !currentElement().readOnly &&
-    !isClickable(currentElement()) &&
+    !isClickableInput(currentElement()) &&
     newValue !== prevValue
   ) {
     if (isContentEditable(currentElement())) {
@@ -583,7 +583,11 @@ function handleEnter({currentElement, eventOverrides}) {
     })
 
     if (keyPressDefaultNotPrevented) {
-      if (isClickable(currentElement())) {
+      if (
+        isClickableInput(currentElement()) ||
+        // Links with href handle Enter the same as a click
+        (currentElement().tagName === 'A' && currentElement().href)
+      ) {
         fireEvent.click(currentElement(), {
           ...eventOverrides,
         })
@@ -712,7 +716,7 @@ function handleSelectall({currentElement}) {
 }
 
 function handleSpace(context) {
-  if (isClickable(context.currentElement())) {
+  if (isClickableInput(context.currentElement())) {
     handleSpaceOnClickable(context)
     return
   }

--- a/src/type.js
+++ b/src/type.js
@@ -15,6 +15,7 @@ import {
   isContentEditable,
   isValidInputTimeValue,
   buildTimeValue,
+  isInstanceOfElement,
 } from './utils'
 import {click} from './click'
 import {navigationKey} from './keys/navigation-key'
@@ -585,8 +586,9 @@ function handleEnter({currentElement, eventOverrides}) {
     if (keyPressDefaultNotPrevented) {
       if (
         isClickableInput(currentElement()) ||
-        // Links with href handle Enter the same as a click
-        (currentElement().tagName === 'A' && currentElement().href)
+        // Links with href defined should handle Enter the same as a click
+        (isInstanceOfElement(currentElement(), 'HTMLAnchorElement') &&
+          currentElement().href)
       ) {
         fireEvent.click(currentElement(), {
           ...eventOverrides,

--- a/src/utils.js
+++ b/src/utils.js
@@ -288,6 +288,7 @@ const CLICKABLE_INPUT_TYPES = [
 function isClickable(element) {
   return (
     element.tagName === 'BUTTON' ||
+    (element.tagName === 'A' && element.href) ||
     (isInstanceOfElement(element, 'HTMLInputElement') &&
       CLICKABLE_INPUT_TYPES.includes(element.type))
   )

--- a/src/utils.js
+++ b/src/utils.js
@@ -285,10 +285,9 @@ const CLICKABLE_INPUT_TYPES = [
   'submit',
 ]
 
-function isClickable(element) {
+function isClickableInput(element) {
   return (
     element.tagName === 'BUTTON' ||
-    (element.tagName === 'A' && element.href) ||
     (isInstanceOfElement(element, 'HTMLInputElement') &&
       CLICKABLE_INPUT_TYPES.includes(element.type))
   )
@@ -354,7 +353,7 @@ function isValidInputTimeValue(element, timeValue) {
 export {
   FOCUSABLE_SELECTOR,
   isFocusable,
-  isClickable,
+  isClickableInput,
   getMouseEventOptions,
   isLabelWithInternallyDisabledControl,
   getActiveElement,

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,8 @@ import {getWindowFromNode} from '@testing-library/dom/dist/helpers'
 /**
  * Check if an element is of a given type.
  *
- * @param Element The element to test
- * @param string Constructor name. E.g. 'HTMLSelectElement'
+ * @param {Element} element The element to test
+ * @param {string} elementType Constructor name. E.g. 'HTMLSelectElement'
  */
 function isInstanceOfElement(element, elementType) {
   try {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: in `handleEnter`, there is currently a check for whether the element is clickable, and if it is, it fires a click event on that element. This PR includes anchor tags (with truthy `href` values) in that check.

<!-- Why are these changes necessary? -->

**Why**: anchor tags are incorrectly missed out of this logic – browsers fire click events on anchor tags when they are focused and the user presses the `Enter` key.

<!-- How were these changes implemented? -->

**How**: included anchor tags in the `isClickable` util function.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] ~~Documentation~~ N/A
- [x] Tests
- [x] ~~Typings~~ N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
