### PR TITLE
feat(upload): accept filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,14 @@ test('types into the input', () => {
 })
 ```
 
-### `upload(element, file, [{ clickInit, changeInit }])`
+### `upload(element, file, [{ clickInit, changeInit }], [options])`
 
 Uploads file to an `<input>`. For uploading multiple files use `<input>` with
 `multiple` attribute and the second `upload` argument must be array then. Also
 it's possible to initialize click or change event with using third argument.
+
+If `options.applyAccept` is set to `true` and there is an `accept` attribute on
+the element, files that don't match will be discarded.
 
 ```jsx
 import React from 'react'

--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -163,3 +163,55 @@ test('should call onChange/input bubbling up the event when a file is selected',
   expect(onInputInput).toHaveBeenCalledTimes(1)
   expect(onInputForm).toHaveBeenCalledTimes(1)
 })
+
+test('should upload file with accepted format', () => {
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+  const {element} = setup('<input type="file" accept="image/png" />')
+
+  userEvent.upload(element, file)
+
+  expect(element.files).toHaveLength(1)
+})
+
+test('should upload multiple files with accepted format', () => {
+  const files = [
+    new File(['hello'], 'hello.png', {type: 'image/png'}),
+    new File(['there'], 'there.jpg', {type: 'audio/mp3'}),
+    new File(['there'], 'there.csv', {type: 'text/csv'}),
+    new File(['there'], 'there.jpg', {type: 'video/mp4'}),
+  ]
+  const {element} = setup(`
+    <input 
+      type="file" 
+      accept="video/*,audio/*,.png" multiple 
+    />
+  `)
+
+  userEvent.upload(element, files)
+
+  expect(element.files).toHaveLength(3)
+})
+
+test('should not upload file with unaccepted format', () => {
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+  const {element} = setup('<input type="file" accept="image/jpg" />')
+
+  userEvent.upload(element, file)
+
+  expect(element.files).toHaveLength(0)
+})
+
+test('should not upload multiple files with unaccepted formats', () => {
+  const files = [
+    new File(['hello'], 'hello.txt', {type: 'text/plain'}),
+    new File(['there'], 'there.pdf', {type: 'application/pdf'}),
+    new File(['there'], 'there.png', {type: 'image/png'}),
+  ]
+  const {element} = setup(`
+    <input id="files" type="file" accept="video/*" multiple />
+  `)
+
+  userEvent.upload(element, files)
+
+  expect(element.files).toHaveLength(0)
+})

--- a/src/upload.js
+++ b/src/upload.js
@@ -10,15 +10,19 @@ function upload(element, fileOrFiles, init) {
 
   const input = element.tagName === 'LABEL' ? element.control : element
 
-  const files = (Array.isArray(fileOrFiles)
-    ? fileOrFiles
-    : [fileOrFiles]
-  ).slice(0, input.multiple ? undefined : 1)
+  const files = (Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles])
+    .filter(file => isAcceptableFile(file, element.accept))
+    .slice(0, input.multiple ? undefined : 1)
 
   // blur fires when the file selector pops up
   blur(element, init)
   // focus fires when they make their selection
   focus(element, init)
+
+  // treat empty array as if the user just closed the file upload dialog
+  if (files.length === 0) {
+    return
+  }
 
   // the event fired in the browser isn't actually an "input" or "change" event
   // but a new Event with a type set to "input" and "change"
@@ -43,6 +47,24 @@ function upload(element, fileOrFiles, init) {
   fireEvent.change(input, {
     target: {files: inputFiles},
     ...init,
+  })
+}
+
+function isAcceptableFile(file, accept) {
+  if (!accept) {
+    return true
+  }
+
+  const wildcards = ['audio/*', 'image/*', 'video/*']
+
+  return accept.split(',').some(acceptToken => {
+    if (acceptToken[0] === '.') {
+      // tokens starting with a dot represent a file extension
+      return file.name.endsWith(acceptToken)
+    } else if (wildcards.includes(acceptToken)) {
+      return file.type.startsWith(acceptToken.substr(0, acceptToken.length - 1))
+    }
+    return file.type === acceptToken
   })
 }
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -3,7 +3,7 @@ import {click} from './click'
 import {blur} from './blur'
 import {focus} from './focus'
 
-function upload(element, fileOrFiles, init) {
+function upload(element, fileOrFiles, init, {applyAccept = false} = {}) {
   if (element.disabled) return
 
   click(element, init)
@@ -11,7 +11,7 @@ function upload(element, fileOrFiles, init) {
   const input = element.tagName === 'LABEL' ? element.control : element
 
   const files = (Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles])
-    .filter(file => isAcceptableFile(file, element.accept))
+    .filter(file => !applyAccept || isAcceptableFile(file, element.accept))
     .slice(0, input.multiple ? undefined : 1)
 
   // blur fires when the file selector pops up

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -26,6 +26,10 @@ export interface IClickOptions {
   clickCount?: number
 }
 
+export interface IUploadOptions {
+  applyAccept?: boolean
+}
+
 declare const userEvent: {
   clear: (element: TargetElement) => void
   click: (
@@ -52,6 +56,7 @@ declare const userEvent: {
     element: TargetElement,
     files: FilesArgument,
     init?: UploadInitArgument,
+    options?: IUploadOptions,
   ) => void
   type: <T extends ITypeOpts>(
     element: TargetElement,


### PR DESCRIPTION
**What**:

Add `applyAccept` option to `userEvent.upload` that defaults to `false`.

**Why**:

Filtering the files for the the input causes problems for those testing their own filters.
https://github.com/testing-library/user-event/pull/558#issuecomment-783397519

Those who want to test their accept attributes can opt-in per:
```js
  userEvent.upload(element, files, undefined, { applyAccept: true })
```

**How**:

Add an options parameter to the API.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Typings
- [x] Ready to be merged

