### PR TITLE
fix(type): catch internal promise rejections

### DIFF
--- a/src/__tests__/keyboard/getNextKeyDef.ts
+++ b/src/__tests__/keyboard/getNextKeyDef.ts
@@ -87,3 +87,24 @@ cases(
     },
   },
 )
+
+cases(
+  'errors',
+  ({text, expectedError}) => {
+    expect(() => getNextKeyDef(`${text}`, options)).toThrow(expectedError)
+  },
+  {
+    'invalid descriptor': {
+      text: '{!}',
+      expectedError: 'Expected key descriptor but found "!" in "{!}"',
+    },
+    'missing descriptor': {
+      text: '',
+      expectedError: 'Expected key descriptor but found "" in ""',
+    },
+    'missing closing bracket': {
+      text: '{a)',
+      expectedError: 'Expected closing bracket but found ")" in "{a)"',
+    },
+  },
+)

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1410,22 +1410,30 @@ test('overwrite selection with same value', () => {
   expect(element).toHaveValue('11123')
 })
 
-test.each([
-  ['foo', '[{', 'Unable to find the "window"'],
-  [document.body, '[{', 'Expected key descriptor but found "{"'],
-])(
-  'catch promise rejections and report to the console on synchronous calls',
-  async (element, text, errorMessage) => {
-    const errLog = jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+describe('promise rejections', () => {
+  afterEach(() => {
+    console.error.mockReset()
+  })
 
-    userEvent.type(element, text)
+  test.each([
+    ['foo', '[{', 'Unable to find the "window"'],
+    [document.body, '[{', 'Expected key descriptor but found "{"'],
+  ])(
+    'catch promise rejections and report to the console on synchronous calls',
+    async (element, text, errorMessage) => {
+      const errLog = jest
+        .spyOn(console, 'error')
+        .mockImplementationOnce(() => {})
 
-    await wait(1)
+      userEvent.type(element, text)
 
-    expect(errLog).toBeCalledWith(
-      expect.objectContaining({
-        message: expect.stringMatching(errorMessage),
-      }),
-    )
-  },
-)
+      await wait(1)
+
+      expect(errLog).toBeCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(errorMessage),
+        }),
+      )
+    },
+  )
+})

--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1,4 +1,5 @@
 import userEvent from '../'
+import {wait} from '../utils'
 import {setup, addListeners} from './helpers/utils'
 import './helpers/custom-element'
 
@@ -1408,3 +1409,23 @@ test('overwrite selection with same value', () => {
 
   expect(element).toHaveValue('11123')
 })
+
+test.each([
+  ['foo', '[{', 'Unable to find the "window"'],
+  [document.body, '[{', 'Expected key descriptor but found "{"'],
+])(
+  'catch promise rejections and report to the console on synchronous calls',
+  async (element, text, errorMessage) => {
+    const errLog = jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+    userEvent.type(element, text)
+
+    await wait(1)
+
+    expect(errLog).toBeCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(errorMessage),
+      }),
+    )
+  },
+)

--- a/src/keyboard/getNextKeyDef.ts
+++ b/src/keyboard/getNextKeyDef.ts
@@ -28,10 +28,9 @@ export function getNextKeyDef(
       : text.slice(descriptorStart).match(/^\w+/)?.[0]
     : text[descriptorStart]
 
-  // istanbul ignore if
   if (!descriptor) {
     throw new Error(
-      `Expected key descriptor but found "${text[descriptorStart]}" in "${text}"`,
+      getErrorMessage('key descriptor', text[descriptorStart], text),
     )
   }
 
@@ -50,12 +49,13 @@ export function getNextKeyDef(
       ? '}'
       : ']'
 
-  // istanbul ignore if
   if (endBracket && text[descriptorEnd + endModifier.length] !== endBracket) {
     throw new Error(
-      `Expected closing bracket but found "${
-        text[descriptorEnd + endModifier.length]
-      }" in "${text}"`,
+      getErrorMessage(
+        'closing bracket',
+        text[descriptorEnd + endModifier.length],
+        text,
+      ),
     )
   }
 
@@ -134,4 +134,12 @@ function isPrintableCharacter(startBracket: string, descriptor: string) {
     startBracket === descriptor ||
     (startBracket === '{' && descriptor.length === 1)
   )
+}
+
+function getErrorMessage(
+  expected: string,
+  found: string | undefined,
+  text: string,
+) {
+  return `Expected ${expected} but found "${found ?? ''}" in "${text}"`
 }

--- a/src/type/typeImplementation.ts
+++ b/src/type/typeImplementation.ts
@@ -47,9 +47,10 @@ export async function typeImplementation(
 
   const {selectionStart, selectionEnd} = getSelectionRange(element)
 
-  if (value != null &&
-      (selectionStart === null || selectionStart === 0) &&
-      (selectionEnd === null || selectionEnd === 0)
+  if (
+    value != null &&
+    (selectionStart === null || selectionStart === 0) &&
+    (selectionEnd === null || selectionEnd === 0)
   ) {
     setSelectionRange(
       currentElement() as Element,
@@ -70,4 +71,7 @@ export async function typeImplementation(
   if (!skipAutoClose) {
     releaseAllKeys()
   }
+
+  // eslint-disable-next-line consistent-return -- we need to return the internal Promise so that it is catchable if we don't await
+  return promise
 }


### PR DESCRIPTION
**What**:

Fix UncaughtPromiseRejectionWarning for synchronous `userEvent.type()` that previously slipped through out catch.
Promise rejections are reported per `console.error`.

Asynchronous calls remain unaffected. Users can and have to handle promise rejections themselves.


Also includes an improved error message for undefined characters and adds test coverage for the error messages.

**Why**:

Close #633 

**How**:

`Return` the internal promise if it is not `await`ed.

**Checklist**:

- N/A Documentation
- [x] Tests
- [x] Ready to be merged
