### PR TITLE
chore: update release config

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Release
-        uses: ph-fritsche/action-release@v1
+        uses: ph-fritsche/action-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**What**:

update release action

**Why**:

`semantic-release` does not include `main` in the default release branches.
https://github.com/semantic-release/semantic-release/blob/master/lib/get-config.js#L57-L64

**How**:

I added `main` to the default config applied in `action-release@2`.

**Checklist**:
- [x] Ready to be merged
