### PR TITLE
fix(type): type a space into email and url input (#479)

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1479,3 +1479,94 @@ describe('promise rejections', () => {
     },
   )
 })
+
+// https://github.com/testing-library/user-event/issues/479
+test('can type "{space}" into email inputs', () => {
+  const {element, getEventSnapshot} = setup('<input type="email" />')
+  userEvent.type(element, 's{space}s')
+  expect(element).toHaveValue('s s')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="s s"]
+    
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: s (115)
+    input[value=""] - keypress: s (115)
+    input[value="s"] - input
+    input[value="s"] - keyup: s (115)
+    input[value="s"] - keydown: (32)
+    input[value="s"] - keypress: (32)
+    input[value="s"] - input
+    input[value="s"] - keyup: (32)
+    input[value="s"] - keydown: s (115)
+    input[value="s"] - keypress: s (115)
+    input[value="s s"] - input
+    input[value="s s"] - keyup: s (115)
+`)
+})
+
+// https://github.com/testing-library/user-event/issues/479
+test('can type "{space}" into url inputs', () => {
+  const {element, getEventSnapshot} = setup('<input type="url" />')
+  userEvent.type(element, 's{space}s.com')
+  expect(element).toHaveValue('s s.com')
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+Events fired on: input[value="s s.com"]
+
+input[value=""] - pointerover
+input[value=""] - pointerenter
+input[value=""] - mouseover: Left (0)
+input[value=""] - mouseenter: Left (0)
+input[value=""] - pointermove
+input[value=""] - mousemove: Left (0)
+input[value=""] - pointerdown
+input[value=""] - mousedown: Left (0)
+input[value=""] - focus
+input[value=""] - focusin
+input[value=""] - pointerup
+input[value=""] - mouseup: Left (0)
+input[value=""] - click: Left (0)
+input[value=""] - keydown: s (115)
+input[value=""] - keypress: s (115)
+input[value="s"] - input
+input[value="s"] - keyup: s (115)
+input[value="s"] - keydown: (32)
+input[value="s"] - keypress: (32)
+input[value="s"] - select
+input[value="s"] - input
+input[value="s"] - keyup: (32)
+input[value="s"] - keydown: s (115)
+input[value="s"] - keypress: s (115)
+input[value="s s"] - input
+input[value="s s"] - keyup: s (115)
+input[value="s s"] - keydown: . (46)
+input[value="s s"] - keypress: . (46)
+input[value="s s."] - input
+input[value="s s."] - keyup: . (46)
+input[value="s s."] - keydown: c (99)
+input[value="s s."] - keypress: c (99)
+input[value="s s.c"] - input
+input[value="s s.c"] - keyup: c (99)
+input[value="s s.c"] - keydown: o (111)
+input[value="s s.c"] - keypress: o (111)
+input[value="s s.co"] - input
+input[value="s s.co"] - keyup: o (111)
+input[value="s s.co"] - keydown: m (109)
+input[value="s s.co"] - keypress: m (109)
+input[value="s s.com"] - input
+input[value="s s.com"] - keyup: m (109)
+`)
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
Closes [#479](https://github.com/testing-library/user-event/issues/479) 

**Why**:
It makes type behave more like it would in the browser for email and url inputs. Currently both input types ignore spaces

**How**:
Added new handlers in character.js for email inputs and url inputs, which keep the value of the space and use on the next iteration.


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
