### PR TITLE
Don't allow tabbing to elements inside hidden parents

### DIFF
--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -17,7 +17,7 @@ test('fires events when tabbing between two elements', () => {
   userEvent.tab()
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: div
-    
+
     input#a[value=""] - keydown: Tab (9)
     input#a[value=""] - focusout
     input#b[value=""] - focusin
@@ -45,7 +45,7 @@ test('does not change focus if default prevented on keydown', () => {
   userEvent.tab()
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: div
-    
+
     input#a[value=""] - keydown: Tab (9)
     input#a[value=""] - keyup: Tab (9)
   `)
@@ -416,6 +416,26 @@ test('should not focus disabled elements', () => {
 
   userEvent.tab()
   expect(five).toHaveFocus()
+})
+
+test('should not focus elements inside a hidden parent', () => {
+  setup(`
+    <div>
+      <input data-testid="one" />
+      <div hidden="">
+        <button>click</button>
+      </div>
+      <input data-testid="three" />
+    </div>`)
+
+  const one = document.querySelector('[data-testid="one"]')
+  const three = document.querySelector('[data-testid="three"]')
+
+  userEvent.tab()
+  expect(one).toHaveFocus()
+
+  userEvent.tab()
+  expect(three).toHaveFocus()
 })
 
 test('should keep focus on the document if there are no enabled, focusable elements', () => {

--- a/src/tab.js
+++ b/src/tab.js
@@ -31,7 +31,11 @@ function tab({shift = false, focusTrap} = {}) {
   const enabledElements = [...focusableElements].filter(
     el =>
       el === previousElement ||
-      (el.getAttribute('tabindex') !== '-1' && !el.disabled),
+      (el.getAttribute('tabindex') !== '-1' &&
+        !el.disabled &&
+        // Hidden elements are taken out of the
+        // document, along with all their children.
+        !el.closest('[hidden]')),
   )
 
   if (enabledElements.length === 0) return


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Don't allow tabbing to elements inside hidden parents.

<!-- Why are these changes necessary? -->

**Why**: I _think_ this correctly matches browser behaviour.

<!-- How were these changes implemented? -->

**How**: Add a `!el.closest('[hidden]')` check in the focusable elements filter.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] Typings N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
