### PR TITLE
Do not assume global HTMLSelectElement

### DIFF
--- a/src/select-options.js
+++ b/src/select-options.js
@@ -36,7 +36,7 @@ function selectOptionsBase(newValue, select, values, init) {
 
   if (select.disabled || !selectedOptions.length) return
 
-  if (select instanceof HTMLSelectElement) {
+  if (select instanceof select.ownerDocument.defaultView.HTMLSelectElement) {
     if (select.multiple) {
       for (const option of selectedOptions) {
         // events fired for multiple select are weird. Can't use hover...


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Do not assume that `HTMLSelectElement` is defined globally.

<!-- Why are these changes necessary? -->

**Why**: Running Node without a shimmed browser environment has no browser globals.

<!-- How were these changes implemented? -->

**How**: Following patterns elsewhere in the code, lookup HTMLSelectElement from the `document`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [ ] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I've not added any tests here. I think there may be value in a suite of tests that verifies the library functions in a non-dom environment but didn't want to bloat the PR.
