### PR TITLE
feat: apply modifier keys in pointer events

### DIFF
--- a/src/__tests__/pointer/index.ts
+++ b/src/__tests__/pointer/index.ts
@@ -387,3 +387,28 @@ test('asynchronous pointer', async () => {
     mousemove - button=0; buttons=0; detail=0
   `)
 })
+
+test('apply modifiers from keyboardstate', async () => {
+  const {element, getEvents} = setup(`<input/>`)
+
+  element.focus()
+  let keyboardState = userEvent.keyboard('[ShiftLeft>]')
+  userEvent.pointer({keys: '[MouseLeft]', target: element}, {keyboardState})
+  keyboardState = userEvent.keyboard('[/ShiftLeft][ControlRight>]', {
+    keyboardState,
+  })
+  userEvent.pointer({keys: '[MouseLeft]', target: element}, {keyboardState})
+  keyboardState = userEvent.keyboard('[/ControlRight][AltLeft>]', {
+    keyboardState,
+  })
+  userEvent.pointer({keys: '[MouseLeft]', target: element}, {keyboardState})
+  keyboardState = userEvent.keyboard('[/AltLeft][MetaLeft>]', {keyboardState})
+  userEvent.pointer({keys: '[MouseLeft]', target: element}, {keyboardState})
+
+  expect(getEvents('click')).toEqual([
+    expect.objectContaining({shiftKey: true}),
+    expect.objectContaining({ctrlKey: true}),
+    expect.objectContaining({altKey: true}),
+    expect.objectContaining({metaKey: true}),
+  ])
+})

--- a/src/pointer/pointerAction.ts
+++ b/src/pointer/pointerAction.ts
@@ -1,7 +1,7 @@
 import {Coords, wait} from '../utils'
 import {pointerMove, PointerMoveAction} from './pointerMove'
 import {pointerPress, PointerPressAction} from './pointerPress'
-import {pointerOptions, pointerState} from './types'
+import {inputDeviceState, pointerOptions, pointerState} from './types'
 
 export type PointerActionTarget = {
   target?: Element
@@ -17,7 +17,7 @@ export type PointerAction = PointerActionTarget &
 export async function pointerAction(
   actions: PointerAction[],
   options: pointerOptions,
-  state: pointerState,
+  state: inputDeviceState,
 ): Promise<unknown[]> {
   const ret: Array<Promise<void>> = []
 
@@ -32,10 +32,11 @@ export async function pointerAction(
           : action.keyDef.pointerType
         : 'mouse'
 
-    const target = action.target ?? getPrevTarget(pointerName, state)
+    const target =
+      action.target ?? getPrevTarget(pointerName, state.pointerState)
     const coords = completeCoords({
-      ...(pointerName in state.position
-        ? state.position[pointerName].coords
+      ...(pointerName in state.pointerState.position
+        ? state.pointerState.position[pointerName].coords
         : undefined),
       ...action.coords,
     })
@@ -55,7 +56,7 @@ export async function pointerAction(
     }
   }
 
-  delete state.activeClickCount
+  delete state.pointerState.activeClickCount
 
   return Promise.all(ret)
 }

--- a/src/pointer/types.ts
+++ b/src/pointer/types.ts
@@ -1,3 +1,4 @@
+import {keyboardState} from 'keyboard/types'
 import {Coords, MouseButton} from '../utils'
 
 /**
@@ -60,4 +61,9 @@ export interface pointerKey {
 export interface PointerTarget {
   target: Element
   coords: Coords
+}
+
+export interface inputDeviceState {
+  pointerState: pointerState
+  keyboardState: keyboardState
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -160,7 +160,7 @@ function _setup(
 
     // pointer needs typecasting because of the overloading
     pointer: ((...args: Parameters<typeof pointer>) => {
-      args[1] = {...pointerApiDefaults, ...args[1], pointerState}
+      args[1] = {...pointerApiDefaults, ...args[1], pointerState, keyboardState}
       const ret = pointer(...args) as pointerState | Promise<pointerState>
       if (ret instanceof Promise) {
         return ret.then(() => undefined)

--- a/src/utils/pointer/firePointerEvents.ts
+++ b/src/utils/pointer/firePointerEvents.ts
@@ -1,4 +1,6 @@
 import {fireEvent} from '@testing-library/dom'
+import type {pointerState} from 'pointer/types'
+import type {keyboardState} from 'keyboard/types'
 import {FakeEventInit, FakeMouseEvent, FakePointerEvent} from './fakeEvent'
 import {getMouseButton, getMouseButtons, MouseButton} from './mouseButtons'
 
@@ -17,17 +19,19 @@ export function firePointerEvent(
   target: Element,
   type: string,
   {
+    pointerState,
+    keyboardState,
     pointerType,
     button,
-    buttons,
     coords,
     pointerId,
     isPrimary,
     clickCount,
   }: {
+    pointerState: pointerState
+    keyboardState: keyboardState
     pointerType?: 'mouse' | 'pen' | 'touch'
     button?: MouseButton
-    buttons: MouseButton[]
     coords: Coords
     pointerId?: number
     isPrimary?: boolean
@@ -41,6 +45,10 @@ export function firePointerEvent(
 
   let init: FakeEventInit = {
     ...coords,
+    altKey: keyboardState.modifiers.alt,
+    ctrlKey: keyboardState.modifiers.ctrl,
+    metaKey: keyboardState.modifiers.meta,
+    shiftKey: keyboardState.modifiers.shift,
   }
   if (Event === FakePointerEvent) {
     init = {...init, pointerId, pointerType}
@@ -52,7 +60,11 @@ export function firePointerEvent(
     ['mousedown', 'mouseup', 'pointerdown', 'pointerup', 'click'].includes(type)
   ) {
     init.button = getMouseButton(button ?? 0)
-    init.buttons = getMouseButtons(...buttons)
+    init.buttons = getMouseButtons(
+      ...pointerState.pressed
+        .filter(p => p.keyDef.pointerType === pointerType)
+        .map(p => p.keyDef.button ?? 0),
+    )
   }
   if (['mousedown', 'mouseup', 'click'].includes(type)) {
     init.detail = clickCount


### PR DESCRIPTION
**What**:

Set `altKey`, `ctrlKey`, `metaKey` and `shiftKey` according to `keyboardState`.

**Why**:

Closes #713 

**How**:

Add `keyboardState` to parameters of `pointer()`.

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
