### PR TITLE
chore: replace release action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,6 @@ on:
       [
         '+([0-9])?(.{+([0-9]),x}).x',
         'main',
-        'master',
         'next',
         'next-major',
         'beta',
@@ -47,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     if:
       ${{ github.repository == 'testing-library/user-event' &&
-      contains('refs/heads/main,refs/heads/master,refs/heads/beta,refs/heads/next,refs/heads/alpha',
-      github.ref) && github.event_name == 'push' }}
+      contains('refs/heads/main,refs/heads/beta,refs/heads/alpha', github.ref)
+      && github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2
@@ -69,19 +68,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v2
-        with:
-          semantic_version: 17
-          branches: |
-            [
-              '+([0-9])?(.{+([0-9]),x}).x',
-              'main',
-              'master',
-              'next',
-              'next-major',
-              {name: 'beta', prerelease: true},
-              {name: 'alpha', prerelease: true}
-            ]
+        uses: ph-fritsche/action-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**What**:

Replace release action.

**Why**:

A few months ago I wanted to file a PR for [`cycjimmy/semantic-release-action`](https://github.com/cycjimmy/semantic-release-action).
But figuring out what part of the code to change was difficult and I felt I had not enough confidence in the changes as the project was written in JS and there were no tests to verify if my guesses in the code base were heading in the right direction.
So I went and wrote [`action-release`](https://github.com/ph-fritsche/action-release) from scratch.

It is in TS, it is unit tested and it dogfeeds itself for releases.

**Checklist**:
- [x] Ready to be merged
