### PR TITLE
Fix unexpected behavior with setSelectionRange on inputs in the browser

### DIFF
--- a/src/utils/edit/selectionRange.ts
+++ b/src/utils/edit/selectionRange.ts
@@ -107,7 +107,13 @@ export function setSelectionRange(
 
   const selection = element.ownerDocument.getSelection()
   // istanbul ignore else
-  if (selection) {
+  if (
+    selection &&
+    // Skip setting the range for <input> and <textarea> because
+    // the parent <div> will be selected.
+    !isElementType(element, 'input') &&
+    !isElementType(element, 'textarea')
+  ) {
     selection.removeAllRanges()
     selection.addRange(range)
   }

--- a/src/utils/edit/selectionRange.ts
+++ b/src/utils/edit/selectionRange.ts
@@ -96,6 +96,11 @@ export function setSelectionRange(
     }
   }
 
+  // Moving the selection inside <input> or <textarea> does not alter the document Selection.
+  if (isElementType(element, 'input') || isElementType(element, 'textarea')) {
+    return
+  }
+
   const range = element.ownerDocument.createRange()
   range.selectNodeContents(element)
 
@@ -107,13 +112,7 @@ export function setSelectionRange(
 
   const selection = element.ownerDocument.getSelection()
   // istanbul ignore else
-  if (
-    selection &&
-    // Skip setting the range for <input> and <textarea> because
-    // the parent <div> will be selected.
-    !isElementType(element, 'input') &&
-    !isElementType(element, 'textarea')
-  ) {
+  if (selection) {
     selection.removeAllRanges()
     selection.addRange(range)
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
`userEvent.type` with selection range does not work as expected in the browser. Closes #677 

**Why**:
<!-- Why are these changes necessary? -->
When an input or textarea is clicked, the parent div is selected and the `Selection` range should not be updated at the end of `setSelectionRange`.

**How**:
<!-- How were these changes implemented? -->
Skip setting `Selection` range for `<input>` and `<textarea>` in `setSelectionRange` utility. (see [comment](https://github.com/testing-library/user-event/issues/677#issuecomment-836280924) on issue)

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Documentation
- [x] Tests
  - [x] Tests pass locally
  - [x] Updated [sandbox](https://codesandbox.io/s/rtl-selection-range-example-u63zc?file=/src/index.js) works as expected
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->