### PR TITLE
fix(paste): correct the paste event type (#512)

### DIFF
--- a/src/paste.ts
+++ b/src/paste.ts
@@ -14,7 +14,7 @@ interface pasteOptions {
 function paste(
   element: HTMLInputElement | HTMLTextAreaElement,
   text: string,
-  init?: MouseEventInit,
+  init?: ClipboardEventInit,
   {initialSelectionStart, initialSelectionEnd}: pasteOptions = {},
 ) {
   if (isDisabled(element)) {


### PR DESCRIPTION
**What**: Fix the event init type of paste by changing from MouseEventInit to ClipboardEventInit. This aligns with the type definition of fireEvent for pasting: https://github.com/testing-library/dom-testing-library/blob/master/src/event-map.js#L11-L14

**Why**: Types should be correct.

**How**: N/A

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [x] Typings
- [x] Ready to be merged