### PR TITLE
fix: right click triggers contextmenu

### DIFF
--- a/src/__tests__/click.js
+++ b/src/__tests__/click.js
@@ -459,3 +459,17 @@ test('move focus to closest focusable element', () => {
   userEvent.click(element.children[0])
   expect(element).toHaveFocus()
 })
+
+test('right click fires `contextmenu` instead of `click', () => {
+  const {element, getEvents, clearEventCalls} = setup(`<button/>`)
+
+  userEvent.click(element)
+  expect(getEvents('click')).toHaveLength(1)
+  expect(getEvents('contextmenu')).toHaveLength(0)
+
+  clearEventCalls()
+
+  userEvent.click(element, {buttons: 2})
+  expect(getEvents('contextmenu')).toHaveLength(1)
+  expect(getEvents('click')).toHaveLength(0)
+})

--- a/src/click.ts
+++ b/src/click.ts
@@ -38,7 +38,7 @@ function clickLabel(
   )
   fireEvent.pointerUp(label, init)
   fireEvent.mouseUp(label, getMouseEventOptions('mouseup', init, clickCount))
-  fireEvent.click(label, getMouseEventOptions('click', init, clickCount))
+  fireClick(label, getMouseEventOptions('click', init, clickCount))
   // clicking the label will trigger a click of the label.control
   // however, it will not focus the label.control so we have to do it
   // ourselves.
@@ -64,7 +64,7 @@ function clickBooleanElement(
       element,
       getMouseEventOptions('mouseup', init, clickCount),
     )
-    fireEvent.click(element, getMouseEventOptions('click', init, clickCount))
+    fireClick(element, getMouseEventOptions('click', init, clickCount))
   }
 }
 
@@ -95,7 +95,7 @@ function clickElement(
       element,
       getMouseEventOptions('mouseup', init, clickCount),
     )
-    fireEvent.click(element, getMouseEventOptions('click', init, clickCount))
+    fireClick(element, getMouseEventOptions('click', init, clickCount))
     const parentLabel = element.closest('label')
     if (parentLabel?.control) focus(parentLabel.control)
   }
@@ -130,6 +130,14 @@ function click(
     }
   } else {
     clickElement(element, init, {clickCount})
+  }
+}
+
+function fireClick(element: Element, mouseEventOptions: MouseEventInit) {
+  if (mouseEventOptions.button === 2) {
+    fireEvent.contextMenu(element, mouseEventOptions)
+  } else {
+    fireEvent.click(element, mouseEventOptions)
   }
 }
 


### PR DESCRIPTION
**What**:

Dispatch `contextmenu` instead of `click` for right button clicks.

**Why**:

Closes #445 

**How**:

Check `button === 2` before calling `fireEvent.click`/`fireEvent.contextmenu`

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
