### PR TITLE
fix: override build config for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "kcd-scripts build",
+    "build": "kcd-scripts build --no-ts-defs && tsc -p tsconfig.build.json",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "#src": ["./src/index"],
       "#src/*": ["./src/*"],
       "#testHelpers/*": ["./tests/_helpers/*"]
-    }
+    },
+    "noEmit": true
   },
-  "include": ["./src/**/*", "./tests/**/*"]
+  "include": ["./src", "./tests"]
 }


### PR DESCRIPTION
**What**:

Fix output directory of type definitions.

**Why**:

Types export was broken because the new `tsconfig.json` conflicts with `kcd-scripts`.

**How**:
Skip generating type definitions per `kcd-scripts build`.
Generate types per `tsc -p tsconfig.build.json`.

**Checklist**:
- [x] Ready to be merged
