### PR TITLE
fix(keyboard): trigger onChange in React

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,16 @@
   "devDependencies": {
     "@testing-library/dom": "^7.28.1",
     "@testing-library/jest-dom": "^5.11.6",
+    "@testing-library/react": "^11.2.5",
     "@types/estree": "0.0.45",
     "@types/jest-in-case": "^1.0.3",
+    "@types/react": "^17.0.3",
     "is-ci": "^2.0.0",
     "jest-in-case": "^1.0.2",
     "jest-serializer-ansi": "^1.0.3",
     "kcd-scripts": "^7.5.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "typescript": "^4.1.2"
   },
   "peerDependencies": {

--- a/src/__tests__/react/tsconfig.json
+++ b/src/__tests__/react/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/src/__tests__/react/type.tsx
+++ b/src/__tests__/react/type.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from 'index'
+
+test('trigger onChange SyntheticEvent on input', () => {
+  const inputHandler = jest.fn()
+  const changeHandler = jest.fn()
+
+  render(<input onInput={inputHandler} onChange={changeHandler} />)
+
+  userEvent.type(screen.getByRole('textbox'), 'abcdef')
+
+  expect(inputHandler).toHaveBeenCalledTimes(6)
+  expect(changeHandler).toHaveBeenCalledTimes(6)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/kcd-scripts/shared-tsconfig.json",
   "compilerOptions": {
-    "allowJs": true
+    "allowJs": true,
+    "esModuleInterop": true
   },
   "include": ["./src", "./typings"]
 }


### PR DESCRIPTION
**What**:

Change element properties while hiding the change from React.

**Why**:

Closes #624 

**How**:

React keeps track of properties by replacing the PropertyDescriptor.
We replace the PropertyDescriptor with the native one before setting the property and reapply React's PropertyDescriptor afterwards.
This way React should detect the value on the `input` event as a new value and dispatch a `SyntheticEvent` for `onChange`.

**Checklist**:

- N/A Documentation
- [x] Tests
- [x] Ready to be merged
