### PR TITLE
feat: Drop support for node 10

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["vbcvs"]
+  "sandboxes": ["vbcvs"],
+  "node": "12"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Giorgio Polvara <polvara@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=10",
+    "node": ">=12",
     "npm": ">=6"
   },
   "repository": {


### PR DESCRIPTION
BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.

**What**:

Closes #681

**Why**:

Reduces maintenance burden

**How**:

Change `engines` field to require `node>=12`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged

