### PR TITLE
feat: add support for pageup and pagedown control keys

### DIFF
--- a/src/__tests__/type.js
+++ b/src/__tests__/type.js
@@ -1024,6 +1024,101 @@ test('navigation key: {home} and {end} moves the cursor', () => {
   `)
 })
 
+test('navigation key: {pageUp} and {pageDown} moves the cursor for <input>', () => {
+  const {element, getEventSnapshot} = setup('<input />')
+  userEvent.type(element, 'c{pageUp}ab{pageDown}d')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value="abcd"]
+
+    input[value=""] - pointerover
+    input[value=""] - pointerenter
+    input[value=""] - mouseover: Left (0)
+    input[value=""] - mouseenter: Left (0)
+    input[value=""] - pointermove
+    input[value=""] - mousemove: Left (0)
+    input[value=""] - pointerdown
+    input[value=""] - mousedown: Left (0)
+    input[value=""] - focus
+    input[value=""] - focusin
+    input[value=""] - pointerup
+    input[value=""] - mouseup: Left (0)
+    input[value=""] - click: Left (0)
+    input[value=""] - keydown: c (99)
+    input[value=""] - keypress: c (99)
+    input[value="c"] - input
+    input[value="c"] - keyup: c (99)
+    input[value="c"] - keydown: PageUp (33)
+    input[value="c"] - select
+    input[value="c"] - keyup: PageUp (33)
+    input[value="c"] - keydown: a (97)
+    input[value="c"] - keypress: a (97)
+    input[value="ac"] - select
+    input[value="ac"] - input
+    input[value="ac"] - keyup: a (97)
+    input[value="ac"] - keydown: b (98)
+    input[value="ac"] - keypress: b (98)
+    input[value="abc"] - select
+    input[value="abc"] - input
+    input[value="abc"] - keyup: b (98)
+    input[value="abc"] - keydown: PageDown (34)
+    input[value="abc"] - select
+    input[value="abc"] - keyup: PageDown (34)
+    input[value="abc"] - keydown: d (100)
+    input[value="abc"] - keypress: d (100)
+    input[value="abcd"] - input
+    input[value="abcd"] - keyup: d (100)
+  `)
+})
+
+test('navigation key: {pageUp} and {pageDown} moves the cursor for <textarea>', () => {
+  const {element, getEventSnapshot} = setup('<textarea></textarea>')
+  userEvent.type(element, '{enter}b{enter}{pageUp}a{pageDown}c')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: textarea[value="a\\nb\\nc"]
+
+    textarea[value=""] - pointerover
+    textarea[value=""] - pointerenter
+    textarea[value=""] - mouseover: Left (0)
+    textarea[value=""] - mouseenter: Left (0)
+    textarea[value=""] - pointermove
+    textarea[value=""] - mousemove: Left (0)
+    textarea[value=""] - pointerdown
+    textarea[value=""] - mousedown: Left (0)
+    textarea[value=""] - focus
+    textarea[value=""] - focusin
+    textarea[value=""] - pointerup
+    textarea[value=""] - mouseup: Left (0)
+    textarea[value=""] - click: Left (0)
+    textarea[value=""] - keydown: Enter (13)
+    textarea[value=""] - keypress: Enter (13)
+    textarea[value="\\n"] - input
+    textarea[value="\\n"] - keyup: Enter (13)
+    textarea[value="\\n"] - keydown: b (98)
+    textarea[value="\\n"] - keypress: b (98)
+    textarea[value="\\nb"] - input
+    textarea[value="\\nb"] - keyup: b (98)
+    textarea[value="\\nb"] - keydown: Enter (13)
+    textarea[value="\\nb"] - keypress: Enter (13)
+    textarea[value="\\nb\\n"] - input
+    textarea[value="\\nb\\n"] - keyup: Enter (13)
+    textarea[value="\\nb\\n"] - keydown: PageUp (33)
+    textarea[value="\\nb\\n"] - select
+    textarea[value="\\nb\\n"] - keyup: PageUp (33)
+    textarea[value="\\nb\\n"] - keydown: a (97)
+    textarea[value="\\nb\\n"] - keypress: a (97)
+    textarea[value="a\\nb\\n"] - select
+    textarea[value="a\\nb\\n"] - input
+    textarea[value="a\\nb\\n"] - keyup: a (97)
+    textarea[value="a\\nb\\n"] - keydown: PageDown (34)
+    textarea[value="a\\nb\\n"] - select
+    textarea[value="a\\nb\\n"] - keyup: PageDown (34)
+    textarea[value="a\\nb\\n"] - keydown: c (99)
+    textarea[value="a\\nb\\n"] - keypress: c (99)
+    textarea[value="a\\nb\\nc"] - input
+    textarea[value="a\\nb\\nc"] - keyup: c (99)
+  `)
+})
+
 test('can type into an input with type `time`', () => {
   const {element, getEventSnapshot} = setup('<input type="time" />')
   userEvent.type(element, '01:05')

--- a/src/keyboard/keyMap.ts
+++ b/src/keyboard/keyMap.ts
@@ -74,6 +74,8 @@ export const defaultKeyMap: keyboardKey[] = [
   {code: 'Home', key: 'Home', keyCode: 36},
   {code: 'End', key: 'End', keyCode: 35},
   {code: 'Delete', key: 'Delete', keyCode: 46},
+  {code: 'PageUp', key: 'PageUp', keyCode: 33},
+  {code: 'PageDown', key: 'PageDown', keyCode: 34},
 
   // TODO: add mappings
 ]

--- a/src/keyboard/plugins/control.ts
+++ b/src/keyboard/plugins/control.ts
@@ -18,12 +18,15 @@ import {carryValue, fireInputEvent} from '../shared'
 export const keydownBehavior: behaviorPlugin[] = [
   {
     matches: (keyDef, element) =>
-      (keyDef.key === 'Home' || keyDef.key === 'End') &&
+      (keyDef.key === 'Home' ||
+        keyDef.key === 'End' ||
+        keyDef.key === 'PageUp' ||
+        keyDef.key === 'PageDown') &&
       (isElementType(element, ['input', 'textarea']) ||
         isContentEditable(element)),
     handle: (keyDef, element) => {
       // This could probably been improved by collapsing a selection range
-      if (keyDef.key === 'Home') {
+      if (keyDef.key === 'Home' || keyDef.key === 'PageUp') {
         setSelectionRange(element, 0, 0)
       } else {
         const newPos = getValue(element)?.length ?? /* istanbul ignore next */ 0

--- a/src/keyboard/specialCharMap.ts
+++ b/src/keyboard/specialCharMap.ts
@@ -12,4 +12,6 @@ export const specialCharMap = {
   selectAll: '{selectall}',
   space: '{space}',
   whitespace: ' ',
+  pageUp: '{pageUp}',
+  pageDown: '{pageDown}',
 } as const


### PR DESCRIPTION
**What**:
Adding support for `PageUp` and `PageDown` control block keys as requested in issue #694 

**Why**:
To support more possible user inputs.

**How**:
Add `PageDown` and `PageUp` to keymap. The behavior equals the of `Home` and `End` keys.

**Checklist**:
- N/A Documentation
- [x] Tests
- [x] Ready to be merged
      
Keys need to be added to [special characters](https://testing-library.com/docs/ecosystem-user-event/#special-characters) when this gets merged.
