### PR TITLE
fix(click): focus closest focusable (#566)

### DIFF
--- a/src/__tests__/click.js
+++ b/src/__tests__/click.js
@@ -442,3 +442,20 @@ test('calls FocusEvents with relatedTarget', () => {
     element0,
   )
 })
+
+test('move focus to closest focusable element', () => {
+  const {element} = setup(`
+    <div tabIndex="0">
+      <div>this is not focusable</div>
+      <button>this is focusable</button>
+    </div>
+  `)
+
+  document.body.focus()
+  userEvent.click(element.children[1])
+  expect(element.children[1]).toHaveFocus()
+
+  document.body.focus()
+  userEvent.click(element.children[0])
+  expect(element).toHaveFocus()
+})

--- a/src/click.js
+++ b/src/click.js
@@ -61,10 +61,7 @@ function clickElement(element, init, {clickCount}) {
       element,
       getMouseEventOptions('mousedown', init, clickCount),
     )
-    if (
-      continueDefaultHandling &&
-      element !== element.ownerDocument.activeElement
-    ) {
+    if (continueDefaultHandling) {
       const closestFocusable = findClosest(element, isFocusable)
       if (previousElement && !closestFocusable) {
         blur(previousElement, init)

--- a/src/click.js
+++ b/src/click.js
@@ -65,10 +65,11 @@ function clickElement(element, init, {clickCount}) {
       continueDefaultHandling &&
       element !== element.ownerDocument.activeElement
     ) {
-      if (previousElement && !isFocusable(element)) {
+      const closestFocusable = findClosest(element, isFocusable)
+      if (previousElement && !closestFocusable) {
         blur(previousElement, init)
-      } else {
-        focus(element, init)
+      } else if (closestFocusable) {
+        focus(closestFocusable, init)
       }
     }
   }
@@ -82,6 +83,16 @@ function clickElement(element, init, {clickCount}) {
     const parentLabel = element.closest('label')
     if (parentLabel?.control) focus(parentLabel.control, init)
   }
+}
+
+function findClosest(el, callback) {
+  do {
+    if (callback(el)) {
+      return el
+    }
+    el = el.parentElement
+  } while (el && el !== document.body)
+  return undefined
 }
 
 function click(element, init, {skipHover = false, clickCount = 0} = {}) {


### PR DESCRIPTION
**What**:

Focus closest focusable ancestor of the clicked element.

**Why**:

See #566 

**How**:

Only `blur()` if the clicked element does not have a focusable ancestor.

**Checklist**:

- n/a Documentation
- [x] Tests
- n/a Typings
- [x] Ready to be merged
