### PR TITLE
fix(upload): apply changeInit correctly

### DIFF
--- a/src/__tests__/upload.js
+++ b/src/__tests__/upload.js
@@ -251,3 +251,15 @@ test('throw error if trying to use upload on an invalid element', () => {
     `"The associated INPUT element does not accept file uploads"`,
   )
 })
+
+test('apply init options', () => {
+  const {element, getEvents} = setup('<input type="file"/>')
+
+  userEvent.upload(element, new File([], 'hello.png'), {
+    clickInit: {shiftKey: true},
+    changeInit: {cancelable: true},
+  })
+
+  expect(getEvents('click')[0]).toHaveProperty('shiftKey', true)
+  expect(getEvents('change')[0]).toHaveProperty('cancelable', true)
+})

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -6,7 +6,7 @@ import {isDisabled, isElementType} from './utils'
 
 interface uploadInit {
   clickInit?: MouseEventInit
-  changeInit?: Event
+  changeInit?: EventInit
 }
 
 interface uploadOptions {
@@ -74,13 +74,12 @@ function upload(
       bubbles: true,
       cancelable: false,
       composed: true,
-      ...init,
     }),
   )
 
   fireEvent.change(input, {
     target: {files: inputFiles},
-    ...init,
+    ...init?.changeInit,
   })
 }
 


### PR DESCRIPTION
**What**:

Closes #667 

**Why**:

`init` argument was deconstructured incorrectly.
The typing of `init.changeInit` was incorrect.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
