### PR TITLE
fix(keyboard): inputType for Enter on contenteditable

### DIFF
--- a/src/__tests__/keyboard/plugin/character.ts
+++ b/src/__tests__/keyboard/plugin/character.ts
@@ -4,19 +4,21 @@ import {setup} from '__tests__/helpers/utils'
 test('type [Enter] in textarea', () => {
   const {element, getEvents} = setup(`<textarea>f</textarea>`)
 
-  userEvent.type(element as HTMLTextAreaElement, 'oo[Enter]bar')
-
-  expect(element).toHaveValue('foo\nbar')
-  expect(getEvents('input')[2]).toHaveProperty('inputType', 'insertLineBreak')
-})
-
-test('type [Enter] in contenteditable', () => {
-  const {element, getEvents} = setup(`<div contenteditable="true">f</div>`)
-
   userEvent.type(
     element as HTMLTextAreaElement,
     'oo[Enter]bar[ShiftLeft>][Enter]baz',
   )
+
+  expect(element).toHaveValue('foo\nbar\nbaz')
+  expect(getEvents('input')[2]).toHaveProperty('inputType', 'insertLineBreak')
+  expect(getEvents('input')[6]).toHaveProperty('inputType', 'insertLineBreak')
+})
+
+test('type [Enter] in contenteditable', () => {
+  const {element, getEvents} = setup(`<div contenteditable="true">f</div>`)
+  ;(element as HTMLDivElement).focus()
+
+  userEvent.keyboard('oo[Enter]bar[ShiftLeft>][Enter]baz')
 
   expect(element).toHaveTextContent('foo bar baz')
   expect(element?.firstChild).toHaveProperty('nodeValue', 'foo\nbar\nbaz')

--- a/src/__tests__/keyboard/plugin/character.ts
+++ b/src/__tests__/keyboard/plugin/character.ts
@@ -2,18 +2,24 @@ import userEvent from 'index'
 import {setup} from '__tests__/helpers/utils'
 
 test('type [Enter] in textarea', () => {
-  const {element} = setup(`<textarea>f</textarea>`)
+  const {element, getEvents} = setup(`<textarea>f</textarea>`)
 
   userEvent.type(element as HTMLTextAreaElement, 'oo[Enter]bar')
 
   expect(element).toHaveValue('foo\nbar')
+  expect(getEvents('input')[2]).toHaveProperty('inputType', 'insertLineBreak')
 })
 
 test('type [Enter] in contenteditable', () => {
-  const {element} = setup(`<div contenteditable="true">f</div>`)
+  const {element, getEvents} = setup(`<div contenteditable="true">f</div>`)
 
-  userEvent.type(element as HTMLTextAreaElement, 'oo[Enter]bar')
+  userEvent.type(
+    element as HTMLTextAreaElement,
+    'oo[Enter]bar[ShiftLeft>][Enter]baz',
+  )
 
-  expect(element).toHaveTextContent('foo bar')
-  expect(element?.firstChild).toHaveProperty('nodeValue', 'foo\nbar')
+  expect(element).toHaveTextContent('foo bar baz')
+  expect(element?.firstChild).toHaveProperty('nodeValue', 'foo\nbar\nbaz')
+  expect(getEvents('input')[2]).toHaveProperty('inputType', 'insertParagraph')
+  expect(getEvents('input')[6]).toHaveProperty('inputType', 'insertLineBreak')
 })

--- a/src/keyboard/plugins/character.ts
+++ b/src/keyboard/plugins/character.ts
@@ -165,17 +165,22 @@ export const keypressBehavior: behaviorPlugin[] = [
       keyDef.key === 'Enter' &&
       (isInstanceOfElement(element, 'HTMLTextAreaElement') ||
         isContentEditable(element)),
-    handle: (keyDef, element) => {
+    handle: (keyDef, element, options, state) => {
       const {newValue, newSelectionStart} = calculateNewValue(
         '\n',
         element as HTMLElement,
       )
 
+      const inputType =
+        isContentEditable(element) && !state.modifiers.shift
+          ? 'insertParagraph'
+          : 'insertLineBreak'
+
       fireInputEventIfNeeded({
         newValue,
         newSelectionStart,
         eventOverrides: {
-          inputType: 'insertLineBreak',
+          inputType,
         },
         currentElement: () => element,
       })

--- a/src/utils/edit/getSelectionRange.ts
+++ b/src/utils/edit/getSelectionRange.ts
@@ -8,10 +8,9 @@ export function getSelectionRange(
 } {
   if (isContentEditable(element)) {
     const selection = element.ownerDocument.getSelection()
-    const range = selection?.getRangeAt(0)
 
-    // istanbul ignore else
-    if (range) {
+    if (selection?.rangeCount) {
+      const range = selection.getRangeAt(0)
       return {
         selectionStart: range.startOffset,
         selectionEnd: range.endOffset,


### PR DESCRIPTION
**What**:

Dispatch `input` event with `inputType: 'insertParagraph'` on `contenteditable` if `shiftKey: false`.

Fix an exception if `getSelectionRange` is called on `contenteditable` and `Selection.rangeCount === 0`

**Why**:

Closes #605 

**Checklist**:

- N/A Documentation
- [x] Tests
- N/A Typings
- [x] Ready to be merged
