### PR TITLE
fix: selectOptions

### DIFF
--- a/src/__tests__/helpers/utils.js
+++ b/src/__tests__/helpers/utils.js
@@ -74,6 +74,17 @@ function setupListbox() {
   document.body.append(wrapper)
   const listbox = wrapper.querySelector('[role="listbox"]')
   const options = Array.from(wrapper.querySelectorAll('[role="option"]'))
+
+  // the user is responsible for handling aria-selected on listbox options
+  options.forEach(el =>
+    el.addEventListener('click', e =>
+      e.target.setAttribute(
+        'aria-selected',
+        JSON.stringify(!JSON.parse(e.target.getAttribute('aria-selected'))),
+      ),
+    ),
+  )
+
   return {
     ...addListeners(listbox),
     listbox,

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -35,17 +35,6 @@ test('fires correct events on listBox select', () => {
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: ul[value="2"]
 
-    ul - pointerover
-    ul - pointerenter
-    ul - mouseover: Left (0)
-    ul - mouseenter: Left (0)
-    ul - pointermove
-    ul - mousemove: Left (0)
-    ul - pointerdown
-    ul - mousedown: Left (0)
-    ul - pointerup
-    ul - mouseup: Left (0)
-    ul - click: Left (0)
     li#2[value="2"][aria-selected=true] - pointerover
     ul[value="2"] - pointerenter
     li#2[value="2"][aria-selected=true] - mouseover: Left (0)

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -42,22 +42,22 @@ test('fires correct events on listBox select', () => {
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: ul[value="2"]
 
-    li#2[value="2"][aria-selected=true] - pointerover
-    ul[value="2"] - pointerenter
-    li#2[value="2"][aria-selected=true] - mouseover: Left (0)
-    ul[value="2"] - mouseenter: Left (0)
-    li#2[value="2"][aria-selected=true] - pointermove
-    li#2[value="2"][aria-selected=true] - mousemove: Left (0)
-    li#2[value="2"][aria-selected=true] - pointerover
-    ul[value="2"] - pointerenter
-    li#2[value="2"][aria-selected=true] - mouseover: Left (0)
-    ul[value="2"] - mouseenter: Left (0)
-    li#2[value="2"][aria-selected=true] - pointermove
-    li#2[value="2"][aria-selected=true] - mousemove: Left (0)
-    li#2[value="2"][aria-selected=true] - pointerdown
-    li#2[value="2"][aria-selected=true] - mousedown: Left (0)
-    li#2[value="2"][aria-selected=true] - pointerup
-    li#2[value="2"][aria-selected=true] - mouseup: Left (0)
+    li#2[value="2"][aria-selected=false] - pointerover
+    ul - pointerenter
+    li#2[value="2"][aria-selected=false] - mouseover: Left (0)
+    ul - mouseenter: Left (0)
+    li#2[value="2"][aria-selected=false] - pointermove
+    li#2[value="2"][aria-selected=false] - mousemove: Left (0)
+    li#2[value="2"][aria-selected=false] - pointerover
+    ul - pointerenter
+    li#2[value="2"][aria-selected=false] - mouseover: Left (0)
+    ul - mouseenter: Left (0)
+    li#2[value="2"][aria-selected=false] - pointermove
+    li#2[value="2"][aria-selected=false] - mousemove: Left (0)
+    li#2[value="2"][aria-selected=false] - pointerdown
+    li#2[value="2"][aria-selected=false] - mousedown: Left (0)
+    li#2[value="2"][aria-selected=false] - pointerup
+    li#2[value="2"][aria-selected=false] - mouseup: Left (0)
     li#2[value="2"][aria-selected=true] - click: Left (0)
     li#2[value="2"][aria-selected=true] - pointermove
     li#2[value="2"][aria-selected=true] - mousemove: Left (0)

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -22,6 +22,13 @@ test('fires correct events', () => {
     select[name="select"][value="1"] - click: Left (0)
     select[name="select"][value="2"] - input
     select[name="select"][value="2"] - change
+    select[name="select"][value="2"] - pointerover
+    select[name="select"][value="2"] - pointerenter
+    select[name="select"][value="2"] - mouseover: Left (0)
+    select[name="select"][value="2"] - mouseenter: Left (0)
+    select[name="select"][value="2"] - pointerup
+    select[name="select"][value="2"] - mouseup: Left (0)
+    select[name="select"][value="2"] - click: Left (0)
   `)
   const [o1, o2, o3] = options
   expect(o1.selected).toBe(false)

--- a/src/__tests__/select-options.js
+++ b/src/__tests__/select-options.js
@@ -1,5 +1,5 @@
 import userEvent from '../'
-import {setupSelect, addListeners, setupListbox} from './helpers/utils'
+import {setupSelect, addListeners, setupListbox, setup} from './helpers/utils'
 
 test('fires correct events', () => {
   const {select, options, getEventSnapshot} = setupSelect()
@@ -144,6 +144,13 @@ test('a previously focused input gets blurred', () => {
     button - blur
     button - focusout
   `)
+})
+
+test('throws an error if elements is neither select nor listbox', () => {
+  const {element} = setup(`<ul><li role='option'>foo</li></ul>`)
+  expect(() => userEvent.selectOptions(element, ['foo'])).toThrowError(
+    /neither select nor listbox/i,
+  )
 })
 
 test('throws an error one selected option does not match', () => {

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -55,8 +55,20 @@ function selectOptionsBase(newValue, select, values, init) {
         fireEvent.click(option, init)
       }
     } else if (selectedOptions.length === 1) {
+      // the click to open the select options
       click(select, init)
+
       selectOption(selectedOptions[0])
+
+      // the browser triggers another click event on the select for the click on the option
+      // this second click has no 'down' phase
+      fireEvent.pointerOver(select, init)
+      fireEvent.pointerEnter(select, init)
+      fireEvent.mouseOver(select)
+      fireEvent.mouseEnter(select)
+      fireEvent.pointerUp(select, init)
+      fireEvent.mouseUp(select, init)
+      fireEvent.click(select, init)
     } else {
       throw getConfig().getElementError(
         `Cannot select multiple options on a non-multiple select`,

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -77,8 +77,6 @@ function selectOptionsBase(newValue, select, values, init) {
     }
   } else if (select.getAttribute('role') === 'listbox') {
     selectedOptions.forEach(option => {
-      option?.setAttribute?.('aria-selected', newValue)
-
       hover(option, init)
       click(option, init)
       unhover(option, init)

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -36,53 +36,55 @@ function selectOptionsBase(newValue, select, values, init) {
 
   if (select.disabled || !selectedOptions.length) return
 
-  if (select.multiple) {
-    for (const option of selectedOptions) {
-      // events fired for multiple select are weird. Can't use hover...
-      fireEvent.pointerOver(option, init)
-      fireEvent.pointerEnter(select, init)
-      fireEvent.mouseOver(option)
-      fireEvent.mouseEnter(select)
-      fireEvent.pointerMove(option, init)
-      fireEvent.mouseMove(option, init)
-      fireEvent.pointerDown(option, init)
-      fireEvent.mouseDown(option, init)
-      focus(select, init)
-      fireEvent.pointerUp(option, init)
-      fireEvent.mouseUp(option, init)
-      selectOption(option)
-      fireEvent.click(option, init)
+  if (select instanceof HTMLSelectElement) {
+    if (select.multiple) {
+      for (const option of selectedOptions) {
+        // events fired for multiple select are weird. Can't use hover...
+        fireEvent.pointerOver(option, init)
+        fireEvent.pointerEnter(select, init)
+        fireEvent.mouseOver(option)
+        fireEvent.mouseEnter(select)
+        fireEvent.pointerMove(option, init)
+        fireEvent.mouseMove(option, init)
+        fireEvent.pointerDown(option, init)
+        fireEvent.mouseDown(option, init)
+        focus(select, init)
+        fireEvent.pointerUp(option, init)
+        fireEvent.mouseUp(option, init)
+        selectOption(option)
+        fireEvent.click(option, init)
+      }
+    } else if (selectedOptions.length === 1) {
+      click(select, init)
+      selectOption(selectedOptions[0])
+    } else {
+      throw getConfig().getElementError(
+        `Cannot select multiple options on a non-multiple select`,
+        select,
+      )
     }
-  } else if (selectedOptions.length === 1) {
-    click(select, init)
-    selectOption(selectedOptions[0])
-  } else {
-    throw getConfig().getElementError(
-      `Cannot select multiple options on a non-multiple select`,
-      select,
-    )
-  }
-
-  function selectOption(option) {
-    if (option.getAttribute('role') === 'option') {
+  } else if (select.getAttribute('role') === 'listbox') {
+    selectedOptions.forEach(option => {
       option?.setAttribute?.('aria-selected', newValue)
 
       hover(option, init)
       click(option, init)
       unhover(option, init)
-    } else {
-      option.selected = newValue
-      fireEvent(
-        select,
-        createEvent('input', select, {
-          bubbles: true,
-          cancelable: false,
-          composed: true,
-          ...init,
-        }),
-      )
-      fireEvent.change(select, init)
-    }
+    })
+  }
+
+  function selectOption(option) {
+    option.selected = newValue
+    fireEvent(
+      select,
+      createEvent('input', select, {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        ...init,
+      }),
+    )
+    fireEvent.change(select, init)
   }
 }
 

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -81,6 +81,11 @@ function selectOptionsBase(newValue, select, values, init) {
       click(option, init)
       unhover(option, init)
     })
+  } else {
+    throw getConfig().getElementError(
+      `Cannot select options on elements that are neither select nor listbox elements`,
+      select,
+    )
   }
 
   function selectOption(option) {


### PR DESCRIPTION
**What**:

These changes fix bugs on selectOptions.

**Why**:

1. `selectOptions` failed to trigger correct events on options with `role` attribute. - see #542
2. `selectOptions` missed pointer events that happen when selecting an option of regular `<select>`.
3. `selectOptions` made the false assumption the browser would change `aria-selected` attributes when clicking an element with `role="option"`.

See https://codesandbox.io/s/user-event-changle-handler-with-role-forked-d5ubs?file=/src/LoggingSelects.js for tracking events that actually happen in the browser.

**How**:

1. Decide which event pattern to follow based on element type of the `listbox` instead of `role` attribute of the `option`.
2. Add the pointer events observed in the browser.
3. Move event handling into utility component and fix the EventSnapshot.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
