### PR TITLE
fix(upload): implement iterable on input.files

### DIFF
--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -219,3 +219,19 @@ test('should not trigger input event when selected files are the same', () => {
   expect(eventWasFired('input')).toBe(true)
   expect(element.files).toHaveLength(0)
 })
+
+test('input.files implements iterable', () => {
+  const {element, getEvents} = setup(`<input type="file" multiple/>`)
+  const files = [
+    new File(['hello'], 'hello.png', {type: 'image/png'}),
+    new File(['there'], 'there.png', {type: 'image/png'}),
+  ]
+
+  userEvent.upload(element, files)
+  const eventTargetFiles = getEvents('input')[0].target.files
+
+  expect(eventTargetFiles).toBe(element.files)
+  expect(eventTargetFiles).not.toEqual(files)
+
+  expect(Array.from(eventTargetFiles)).toEqual(files)
+})

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -47,10 +47,19 @@ function upload(
   // the event fired in the browser isn't actually an "input" or "change" event
   // but a new Event with a type set to "input" and "change"
   // Kinda odd...
-  const inputFiles: FileList = {
+  const inputFiles: FileList & Iterable<File> = {
     ...files,
     length: files.length,
     item: (index: number) => files[index],
+    [Symbol.iterator]() {
+      let i = 0
+      return {
+        next: () => ({
+          done: i >= files.length,
+          value: files[i++],
+        }),
+      }
+    },
   }
 
   fireEvent(


### PR DESCRIPTION
**What**:

Implement [`iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) on `target.files`.

**Why**:

MDN states that [`HTMLInputElement.files`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#htmlattrdeffiles) is a [`FileList`](https://developer.mozilla.org/en-US/docs/Web/API/FileList).
The browser also implements the `iterable` on this object, and some libraries rely on it:
Closes #576 

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
