### PR TITLE
fix: Wrong Escape key definiation in keymap

### DIFF
--- a/src/keyboard/keyMap.ts
+++ b/src/keyboard/keyMap.ts
@@ -56,7 +56,6 @@ export const defaultKeyMap: keyboardKey[] = [
   {code: 'OSLeft', key: 'OS', location: DOM_KEY_LOCATION.LEFT, keyCode: 91},
   {code: 'OSRight', key: 'OS', location: DOM_KEY_LOCATION.RIGHT, keyCode: 91},
 
-  {code: 'Escape', key: 'CapsLock', keyCode: 20},
   {code: 'CapsLock', key: 'CapsLock', keyCode: 20},
   {code: 'Backspace', key: 'Backspace', keyCode: 8},
   {code: 'Enter', key: 'Enter', keyCode: 13},


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
`{code: 'Escape', key: 'CapsLock', keyCode: 20},` is wrong here. But there is another definition of escape key later so it doesn't introduce any unexpected behaviour.

**Why**:
<!-- Why are these changes necessary? -->
bug fix

**How**:
<!-- How were these changes implemented? -->
remove this line

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
