### PR TITLE
fix(keyboard): dispatch change event on blur

### DIFF
--- a/src/__tests__/keyboard/shared/fireInputEvent.ts
+++ b/src/__tests__/keyboard/shared/fireInputEvent.ts
@@ -1,0 +1,23 @@
+import {setup} from '__tests__/helpers/utils'
+import userEvent from '../../../'
+
+it('dispatch change event on blur', () => {
+  const {element, getEvents} = setup('<input/>')
+
+  ;(element as HTMLInputElement).focus()
+  userEvent.keyboard('foo')
+  ;(element as HTMLInputElement).blur()
+
+  expect(getEvents('change')).toHaveLength(1)
+})
+
+it('do not dispatch change event if value did not change', () => {
+  const {element, getEvents} = setup('<input/>')
+
+  ;(element as HTMLInputElement).focus()
+  userEvent.keyboard('foo')
+  userEvent.keyboard('{backspace}{backspace}{backspace}')
+  ;(element as HTMLInputElement).blur()
+
+  expect(getEvents('change')).toHaveLength(0)
+})


### PR DESCRIPTION
**What**:
Closes #682 

**Why**:
The browser dispatches a `change` event when an element with changed value loses focus.
When we alter the element `value`/`textContent`, we dispatch an `input` event but no native `change` event.

**How**:
When setting the `value`/`textContent` an event handler is added to the capture phase of the `blur` event on the `window`.
If the `value`/`textContent` on our element is different than the initial one, we dispatch a `change` event.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged

**Constraints**:
* We can not determine if an element was changed between gaining focus and our first edit.
  We could (also) set the initial value on the `focus` event, but for this we would either:
  1) add it on the document as side-effect of the `import` (only works if the `document` is global)
  2) add it per additional `setup` API (and/or implicitly when calling one of our other APIs)
* There is no cross-platform solution for adding an event handler to the bottom of the stack.
  Therefore other event handlers on `blur` (that are added on the capture phase on `window`) might be executed before we dispatch the change event.