### PR TITLE
chore: set protocol for npm to `https`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 package-lock=false
 yes=true
 


### PR DESCRIPTION
**Why**:
```
npm notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect.
```
