### PR TITLE
fix(typings): add home and end to specialChars enum

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -89,6 +89,8 @@ export enum specialChars {
   escape = '{esc}',
   delete = '{del}',
   backspace = '{backspace}',
+  home = '{home}',
+  end = '{end}',
   selectAll = '{selectall}',
   space = '{space}',
   whitespace = ' ',


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added home and end to the specialChars enum in typings

<!-- Why are these changes necessary? -->

**Why**: In PR #536 home and end typings were not added, so `specialChars.home` could not be used with typescipt

<!-- How were these changes implemented? -->

**How**: added the missing typings

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
