### PR TITLE
fix(keyboard): add link to docs in key descriptor error

### DIFF
--- a/src/__tests__/keyboard/index.ts
+++ b/src/__tests__/keyboard/index.ts
@@ -95,7 +95,7 @@ describe('error', () => {
     expect(err).toHaveBeenCalledWith(expect.any(Error) as unknown)
     expect(err.mock.calls[0][0]).toHaveProperty(
       'message',
-      'Expected key descriptor but found "!" in "{!"',
+      expect.stringContaining('Expected key descriptor but found "!" in "{!"'),
     )
   })
 

--- a/src/keyboard/getNextKeyDef.ts
+++ b/src/keyboard/getNextKeyDef.ts
@@ -141,5 +141,7 @@ function getErrorMessage(
   found: string | undefined,
   text: string,
 ) {
-  return `Expected ${expected} but found "${found ?? ''}" in "${text}"`
+  return `Expected ${expected} but found "${found ?? ''}" in "${text}"
+    See https://github.com/testing-library/user-event/blob/master/README.md#keyboardtext-options
+    for more information about how userEvent parses your input.`
 }


### PR DESCRIPTION
**What**:

Closes #633 

**Why**:

People updating userEvent get confused by the error messages about expected key descriptors or unexpected brackets.

**How**:

Add a link to the section of the README explaining how userEvent parses the `text` argument.

**Checklist**:
- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
