### PR TITLE
chore: set node version of Codesandbox CI to `14`

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
+  "node": "14",
   "sandboxes": ["vbcvs"]
 }


### PR DESCRIPTION
**Why**:
![image](https://user-images.githubusercontent.com/39068198/136368211-d66c42b5-7e40-42a3-a00d-81c4a7515e59.png)
