### PR TITLE
fix(keyboard): parse modifiers as characters

### DIFF
--- a/src/__tests__/keyboard/getNextKeyDef.ts
+++ b/src/__tests__/keyboard/getNextKeyDef.ts
@@ -19,6 +19,16 @@ cases(
           key,
           code,
         }) as keyboardKey,
+        consumedLength: text.length,
+      }),
+    )
+    expect(getNextKeyDef(`${text}/foo`, options)).toEqual(
+      expect.objectContaining({
+        keyDef: expect.objectContaining({
+          key,
+          code,
+        }) as keyboardKey,
+        consumedLength: text.length,
       }),
     )
   },
@@ -29,6 +39,7 @@ cases(
     'unimplemented key': {text: '{Foo}', key: 'Foo', code: 'Unknown'},
     'legacy modifier': {text: '{ctrl}', key: 'Control', code: 'ControlLeft'},
     'printable character': {text: 'a', key: 'a', code: 'KeyA'},
+    'modifiers as printable characters': {text: '/', key: '/', code: 'Unknown'},
     '{ as printable': {text: '{{', key: '{', code: 'Unknown'},
     '[ as printable': {text: '[[', key: '[', code: 'Unknown'},
   },

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1514,3 +1514,11 @@ test('{enter} fires click on links', () => {
     a - keyup: Enter (13)
   `)
 })
+
+test('type non-alphanumeric characters', () => {
+  const {element} = setup(`<input/>`)
+
+  userEvent.type(element, 'https://test.local')
+
+  expect(element).toHaveValue('https://test.local')
+})

--- a/src/keyboard/getNextKeyDef.ts
+++ b/src/keyboard/getNextKeyDef.ts
@@ -19,7 +19,7 @@ export function getNextKeyDef(
   releaseSelf: boolean
 } {
   const startBracket = ['{', '['].includes(text[0]) ? text[0] : ''
-  const startModifier = text[1] === '/' ? '/' : ''
+  const startModifier = startBracket && text[1] === '/' ? '/' : ''
 
   const descriptorStart = startBracket.length + startModifier.length
   const descriptor = startBracket
@@ -37,7 +37,9 @@ export function getNextKeyDef(
 
   const descriptorEnd = descriptorStart + descriptor.length
   const endModifier =
-    descriptor !== startBracket && ['/', '>'].includes(text[descriptorEnd])
+    startBracket &&
+    descriptor !== startBracket &&
+    ['/', '>'].includes(text[descriptorEnd])
       ? text[descriptorEnd]
       : ''
 


### PR DESCRIPTION
**What**:

Fix parsing modifiers as printable characters.

**Why**:

Closes #587 

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
