### PR TITLE
test: fix istanbul ignore

### DIFF
--- a/src/keyboard/shared/fireInputEvent.ts
+++ b/src/keyboard/shared/fireInputEvent.ts
@@ -25,7 +25,7 @@ export function fireInputEvent(
   // apply the changes before firing the input event, so that input handlers can access the altered dom and selection
   if (isContentEditable(element)) {
     applyNative(element, 'textContent', newValue)
-  } /* istanbul ignore else */ else if (
+  } else /* istanbul ignore else */ if (
     isElementType(element, ['input', 'textarea'])
   ) {
     applyNative(element, 'value', newValue)


### PR DESCRIPTION
**What**:
Fix istanbul ignore.

**Why**:
Previously the `ignore else` had to be writting before `else if` to ignore the consecutive `else`.
Istanbul now seems to expect it right before the `if`.

**How**:
Committed with `--no-verify` as the pre-commit hook lint-fixed the change :shrug: 

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
