### PR TITLE
Relaxing element type definitions to HTMLElement

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -846,6 +846,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "loreanvictor",
+      "name": "Eugene Ghanizadeh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13572283?v=4",
+      "profile": "https://eugene.coding.blog",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none",

--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ Thanks goes to these people ([emoji key][emojis]):
   <tr>
     <td align="center"><a href="https://github.com/MohitPopli"><img src="https://avatars.githubusercontent.com/u/17976072?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mohit</b></sub></a><br /><a href="https://github.com/testing-library/user-event/issues?q=author%3AMohitPopli" title="Bug reports">🐛</a> <a href="https://github.com/testing-library/user-event/commits?author=MohitPopli" title="Code">💻</a> <a href="https://github.com/testing-library/user-event/commits?author=MohitPopli" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/InExtremaRes"><img src="https://avatars.githubusercontent.com/u/1635491?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Contreras</b></sub></a><br /><a href="https://github.com/testing-library/user-event/issues?q=author%3AInExtremaRes" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://eugene.coding.blog"><img src="https://avatars.githubusercontent.com/u/13572283?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eugene Ghanizadeh</b></sub></a><br /><a href="https://github.com/testing-library/user-event/commits?author=loreanvictor" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/__tests__/paste.js
+++ b/src/__tests__/paste.js
@@ -103,6 +103,6 @@ test('should give error if we are trying to call paste on an invalid element', (
   expect(() =>
     userEvent.paste(element, "I'm only a div :("),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"the current element is of type DIV and doesn't have a valid value"`,
+    `"the current element is of type DIV and does not support pasting"`,
   )
 })

--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -180,9 +180,9 @@ test.each([
       new File(['there'], 'there.jpg', {type: 'video/mp4'}),
     ]
     const {element} = setup(`
-    <input 
-      type="file" 
-      accept="${acceptAttribute}" multiple 
+    <input
+      type="file"
+      accept="${acceptAttribute}" multiple
     />
   `)
 
@@ -234,4 +234,13 @@ test('input.files implements iterable', () => {
   expect(eventTargetFiles).not.toEqual(files)
 
   expect(Array.from(eventTargetFiles)).toEqual(files)
+})
+
+test('should give error if we are trying to call upload on an invalid element', () => {
+  const {element} = setup('<div  />')
+  expect(() =>
+    userEvent.paste(element, "I'm only a div :("),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"the current element is of type DIV and doesn't have a valid value"`,
+  )
 })

--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -239,8 +239,8 @@ test('input.files implements iterable', () => {
 test('should give error if we are trying to call upload on an invalid element', () => {
   const {element} = setup('<div  />')
   expect(() =>
-    userEvent.paste(element, "I'm only a div :("),
+    userEvent.upload(element, "I'm only a div :("),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"the current element is of type DIV and doesn't have a valid value"`,
+    `"the current element is of type DIV and does not accept file uploads"`,
   )
 })

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -5,11 +5,23 @@ import {
   calculateNewValue,
   eventWrapper,
   isDisabled,
+  isElementType,
 } from './utils'
 
 interface pasteOptions {
   initialSelectionStart?: number
   initialSelectionEnd?: number
+}
+
+function isPasteableElement(
+  element: HTMLElement,
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return (
+    (isElementType(element, 'input') &&
+      element.type !== 'file' &&
+      element.type !== 'button') ||
+    isElementType(element, 'textarea')
+  )
 }
 
 function paste(
@@ -23,15 +35,9 @@ function paste(
   }
 
   // TODO: implement for contenteditable
-  if (
-    !(
-      element instanceof HTMLInputElement ||
-      element instanceof HTMLTextAreaElement
-    ) ||
-    typeof element.value === 'undefined'
-  ) {
+  if (!isPasteableElement(element)) {
     throw new TypeError(
-      `the current element is of type ${element.tagName} and doesn't have a valid value`,
+      `the current element is of type ${element.tagName} and does not support pasting`,
     )
   }
   eventWrapper(() => element.focus())

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -13,7 +13,7 @@ interface pasteOptions {
 }
 
 function paste(
-  element: HTMLInputElement | HTMLTextAreaElement,
+  element: HTMLElement,
   text: string,
   init?: ClipboardEventInit,
   {initialSelectionStart, initialSelectionEnd}: pasteOptions = {},
@@ -23,7 +23,13 @@ function paste(
   }
 
   // TODO: implement for contenteditable
-  if (typeof element.value === 'undefined') {
+  if (
+    !(
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement
+    ) ||
+    typeof element.value === 'undefined'
+  ) {
     throw new TypeError(
       `the current element is of type ${element.tagName} and doesn't have a valid value`,
     )

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -14,11 +14,20 @@ interface uploadOptions {
 }
 
 function upload(
-  element: HTMLInputElement | HTMLLabelElement,
+  element: HTMLElement,
   fileOrFiles: File | File[],
   init?: uploadInit,
   {applyAccept = false}: uploadOptions = {},
 ) {
+  if (
+    !(
+      element instanceof HTMLInputElement || element instanceof HTMLLabelElement
+    )
+  ) {
+    throw new TypeError(
+      `the current element is of type ${element.tagName} and does not accept file uploads`,
+    )
+  }
   if (isDisabled(element)) return
 
   click(element, init?.clickInit)

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -13,17 +13,25 @@ interface uploadOptions {
   applyAccept?: boolean
 }
 
+function isFileUploadElement(
+  element: HTMLElement,
+): element is HTMLInputElement | HTMLLabelElement {
+  return (
+    (isElementType(element, 'input') && element.type === 'file') ||
+    (isElementType(element, 'label') &&
+      element.control !== null &&
+      isElementType(element.control, 'input') &&
+      element.control.type === 'file')
+  )
+}
+
 function upload(
   element: HTMLElement,
   fileOrFiles: File | File[],
   init?: uploadInit,
   {applyAccept = false}: uploadOptions = {},
 ) {
-  if (
-    !(
-      element instanceof HTMLInputElement || element instanceof HTMLLabelElement
-    )
-  ) {
+  if (!isFileUploadElement(element)) {
     throw new TypeError(
       `the current element is of type ${element.tagName} and does not accept file uploads`,
     )


### PR DESCRIPTION
Fixes #648

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Relaxing element argument types to match the type returned by react-testing-library queries.

<!-- Why are these changes necessary? -->

**Why**: 

To allow user-event functions to be used with RTS queries without type casting.

**How**:

I'm narrowing the element type by checking that the passed elements are instances of valid element types. Thus, the check is runtime only, which makes sense since DOM queries are not fully type safe.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Typings
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
