### PR TITLE
fix: apply changes before input event

### DIFF
--- a/src/__tests__/clear.js
+++ b/src/__tests__/clear.js
@@ -24,7 +24,6 @@ test('clears text', () => {
     input[value="hello"] - select
     input[value="hello"] - keydown: Delete (46)
     input[value=""] - input
-      "{SELECTION}hello{/SELECTION}" -> "{CURSOR}"
     input[value=""] - keyup: Delete (46)
   `)
 })

--- a/src/__tests__/keyboard/index.ts
+++ b/src/__tests__/keyboard/index.ts
@@ -130,7 +130,6 @@ it('continue typing with state', () => {
     input[value=""] - keydown: F (70) {shift}
     input[value=""] - keypress: F (70) {shift}
     input[value="F"] - input
-      "{CURSOR}" -> "F{CURSOR}"
     input[value="F"] - keyup: F (70) {shift}
     input[value="F"] - keyup: Shift (16)
   `)

--- a/src/__tests__/keyboard/plugin/functional.ts
+++ b/src/__tests__/keyboard/plugin/functional.ts
@@ -54,12 +54,10 @@ test('backspace to valid value', () => {
     input[value=""] - keydown: 5 (53)
     input[value=""] - keypress: 5 (53)
     input[value="5"] - input
-      "{CURSOR}" -> "{CURSOR}5"
     input[value="5"] - keyup: 5 (53)
     input[value="5"] - keydown: e (101)
     input[value="5"] - keypress: e (101)
     input[value=""] - input
-      "{CURSOR}5" -> "{CURSOR}"
     input[value=""] - keyup: e (101)
     input[value=""] - keydown: - (45)
     input[value=""] - keypress: - (45)
@@ -70,7 +68,6 @@ test('backspace to valid value', () => {
     input[value=""] - keyup: Backspace (8)
     input[value=""] - keydown: Backspace (8)
     input[value="5"] - input
-      "{CURSOR}" -> "{CURSOR}5"
     input[value="5"] - keyup: Backspace (8)
   `)
 })

--- a/src/__tests__/type-modifiers.js
+++ b/src/__tests__/type-modifiers.js
@@ -63,11 +63,9 @@ test('a{backspace}', () => {
     input[value=""] - keydown: a (97)
     input[value=""] - keypress: a (97)
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97)
     input[value="a"] - keydown: Backspace (8)
     input[value=""] - input
-      "a{CURSOR}" -> "{CURSOR}"
     input[value=""] - keyup: Backspace (8)
   `)
 })
@@ -96,7 +94,6 @@ test('{backspace}a', () => {
     input[value=""] - keydown: a (97)
     input[value=""] - keypress: a (97)
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97)
   `)
 })
@@ -125,9 +122,8 @@ test('{backspace} triggers typing the backspace character and deletes the charac
     input[value="yo"] - mouseup: Left (0)
     input[value="yo"] - click: Left (0)
     input[value="yo"] - keydown: Backspace (8)
-    input[value="o"] - input
-      "y{CURSOR}o" -> "o{CURSOR}"
     input[value="o"] - select
+    input[value="o"] - input
     input[value="o"] - keyup: Backspace (8)
   `)
 })
@@ -214,9 +210,8 @@ test('{backspace} deletes the selected range', () => {
     input[value="Hi there"] - mouseup: Left (0)
     input[value="Hi there"] - click: Left (0)
     input[value="Hi there"] - keydown: Backspace (8)
-    input[value="Here"] - input
-      "H{SELECTION}i th{/SELECTION}ere" -> "Here{CURSOR}"
     input[value="Here"] - select
+    input[value="Here"] - input
     input[value="Here"] - keyup: Backspace (8)
   `)
 })
@@ -282,7 +277,6 @@ test('{meta}a{/meta}', () => {
     input[value=""] - keydown: a (97) {meta}
     input[value=""] - keypress: a (97) {meta}
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97) {meta}
     input[value="a"] - keyup: Meta (93)
   `)
@@ -341,7 +335,6 @@ test('{shift}a{/shift}', () => {
     input[value=""] - keydown: a (97) {shift}
     input[value=""] - keypress: a (97) {shift}
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97) {shift}
     input[value="a"] - keyup: Shift (16)
   `)
@@ -374,7 +367,6 @@ test('{capslock}a{capslock}', () => {
     input[value=""] - keydown: a (97)
     input[value=""] - keypress: a (97)
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97)
     input[value="a"] - keydown: CapsLock (20)
     input[value="a"] - keyup: CapsLock (20)
@@ -405,7 +397,6 @@ test('a{enter}', () => {
     input[value=""] - keydown: a (97)
     input[value=""] - keypress: a (97)
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97)
     input[value="a"] - keydown: Enter (13)
     input[value="a"] - keypress: Enter (13)
@@ -673,7 +664,6 @@ test('{space} on an input', () => {
     input[value=""] - keydown: (32)
     input[value=""] - keypress: (32)
     input[value=" "] - input
-      "{CURSOR}" -> " {CURSOR}"
     input[value=" "] - keyup: (32)
   `)
 })
@@ -792,7 +782,6 @@ test('{enter} on a textarea', () => {
     textarea[value=""] - keydown: Enter (13)
     textarea[value=""] - keypress: Enter (13)
     textarea[value="\\n"] - input
-      "{CURSOR}" -> "\\n{CURSOR}"
     textarea[value="\\n"] - keyup: Enter (13)
   `)
 })
@@ -976,9 +965,8 @@ test('{del} at the start of the input', () => {
     input[value="hello"] - mouseup: Left (0)
     input[value="hello"] - click: Left (0)
     input[value="hello"] - keydown: Delete (46)
-    input[value="ello"] - input
-      "{CURSOR}hello" -> "ello{CURSOR}"
     input[value="ello"] - select
+    input[value="ello"] - input
     input[value="ello"] - keyup: Delete (46)
   `)
 })
@@ -1040,9 +1028,8 @@ test('{del} in the middle of the input', () => {
     input[value="hello"] - click: Left (0)
     input[value="hello"] - select
     input[value="hello"] - keydown: Delete (46)
-    input[value="helo"] - input
-      "he{CURSOR}llo" -> "helo{CURSOR}"
     input[value="helo"] - select
+    input[value="helo"] - input
     input[value="helo"] - keyup: Delete (46)
   `)
 })
@@ -1075,9 +1062,8 @@ test('{del} with a selection range', () => {
     input[value="hello"] - click: Left (0)
     input[value="hello"] - select
     input[value="hello"] - keydown: Delete (46)
-    input[value="hlo"] - input
-      "h{SELECTION}el{/SELECTION}lo" -> "hlo{CURSOR}"
     input[value="hlo"] - select
+    input[value="hlo"] - input
     input[value="hlo"] - keyup: Delete (46)
   `)
 })
@@ -1165,7 +1151,6 @@ test('modifiers will not be closed if skipAutoClose is enabled', () => {
     input[value=""] - keydown: a (97) {meta}
     input[value=""] - keypress: a (97) {meta}
     input[value="a"] - input
-      "{CURSOR}" -> "a{CURSOR}"
     input[value="a"] - keyup: a (97) {meta}
   `)
 })

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -24,17 +24,14 @@ test('types text in input', () => {
     input[value=""] - keydown: S (83)
     input[value=""] - keypress: S (83)
     input[value="S"] - input
-      "{CURSOR}" -> "S{CURSOR}"
     input[value="S"] - keyup: S (83)
     input[value="S"] - keydown: u (117)
     input[value="S"] - keypress: u (117)
     input[value="Su"] - input
-      "S{CURSOR}" -> "Su{CURSOR}"
     input[value="Su"] - keyup: u (117)
     input[value="Su"] - keydown: p (112)
     input[value="Su"] - keypress: p (112)
     input[value="Sup"] - input
-      "Su{CURSOR}" -> "Sup{CURSOR}"
     input[value="Sup"] - keyup: p (112)
   `)
 })
@@ -50,17 +47,14 @@ test('can skip the initial click', () => {
     input[value=""] - keydown: S (83)
     input[value=""] - keypress: S (83)
     input[value="S"] - input
-      "{CURSOR}" -> "S{CURSOR}"
     input[value="S"] - keyup: S (83)
     input[value="S"] - keydown: u (117)
     input[value="S"] - keypress: u (117)
     input[value="Su"] - input
-      "S{CURSOR}" -> "Su{CURSOR}"
     input[value="Su"] - keyup: u (117)
     input[value="Su"] - keydown: p (112)
     input[value="Su"] - keypress: p (112)
     input[value="Sup"] - input
-      "Su{CURSOR}" -> "Sup{CURSOR}"
     input[value="Sup"] - keyup: p (112)
   `)
 })
@@ -91,17 +85,14 @@ test('types text inside custom element', () => {
     input[value=""] - keydown: S (83)
     input[value=""] - keypress: S (83)
     input[value="S"] - input
-      "{CURSOR}" -> "S{CURSOR}"
     input[value="S"] - keyup: S (83)
     input[value="S"] - keydown: u (117)
     input[value="S"] - keypress: u (117)
     input[value="Su"] - input
-      "S{CURSOR}" -> "Su{CURSOR}"
     input[value="Su"] - keyup: u (117)
     input[value="Su"] - keydown: p (112)
     input[value="Su"] - keypress: p (112)
     input[value="Sup"] - input
-      "Su{CURSOR}" -> "Sup{CURSOR}"
     input[value="Sup"] - keyup: p (112)
   `)
 })
@@ -128,17 +119,14 @@ test('types text in textarea', () => {
     textarea[value=""] - keydown: S (83)
     textarea[value=""] - keypress: S (83)
     textarea[value="S"] - input
-      "{CURSOR}" -> "S{CURSOR}"
     textarea[value="S"] - keyup: S (83)
     textarea[value="S"] - keydown: u (117)
     textarea[value="S"] - keypress: u (117)
     textarea[value="Su"] - input
-      "S{CURSOR}" -> "Su{CURSOR}"
     textarea[value="Su"] - keyup: u (117)
     textarea[value="Su"] - keydown: p (112)
     textarea[value="Su"] - keypress: p (112)
     textarea[value="Sup"] - input
-      "Su{CURSOR}" -> "Sup{CURSOR}"
     textarea[value="Sup"] - keyup: p (112)
   `)
 })
@@ -339,12 +327,11 @@ test('typing into a controlled input works', () => {
     input[value=""] - keydown: 2 (50)
     input[value=""] - keypress: 2 (50)
     input[value="2"] - input
-      "{CURSOR}" -> "$2{CURSOR}"
+      "2{CURSOR}" -> "$2{CURSOR}"
     input[value="$2"] - keyup: 2 (50)
     input[value="$2"] - keydown: 3 (51)
     input[value="$2"] - keypress: 3 (51)
     input[value="$23"] - input
-      "$2{CURSOR}" -> "$23{CURSOR}"
     input[value="$23"] - keyup: 3 (51)
   `)
 })
@@ -375,9 +362,8 @@ test('typing in the middle of a controlled input works', () => {
     input[value="$23"] - click: Left (0)
     input[value="$23"] - keydown: 1 (49)
     input[value="$23"] - keypress: 1 (49)
-    input[value="$213"] - input
-      "$2{CURSOR}3" -> "$213{CURSOR}"
     input[value="$213"] - select
+    input[value="$213"] - input
     input[value="$213"] - keyup: 1 (49)
   `)
 })
@@ -417,8 +403,9 @@ test('ignored {backspace} in controlled input', () => {
     input[value="$23"] - mouseup: Left (0)
     input[value="$23"] - click: Left (0)
     input[value="$23"] - keydown: Backspace (8)
+    input[value="23"] - select
     input[value="23"] - input
-      "\${CURSOR}23" -> "$23{CURSOR}"
+      "{CURSOR}23" -> "$23{CURSOR}"
     input[value="$23"] - keyup: Backspace (8)
     input[value="$23"] - pointerover
     input[value="$23"] - pointerenter
@@ -434,7 +421,6 @@ test('ignored {backspace} in controlled input', () => {
     input[value="$23"] - keydown: 4 (52)
     input[value="$23"] - keypress: 4 (52)
     input[value="$234"] - input
-      "$23{CURSOR}" -> "$234{CURSOR}"
     input[value="$234"] - keyup: 4 (52)
   `)
 })
@@ -472,12 +458,10 @@ test('typing in a textarea with existing text', () => {
     textarea[value="Hello, "] - keydown: 1 (49)
     textarea[value="Hello, "] - keypress: 1 (49)
     textarea[value="Hello, 1"] - input
-      "Hello, {CURSOR}" -> "Hello, 1{CURSOR}"
     textarea[value="Hello, 1"] - keyup: 1 (49)
     textarea[value="Hello, 1"] - keydown: 2 (50)
     textarea[value="Hello, 1"] - keypress: 2 (50)
     textarea[value="Hello, 12"] - input
-      "Hello, 1{CURSOR}" -> "Hello, 12{CURSOR}"
     textarea[value="Hello, 12"] - keyup: 2 (50)
   `)
   expect(element).toHaveValue('Hello, 12')
@@ -511,15 +495,13 @@ test('accepts an initialSelectionStart and initialSelectionEnd', () => {
     textarea[value="Hello, "] - click: Left (0)
     textarea[value="Hello, "] - keydown: 1 (49)
     textarea[value="Hello, "] - keypress: 1 (49)
-    textarea[value="1Hello, "] - input
-      "{CURSOR}Hello, " -> "1Hello, {CURSOR}"
     textarea[value="1Hello, "] - select
+    textarea[value="1Hello, "] - input
     textarea[value="1Hello, "] - keyup: 1 (49)
     textarea[value="1Hello, "] - keydown: 2 (50)
     textarea[value="1Hello, "] - keypress: 2 (50)
-    textarea[value="12Hello, "] - input
-      "1{CURSOR}Hello, " -> "12Hello, {CURSOR}"
     textarea[value="12Hello, "] - select
+    textarea[value="12Hello, "] - input
     textarea[value="12Hello, "] - keyup: 2 (50)
   `)
   expect(element).toHaveValue('12Hello, ')
@@ -584,7 +566,6 @@ test('can type into an input with type `date`', () => {
     input[value=""] - keydown: 9 (57)
     input[value=""] - keypress: 9 (57)
     input[value="2020-06-29"] - input
-      "{CURSOR}" -> "{CURSOR}2020-06-29"
     input[value="2020-06-29"] - change
     input[value="2020-06-29"] - keyup: 9 (57)
   `)
@@ -623,7 +604,6 @@ test('can type "-" into number inputs', () => {
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
     input[value="-3"] - input
-      "{CURSOR}" -> "{CURSOR}-3"
     input[value="-3"] - keyup: 3 (51)
   `)
 })
@@ -653,17 +633,14 @@ test('can type "." into number inputs', () => {
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
     input[value="3"] - input
-      "{CURSOR}" -> "{CURSOR}3"
     input[value="3"] - keyup: 3 (51)
     input[value="3"] - keydown: . (46)
     input[value="3"] - keypress: . (46)
     input[value=""] - input
-      "{CURSOR}3" -> "{CURSOR}"
     input[value=""] - keyup: . (46)
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
     input[value="3.3"] - input
-      "{CURSOR}" -> "{CURSOR}3.3"
     input[value="3.3"] - keyup: 3 (51)
   `)
 })
@@ -939,16 +916,14 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
     input[value=""] - keydown: b (98)
     input[value=""] - keypress: b (98)
     input[value="b"] - input
-      "{CURSOR}" -> "b{CURSOR}"
     input[value="b"] - keyup: b (98)
     input[value="b"] - keydown: ArrowLeft (37)
     input[value="b"] - select
     input[value="b"] - keyup: ArrowLeft (37)
     input[value="b"] - keydown: a (97)
     input[value="b"] - keypress: a (97)
-    input[value="ab"] - input
-      "{CURSOR}b" -> "ab{CURSOR}"
     input[value="ab"] - select
+    input[value="ab"] - input
     input[value="ab"] - keyup: a (97)
     input[value="ab"] - keydown: ArrowRight (39)
     input[value="ab"] - select
@@ -956,7 +931,6 @@ test('navigation key: {arrowleft} and {arrowright} moves the cursor', () => {
     input[value="ab"] - keydown: c (99)
     input[value="ab"] - keypress: c (99)
     input[value="abc"] - input
-      "ab{CURSOR}" -> "abc{CURSOR}"
     input[value="abc"] - keyup: c (99)
   `)
 })
@@ -983,22 +957,19 @@ test('navigation key: {home} and {end} moves the cursor', () => {
     input[value=""] - keydown: c (99)
     input[value=""] - keypress: c (99)
     input[value="c"] - input
-      "{CURSOR}" -> "c{CURSOR}"
     input[value="c"] - keyup: c (99)
     input[value="c"] - keydown: Home (36)
     input[value="c"] - select
     input[value="c"] - keyup: Home (36)
     input[value="c"] - keydown: a (97)
     input[value="c"] - keypress: a (97)
-    input[value="ac"] - input
-      "{CURSOR}c" -> "ac{CURSOR}"
     input[value="ac"] - select
+    input[value="ac"] - input
     input[value="ac"] - keyup: a (97)
     input[value="ac"] - keydown: b (98)
     input[value="ac"] - keypress: b (98)
-    input[value="abc"] - input
-      "a{CURSOR}c" -> "abc{CURSOR}"
     input[value="abc"] - select
+    input[value="abc"] - input
     input[value="abc"] - keyup: b (98)
     input[value="abc"] - keydown: End (35)
     input[value="abc"] - select
@@ -1006,7 +977,6 @@ test('navigation key: {home} and {end} moves the cursor', () => {
     input[value="abc"] - keydown: d (100)
     input[value="abc"] - keypress: d (100)
     input[value="abcd"] - input
-      "abc{CURSOR}" -> "abcd{CURSOR}"
     input[value="abcd"] - keyup: d (100)
   `)
 })
@@ -1015,43 +985,41 @@ test('can type into an input with type `time`', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '01:05')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-      Events fired on: input[value="01:05"]
+    Events fired on: input[value="01:05"]
 
-      input[value=""] - pointerover
-      input[value=""] - pointerenter
-      input[value=""] - mouseover: Left (0)
-      input[value=""] - mouseenter: Left (0)
-      input[value=""] - pointermove
-      input[value=""] - mousemove: Left (0)
-      input[value=""] - pointerdown
-      input[value=""] - mousedown: Left (0)
-      input[value=""] - focus
-      input[value=""] - focusin
-      input[value=""] - pointerup
-      input[value=""] - mouseup: Left (0)
-      input[value=""] - click: Left (0)
-      input[value=""] - keydown: 0 (48)
-      input[value=""] - keypress: 0 (48)
-      input[value=""] - keyup: 0 (48)
-      input[value=""] - keydown: 1 (49)
-      input[value=""] - keypress: 1 (49)
-      input[value=""] - keyup: 1 (49)
-      input[value=""] - keydown: : (58)
-      input[value=""] - keypress: : (58)
-      input[value=""] - keyup: : (58)
-      input[value=""] - keydown: 0 (48)
-      input[value=""] - keypress: 0 (48)
-      input[value="01:00"] - input
-        "{CURSOR}" -> "{CURSOR}01:00"
-      input[value="01:00"] - change
-      input[value="01:00"] - keyup: 0 (48)
-      input[value="01:00"] - keydown: 5 (53)
-      input[value="01:00"] - keypress: 5 (53)
-      input[value="01:05"] - input
-        "{CURSOR}01:00" -> "{CURSOR}01:05"
-      input[value="01:05"] - change
-      input[value="01:05"] - keyup: 5 (53)
-    `)
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 0 (48)
+    input[value=""] - keypress: 0 (48)
+    input[value=""] - keyup: 0 (48)
+    input[value=""] - keydown: 1 (49)
+    input[value=""] - keypress: 1 (49)
+    input[value=""] - keyup: 1 (49)
+    input[value=""] - keydown: : (58)
+    input[value=""] - keypress: : (58)
+    input[value=""] - keyup: : (58)
+    input[value=""] - keydown: 0 (48)
+    input[value=""] - keypress: 0 (48)
+    input[value="01:00"] - input
+    input[value="01:00"] - change
+    input[value="01:00"] - keyup: 0 (48)
+    input[value="01:00"] - keydown: 5 (53)
+    input[value="01:00"] - keypress: 5 (53)
+    input[value="01:05"] - input
+    input[value="01:05"] - change
+    input[value="01:05"] - keyup: 5 (53)
+  `)
   expect(element).toHaveValue('01:05')
 })
 
@@ -1059,40 +1027,38 @@ test('can type into an input with type `time` without ":"', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '0105')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-      Events fired on: input[value="01:05"]
+    Events fired on: input[value="01:05"]
 
-      input[value=""] - pointerover
-      input[value=""] - pointerenter
-      input[value=""] - mouseover: Left (0)
-      input[value=""] - mouseenter: Left (0)
-      input[value=""] - pointermove
-      input[value=""] - mousemove: Left (0)
-      input[value=""] - pointerdown
-      input[value=""] - mousedown: Left (0)
-      input[value=""] - focus
-      input[value=""] - focusin
-      input[value=""] - pointerup
-      input[value=""] - mouseup: Left (0)
-      input[value=""] - click: Left (0)
-      input[value=""] - keydown: 0 (48)
-      input[value=""] - keypress: 0 (48)
-      input[value=""] - keyup: 0 (48)
-      input[value=""] - keydown: 1 (49)
-      input[value=""] - keypress: 1 (49)
-      input[value=""] - keyup: 1 (49)
-      input[value=""] - keydown: 0 (48)
-      input[value=""] - keypress: 0 (48)
-      input[value="01:00"] - input
-        "{CURSOR}" -> "{CURSOR}01:00"
-      input[value="01:00"] - change
-      input[value="01:00"] - keyup: 0 (48)
-      input[value="01:00"] - keydown: 5 (53)
-      input[value="01:00"] - keypress: 5 (53)
-      input[value="01:05"] - input
-        "{CURSOR}01:00" -> "{CURSOR}01:05"
-      input[value="01:05"] - change
-      input[value="01:05"] - keyup: 5 (53)
-    `)
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: 0 (48)
+    input[value=""] - keypress: 0 (48)
+    input[value=""] - keyup: 0 (48)
+    input[value=""] - keydown: 1 (49)
+    input[value=""] - keypress: 1 (49)
+    input[value=""] - keyup: 1 (49)
+    input[value=""] - keydown: 0 (48)
+    input[value=""] - keypress: 0 (48)
+    input[value="01:00"] - input
+    input[value="01:00"] - change
+    input[value="01:00"] - keyup: 0 (48)
+    input[value="01:00"] - keydown: 5 (53)
+    input[value="01:00"] - keypress: 5 (53)
+    input[value="01:05"] - input
+    input[value="01:05"] - change
+    input[value="01:05"] - keyup: 5 (53)
+  `)
   expect(element).toHaveValue('01:05')
 })
 
@@ -1128,13 +1094,11 @@ test('can type more a number higher than 60 minutes into an input `time` and the
     input[value=""] - keydown: 9 (57)
     input[value=""] - keypress: 9 (57)
     input[value="23:09"] - input
-      "{CURSOR}" -> "{CURSOR}23:09"
     input[value="23:09"] - change
     input[value="23:09"] - keyup: 9 (57)
     input[value="23:09"] - keydown: 0 (48)
     input[value="23:09"] - keypress: 0 (48)
     input[value="23:59"] - input
-      "{CURSOR}23:09" -> "{CURSOR}23:59"
     input[value="23:59"] - change
     input[value="23:59"] - keyup: 0 (48)
   `)
@@ -1180,13 +1144,11 @@ test('can type letters into an input `time` and they are ignored', () => {
     input[value=""] - keydown: 3 (51)
     input[value=""] - keypress: 3 (51)
     input[value="16:03"] - input
-      "{CURSOR}" -> "{CURSOR}16:03"
     input[value="16:03"] - change
     input[value="16:03"] - keyup: 3 (51)
     input[value="16:03"] - keydown: 6 (54)
     input[value="16:03"] - keypress: 6 (54)
     input[value="16:36"] - input
-      "{CURSOR}16:03" -> "{CURSOR}16:36"
     input[value="16:36"] - change
     input[value="16:36"] - keyup: 6 (54)
     input[value="16:36"] - keydown: a (97)
@@ -1232,13 +1194,11 @@ test('can type a digit bigger in the hours section, bigger than 2 and it shows t
     input[value=""] - keydown: 2 (50)
     input[value=""] - keypress: 2 (50)
     input[value="09:02"] - input
-      "{CURSOR}" -> "{CURSOR}09:02"
     input[value="09:02"] - change
     input[value="09:02"] - keyup: 2 (50)
     input[value="09:02"] - keydown: 5 (53)
     input[value="09:02"] - keypress: 5 (53)
     input[value="09:25"] - input
-      "{CURSOR}09:02" -> "{CURSOR}09:25"
     input[value="09:25"] - change
     input[value="09:25"] - keyup: 5 (53)
   `)
@@ -1278,13 +1238,11 @@ test('can type two digits in the hours section, equals to 24 and it shows the ho
     input[value=""] - keydown: 5 (53)
     input[value=""] - keypress: 5 (53)
     input[value="23:05"] - input
-      "{CURSOR}" -> "{CURSOR}23:05"
     input[value="23:05"] - change
     input[value="23:05"] - keyup: 5 (53)
     input[value="23:05"] - keydown: 2 (50)
     input[value="23:05"] - keypress: 2 (50)
     input[value="23:52"] - input
-      "{CURSOR}23:05" -> "{CURSOR}23:52"
     input[value="23:52"] - change
     input[value="23:52"] - keyup: 2 (50)
   `)
@@ -1324,13 +1282,11 @@ test('can type two digits in the hours section, bigger than 24 and less than 30,
     input[value=""] - keydown: 5 (53)
     input[value=""] - keypress: 5 (53)
     input[value="23:05"] - input
-      "{CURSOR}" -> "{CURSOR}23:05"
     input[value="23:05"] - change
     input[value="23:05"] - keyup: 5 (53)
     input[value="23:05"] - keydown: 2 (50)
     input[value="23:05"] - keypress: 2 (50)
     input[value="23:52"] - input
-      "{CURSOR}23:05" -> "{CURSOR}23:52"
     input[value="23:52"] - change
     input[value="23:52"] - keyup: 2 (50)
   `)

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1380,3 +1380,22 @@ test('use {selectall} on <input type="number"/>', () => {
 
   expect(element).toHaveValue(4)
 })
+
+test('move selection with arrows', () => {
+  const {element} = setup(`<input/>`)
+  let targetProperties
+  element.addEventListener('input', e => {
+    targetProperties = {
+      value: e.target.value,
+      selectionStart: e.target.selectionStart,
+    }
+  })
+
+  userEvent.type(element, 'abc{ArrowLeft}{ArrowLeft}{ArrowRight}{Backspace}')
+
+  expect(element).toHaveValue('ac')
+  expect(targetProperties).toEqual({
+    value: 'ac',
+    selectionStart: 1,
+  })
+})

--- a/src/__tests__/utils/edit/calculateNewValue.ts
+++ b/src/__tests__/utils/edit/calculateNewValue.ts
@@ -27,12 +27,10 @@ test('honors maxlength', () => {
     input[value=""] - keydown: 1 (49)
     input[value=""] - keypress: 1 (49)
     input[value="1"] - input
-      "{CURSOR}" -> "1{CURSOR}"
     input[value="1"] - keyup: 1 (49)
     input[value="1"] - keydown: 2 (50)
     input[value="1"] - keypress: 2 (50)
     input[value="12"] - input
-      "1{CURSOR}" -> "12{CURSOR}"
     input[value="12"] - keyup: 2 (50)
     input[value="12"] - keydown: 3 (51)
     input[value="12"] - keypress: 3 (51)
@@ -63,17 +61,14 @@ test('honors maxlength="" as if there was no maxlength', () => {
     input[value=""] - keydown: 1 (49)
     input[value=""] - keypress: 1 (49)
     input[value="1"] - input
-      "{CURSOR}" -> "1{CURSOR}"
     input[value="1"] - keyup: 1 (49)
     input[value="1"] - keydown: 2 (50)
     input[value="1"] - keypress: 2 (50)
     input[value="12"] - input
-      "1{CURSOR}" -> "12{CURSOR}"
     input[value="12"] - keyup: 2 (50)
     input[value="12"] - keydown: 3 (51)
     input[value="12"] - keypress: 3 (51)
     input[value="123"] - input
-      "12{CURSOR}" -> "123{CURSOR}"
     input[value="123"] - keyup: 3 (51)
   `)
 })

--- a/src/keyboard/plugins/arrow.ts
+++ b/src/keyboard/plugins/arrow.ts
@@ -4,7 +4,7 @@
  */
 
 import {behaviorPlugin} from '../types'
-import {isElementType, setSelectionRange} from '../../utils'
+import {getSelectionRange, isElementType, setSelectionRange} from '../../utils'
 
 export const keydownBehavior: behaviorPlugin[] = [
   {
@@ -13,7 +13,7 @@ export const keydownBehavior: behaviorPlugin[] = [
       (keyDef.key === 'ArrowLeft' || keyDef.key === 'ArrowRight') &&
       isElementType(element, 'input'),
     handle: (keyDef, element) => {
-      const {selectionStart, selectionEnd} = element as HTMLInputElement
+      const {selectionStart, selectionEnd} = getSelectionRange(element)
 
       const direction = keyDef.key === 'ArrowLeft' ? -1 : 1
 

--- a/src/keyboard/shared/fireInputEventIfNeeded.ts
+++ b/src/keyboard/shared/fireInputEventIfNeeded.ts
@@ -6,7 +6,6 @@ import {
   hasUnreliableEmptyValue,
   isContentEditable,
   setSelectionRange,
-  hasSelectionSupport,
 } from '../../utils'
 
 export function fireInputEventIfNeeded({
@@ -35,8 +34,11 @@ export function fireInputEventIfNeeded({
     // apply the changes before firing the input event, so that input handlers can access the altered dom and selection
     if (isContentEditable(el)) {
       el.textContent = newValue
-    } else if (isElementType(el, ['input', 'textarea'])) {
+    } else /* istanbul ignore else */ if (isElementType(el, ['input', 'textarea'])) {
       el.value = newValue
+    } else {
+      // TODO: properly type guard
+      throw new Error('Invalid Element')
     }
     setSelectionRangeAfterInput(el, newValue, newSelectionStart)
 

--- a/src/keyboard/shared/fireInputEventIfNeeded.ts
+++ b/src/keyboard/shared/fireInputEventIfNeeded.ts
@@ -6,6 +6,7 @@ import {
   hasUnreliableEmptyValue,
   isContentEditable,
   setSelectionRange,
+  hasSelectionSupport,
 } from '../../utils'
 
 export function fireInputEventIfNeeded({
@@ -37,8 +38,14 @@ export function fireInputEventIfNeeded({
         ...eventOverrides,
       })
     } else {
+      const newSelection = hasSelectionSupport(el)
+        ? {selectionStart: newSelectionStart, selectionEnd: newSelectionStart}
+        : undefined
       fireEvent.input(el, {
-        target: {value: newValue},
+        target: {
+          value: newValue,
+          ...newSelection,
+        },
         ...eventOverrides,
       })
     }

--- a/src/utils/edit/selectionRange.ts
+++ b/src/utils/edit/selectionRange.ts
@@ -17,7 +17,7 @@ type InputWithInternalSelection = HTMLInputElement & {
   }
 }
 
-function hasSelectionSupport(
+export function hasSelectionSupport(
   element: Element,
 ): element is
   | HTMLTextAreaElement


### PR DESCRIPTION
**What**:

Apply new value and selection range before `input` event so that `input` handlers can use it.
Get correct selection range for `[ArrowLeft]` and `[ArrowRight]` when active element does not support selectionRange.

**Why**:

Closes #515 

**Checklist**:

- N/A Documentation
- [x] Tests
- [x] Ready to be merged
