### PR TITLE
fix(tab): exclude hidden descendants

### DIFF
--- a/src/__tests__/tab.js
+++ b/src/__tests__/tab.js
@@ -17,7 +17,7 @@ test('fires events when tabbing between two elements', () => {
   userEvent.tab()
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: div
-    
+
     input#a[value=""] - keydown: Tab (9)
     input#a[value=""] - focusout
     input#b[value=""] - focusin
@@ -45,7 +45,7 @@ test('does not change focus if default prevented on keydown', () => {
   userEvent.tab()
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: div
-    
+
     input#a[value=""] - keydown: Tab (9)
     input#a[value=""] - keyup: Tab (9)
   `)
@@ -416,6 +416,26 @@ test('should not focus disabled elements', () => {
 
   userEvent.tab()
   expect(five).toHaveFocus()
+})
+
+test('should not focus elements inside a hidden parent', () => {
+  setup(`
+    <div>
+      <input data-testid="one" />
+      <div hidden="">
+        <button>click</button>
+      </div>
+      <input data-testid="three" />
+    </div>`)
+
+  const one = document.querySelector('[data-testid="one"]')
+  const three = document.querySelector('[data-testid="three"]')
+
+  userEvent.tab()
+  expect(one).toHaveFocus()
+
+  userEvent.tab()
+  expect(three).toHaveFocus()
 })
 
 test('should keep focus on the document if there are no enabled, focusable elements', () => {

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,4 +1,5 @@
-import {isInstanceOfElement} from '../utils'
+import { screen } from '@testing-library/dom'
+import {isInstanceOfElement, isVisible} from '../utils'
 import {setup} from './helpers/utils'
 
 // isInstanceOfElement can be removed once the peerDependency for @testing-library/dom is bumped to a version that includes https://github.com/testing-library/dom-testing-library/pull/885
@@ -70,4 +71,20 @@ describe('check element type per isInstanceOfElement', () => {
 
     expect(() => isInstanceOfElement(element, 'HTMLSpanElement')).toThrow()
   })
+})
+
+test('check if element is visible', () => {
+  setup(`
+    <input data-testid="visibleInput"/>
+    <input data-testid="hiddenInput" hidden/>
+    <input data-testid="styledHiddenInput" style="display: none">
+    <input data-testid="styledDisplayedInput" hidden style="display: block"/>
+    <div style="display: none"><input data-testid="childInput" /></div>
+  `)
+
+  expect(isVisible(screen.getByTestId('visibleInput'))).toBe(true)
+  expect(isVisible(screen.getByTestId('styledDisplayedInput'))).toBe(true)
+  expect(isVisible(screen.getByTestId('styledHiddenInput'))).toBe(false)
+  expect(isVisible(screen.getByTestId('childInput'))).toBe(false)
+  expect(isVisible(screen.getByTestId('hiddenInput'))).toBe(false)
 })

--- a/src/tab.js
+++ b/src/tab.js
@@ -1,5 +1,5 @@
 import {fireEvent} from '@testing-library/dom'
-import {getActiveElement, FOCUSABLE_SELECTOR} from './utils'
+import {getActiveElement, FOCUSABLE_SELECTOR, isVisible} from './utils'
 import {focus} from './focus'
 import {blur} from './blur'
 
@@ -33,9 +33,9 @@ function tab({shift = false, focusTrap} = {}) {
       el === previousElement ||
       (el.getAttribute('tabindex') !== '-1' &&
         !el.disabled &&
-        // Hidden elements are taken out of the
-        // document, along with all their children.
-        !el.closest('[hidden]')),
+        // Hidden elements are not tabable
+        isVisible(el)
+      ),
   )
 
   if (enabledElements.length === 0) return

--- a/src/tab.js
+++ b/src/tab.js
@@ -31,7 +31,11 @@ function tab({shift = false, focusTrap} = {}) {
   const enabledElements = [...focusableElements].filter(
     el =>
       el === previousElement ||
-      (el.getAttribute('tabindex') !== '-1' && !el.disabled),
+      (el.getAttribute('tabindex') !== '-1' &&
+        !el.disabled &&
+        // Hidden elements are taken out of the
+        // document, along with all their children.
+        !el.closest('[hidden]')),
   )
 
   if (enabledElements.length === 0) return

--- a/src/utils.js
+++ b/src/utils.js
@@ -293,6 +293,19 @@ function isClickable(element) {
   )
 }
 
+function isVisible(element) {
+  const getComputedStyle = getWindowFromNode(element).getComputedStyle
+
+  for(; element && element.ownerDocument; element = element.parentNode) {
+    const display = getComputedStyle(element).display
+    if (display === 'none') {
+      return false
+    }
+  }
+
+  return true
+}
+
 function eventWrapper(cb) {
   let result
   getConfig().eventWrapper(() => {
@@ -367,4 +380,5 @@ export {
   getSelectionRange,
   isContentEditable,
   isInstanceOfElement,
+  isVisible,
 }


### PR DESCRIPTION
**What**:

Exclude descendants of hidden elements.
Replaces #556 

**Why**:

Browser does not include hidden parts of the DOM tree in tab order.

**How**:

Run `window.getComputedStyle()` for every ancestor element.
If one is hidden, exclude the element from tab order.

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
