### PR TITLE
fix: check element type in different environments

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,0 +1,73 @@
+import {isInstanceOfElement} from '../utils'
+import {setup} from './helpers/utils'
+
+// isInstanceOfElement can be removed once the peerDependency for @testing-library/dom is bumped to a version that includes https://github.com/testing-library/dom-testing-library/pull/885
+describe('check element type per isInstanceOfElement', () => {
+  let defaultViewDescriptor, spanDescriptor
+  beforeAll(() => {
+    defaultViewDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(global.document),
+      'defaultView',
+    )
+    spanDescriptor = Object.getOwnPropertyDescriptor(
+      global.window,
+      'HTMLSpanElement',
+    )
+  })
+  afterEach(() => {
+    Object.defineProperty(
+      Object.getPrototypeOf(global.document),
+      'defaultView',
+      defaultViewDescriptor,
+    )
+    Object.defineProperty(global.window, 'HTMLSpanElement', spanDescriptor)
+  })
+
+  test('check in regular jest environment', () => {
+    const {element} = setup(`<span></span>`)
+
+    expect(element.ownerDocument.defaultView).toEqual(
+      expect.objectContaining({
+        HTMLSpanElement: expect.any(Function),
+      }),
+    )
+
+    expect(isInstanceOfElement(element, 'HTMLSpanElement')).toBe(true)
+    expect(isInstanceOfElement(element, 'HTMLDivElement')).toBe(false)
+  })
+
+  test('check in detached document', () => {
+    const {element} = setup(`<span></span>`)
+
+    Object.defineProperty(
+      Object.getPrototypeOf(element.ownerDocument),
+      'defaultView',
+      {value: null},
+    )
+
+    expect(element.ownerDocument.defaultView).toBe(null)
+
+    expect(isInstanceOfElement(element, 'HTMLSpanElement')).toBe(true)
+    expect(isInstanceOfElement(element, 'HTMLDivElement')).toBe(false)
+  })
+
+  test('check in environment not providing constructors on window', () => {
+    const {element} = setup(`<span></span>`)
+
+    delete global.window.HTMLSpanElement
+
+    expect(element.ownerDocument.defaultView.HTMLSpanElement).toBe(undefined)
+
+    expect(isInstanceOfElement(element, 'HTMLSpanElement')).toBe(true)
+    expect(isInstanceOfElement(element, 'HTMLDivElement')).toBe(false)
+  })
+
+  test('throw error if element is not created by HTML*Element constructor', () => {
+    const doc = new Document()
+
+    // constructor is global.Element
+    const element = doc.createElement('span')
+
+    expect(() => isInstanceOfElement(element, 'HTMLSpanElement')).toThrow()
+  })
+})

--- a/src/select-options.js
+++ b/src/select-options.js
@@ -1,4 +1,5 @@
 import {createEvent, getConfig, fireEvent} from '@testing-library/dom'
+import {isInstanceOfElement} from './utils'
 import {click} from './click'
 import {focus} from './focus'
 import {hover, unhover} from './hover'
@@ -36,7 +37,7 @@ function selectOptionsBase(newValue, select, values, init) {
 
   if (select.disabled || !selectedOptions.length) return
 
-  if (select instanceof HTMLSelectElement) {
+  if (isInstanceOfElement(select, 'HTMLSelectElement')) {
     if (select.multiple) {
       for (const option of selectedOptions) {
         // events fired for multiple select are weird. Can't use hover...


### PR DESCRIPTION
Add a helper to verify the element type in different environments.

**What**:

Add a helper to utils.
This can be removed from this library and replaced by a shared helper in `@testing-library/dom` once it is bumped to a version that includes https://github.com/testing-library/dom-testing-library/pull/885.

**Why**:

See #550 

**How**:

The helper tries to find the element constructor on the window.

As the window is neither required to be associated with the observed document nor is it required to provide any element constructors, the helper provides a fallback for other environments than Jest+JSDOM.

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
