### PR TITLE
feat!: replace `userEvent.paste`

### DIFF
--- a/src/paste.ts
+++ b/src/paste.ts
@@ -68,7 +68,7 @@ async function readClipboardDataFromClipboardApi(document: Document) {
 
   if (!items) {
     throw new Error(
-      '`userEvent.paste() without `clipboardData` requires the `ClipboardAPI` to be available.',
+      '`userEvent.paste()` without `clipboardData` requires the `ClipboardAPI` to be available.',
     )
   }
 

--- a/src/utils/dataTransfer/Blob.ts
+++ b/src/utils/dataTransfer/Blob.ts
@@ -1,0 +1,13 @@
+// jsdom does not implement Blob.text()
+
+export function readBlobText(blob: Blob) {
+  return new Promise<string>((res, rej) => {
+    const fr = new FileReader()
+    fr.onerror = rej
+    fr.onabort = rej
+    fr.onload = () => {
+      res(String(fr.result))
+    }
+    fr.readAsText(blob)
+  })
+}

--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -1,0 +1,152 @@
+// Clipboard is not available in jsdom
+
+import {readBlobText} from '..'
+
+// Clipboard API is only fully available in secure context or for browser extensions.
+
+type ItemData = Record<string, Blob | string | Promise<Blob | string>>
+
+class ClipboardItemStub implements ClipboardItem {
+  private data: ItemData
+  constructor(data: ItemData) {
+    this.data = data
+  }
+
+  get types() {
+    return Array.from(Object.keys(this.data))
+  }
+
+  async getType(type: string) {
+    const data = await this.data[type]
+
+    if (!data) {
+      throw new Error(
+        `${type} is not one of the available MIME types on this item.`,
+      )
+    }
+
+    return data instanceof Blob ? data : new Blob([data], {type})
+  }
+}
+
+const ClipboardStubControl = Symbol('Manage ClipboardSub')
+
+class ClipboardStub extends EventTarget implements Clipboard {
+  private items: ClipboardItem[] = []
+
+  async read() {
+    return Array.from(this.items)
+  }
+
+  async readText() {
+    let text = ''
+    for (const item of this.items) {
+      const type = item.types.includes('text/plain')
+        ? 'text/plain'
+        : item.types.find(t => t.startsWith('text/'))
+      if (type) {
+        text += await item.getType(type).then(b => readBlobText(b))
+      }
+    }
+    return text
+  }
+
+  async write(data: ClipboardItem[]) {
+    this.items = data
+  }
+
+  async writeText(text: string) {
+    this.items = [createClipboardItem(text)]
+  }
+
+  [ClipboardStubControl]: {
+    resetClipboardStub: () => void
+    detachClipboardStub: () => void
+  }
+}
+
+// MDN lists string|Blob|Promise<Blob|string> as possible types in ClipboardItemData
+// lib.dom.d.ts lists only Promise<Blob|string>
+// https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem#syntax
+export function createClipboardItem(
+  ...blobs: Array<Blob | string>
+): ClipboardItem {
+  // use real ClipboardItem if available
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const constructor =
+    typeof ClipboardItem === 'undefined'
+      ? ClipboardItemStub
+      : /* istanbul ignore next */ ClipboardItem
+  return new constructor(
+    Object.fromEntries(
+      blobs.map(b => [
+        typeof b === 'string' ? 'text/plain' : b.type,
+        Promise.resolve(b),
+      ]),
+    ),
+  )
+}
+
+export function attachClipboardStubToView(window: Window & typeof globalThis) {
+  if (window.navigator.clipboard instanceof ClipboardStub) {
+    return window.navigator.clipboard[ClipboardStubControl]
+  }
+
+  const realClipboard = Object.getOwnPropertyDescriptor(
+    window.navigator,
+    'clipboard',
+  )
+
+  let stub = new ClipboardStub()
+  const control = {
+    resetClipboardStub: () => {
+      stub = new ClipboardStub()
+      stub[ClipboardStubControl] = control
+    },
+    detachClipboardStub: () => {
+      /* istanbul ignore if */
+      if (realClipboard) {
+        Object.defineProperty(window.navigator, 'clipboard', realClipboard)
+      } else {
+        Object.defineProperty(window.navigator, 'clipboard', {
+          value: undefined,
+          configurable: true,
+        })
+      }
+    },
+  }
+  stub[ClipboardStubControl] = control
+
+  Object.defineProperty(window.navigator, 'clipboard', {
+    get: () => stub,
+    configurable: true,
+  })
+
+  return stub[ClipboardStubControl]
+}
+
+export function resetClipboardStubOnView(window: Window & typeof globalThis) {
+  if (window.navigator.clipboard instanceof ClipboardStub) {
+    window.navigator.clipboard[ClipboardStubControl].resetClipboardStub()
+  }
+}
+
+export function detachClipboardStubFromView(
+  window: Window & typeof globalThis,
+) {
+  if (window.navigator.clipboard instanceof ClipboardStub) {
+    window.navigator.clipboard[ClipboardStubControl].detachClipboardStub()
+  }
+}
+
+/* istanbul ignore else */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+if (afterEach) {
+  afterEach(() => resetClipboardStubOnView(window))
+}
+
+/* istanbul ignore else */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+if (afterAll) {
+  afterAll(() => detachClipboardStubFromView(window))
+}

--- a/src/utils/dataTransfer/DataTransfer.ts
+++ b/src/utils/dataTransfer/DataTransfer.ts
@@ -1,0 +1,147 @@
+import {createFileList} from './FileList'
+
+// DataTransfer is not implemented in jsdom.
+
+// DataTransfer with FileList is being created by the browser on certain events.
+
+class DataTransferItemStub implements DataTransferItem {
+  readonly kind: DataTransferItem['kind']
+  readonly type: DataTransferItem['type']
+
+  private file: File | null = null
+  private data: string | undefined = undefined
+
+  constructor(data: string, type: string)
+  constructor(file: File)
+  constructor(dataOrFile: string | File, type?: string) {
+    if (typeof dataOrFile === 'string') {
+      this.kind = 'string'
+      this.type = String(type)
+      this.data = dataOrFile
+    } else {
+      this.kind = 'file'
+      this.type = dataOrFile.type
+      this.file = dataOrFile
+    }
+  }
+
+  getAsFile() {
+    return this.file
+  }
+
+  getAsString(callback: (data: string) => unknown) {
+    if (typeof this.data === 'string') {
+      callback(this.data)
+    }
+  }
+
+  /* istanbul ignore next */
+  webkitGetAsEntry(): never {
+    throw new Error('not implemented')
+  }
+}
+
+class DataTransferItemListStub
+  extends Array<DataTransferItem>
+  implements DataTransferItemList
+{
+  add(data: string, type: string): DataTransferItem
+  add(file: File): DataTransferItem
+  add(...args: never[]) {
+    const item = new DataTransferItemStub(args[0], args[1])
+    this.push(item)
+    return item
+  }
+
+  clear() {
+    this.splice(0, this.length)
+  }
+
+  remove(index: number) {
+    this.splice(index, 1)
+  }
+}
+
+function getTypeMatcher(type: string, exact: boolean) {
+  const [group, sub] = type.split('/')
+  const isGroup = !sub || sub === '*'
+  return (item: DataTransferItem) => {
+    return exact
+      ? item.type === (isGroup ? group : type)
+      : isGroup
+      ? item.type.startsWith(`${group}/`)
+      : item.type === group
+  }
+}
+
+class DataTransferStub implements DataTransfer {
+  getData(format: string) {
+    const match =
+      this.items.find(getTypeMatcher(format, true)) ??
+      this.items.find(getTypeMatcher(format, false))
+
+    let text = ''
+    match?.getAsString(t => {
+      text = t
+    })
+
+    return text
+  }
+
+  setData(format: string, data: string) {
+    const matchIndex = this.items.findIndex(getTypeMatcher(format, true))
+
+    const item = new DataTransferItemStub(data, format) as DataTransferItem
+    if (matchIndex >= 0) {
+      this.items.splice(matchIndex, 1, item)
+    } else {
+      this.items.push(item)
+    }
+  }
+
+  clearData(format?: string) {
+    if (format) {
+      const matchIndex = this.items.findIndex(getTypeMatcher(format, true))
+
+      if (matchIndex >= 0) {
+        this.items.remove(matchIndex)
+      }
+    } else {
+      this.items.clear()
+    }
+  }
+
+  dropEffect: DataTransfer['dropEffect'] = 'none'
+  effectAllowed: DataTransfer['effectAllowed'] = 'uninitialized'
+
+  readonly items = new DataTransferItemListStub()
+  readonly files = createFileList([])
+
+  get types() {
+    const t = []
+    if (this.files.length) {
+      t.push('Files')
+    }
+    this.items.forEach(i => t.push(i.type))
+
+    Object.freeze(t)
+
+    return t
+  }
+
+  /* istanbul ignore next */
+  setDragImage() {}
+}
+
+export function createDataTransfer(files: File[] = []): DataTransfer {
+  // Use real DataTransfer if available
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const dt =
+    typeof DataTransfer === 'undefined'
+      ? (new DataTransferStub() as DataTransfer)
+      : /* istanbul ignore next */ new DataTransfer()
+
+  Object.defineProperty(dt, 'files', {get: () => createFileList(files)})
+
+  return dt
+}

--- a/src/utils/dataTransfer/FileList.ts
+++ b/src/utils/dataTransfer/FileList.ts
@@ -1,0 +1,9 @@
+// FileList can not be created per constructor.
+
+export function createFileList(files: File[]): FileList {
+  const f = [...files]
+
+  Object.setPrototypeOf(f, FileList.prototype)
+
+  return f as unknown as FileList
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,10 @@
 export * from './click/isClickableInput'
 
+export * from './dataTransfer/Blob'
+export * from './dataTransfer/DataTransfer'
+export * from './dataTransfer/FileList'
+export * from './dataTransfer/Clipboard'
+
 export * from './edit/buildTimeValue'
 export * from './edit/calculateNewValue'
 export * from './edit/editInputElement'

--- a/tests/paste.js
+++ b/tests/paste.js
@@ -107,7 +107,7 @@ describe('paste from clipboard', () => {
     element.focus()
 
     await expect(() => userEvent.paste()).rejects.toMatchInlineSnapshot(
-      `[Error: \`userEvent.paste() without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
+      `[Error: \`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
     )
     expect(getEvents('paste')).toHaveLength(0)
   })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -205,7 +205,7 @@ cases<APICase>(
         keyboardMap: [{key: 'y', code: 'SpecialKey'}],
       },
     },
-    paste: {api: 'paste', args: [null, 'foo'], elementArg: 0},
+    paste: {api: 'paste', args: ['foo']},
     pointer: {
       api: 'pointer',
       args: ['foo'],

--- a/tests/utils/dataTransfer/Clipboard.ts
+++ b/tests/utils/dataTransfer/Clipboard.ts
@@ -1,0 +1,56 @@
+import {
+  attachClipboardStubToView,
+  createClipboardItem,
+  detachClipboardStubFromView,
+  readBlobText,
+  resetClipboardStubOnView,
+} from '#src/utils'
+
+describe('read from and write to clipboard', () => {
+  beforeEach(() => {
+    attachClipboardStubToView(window)
+  })
+
+  test('read and write text', async () => {
+    await window.navigator.clipboard.writeText('foo')
+    await expect(window.navigator.clipboard.readText()).resolves.toBe('foo')
+  })
+
+  test('read and write item', async () => {
+    const items = [
+      createClipboardItem(new Blob(['foo'], {type: 'text/plain'})),
+      createClipboardItem(new Blob(['bar'], {type: 'text/html'})),
+      createClipboardItem(new Blob(['PNG'], {type: 'image/png'})),
+      createClipboardItem(
+        new Blob(['baz1'], {type: 'text/plain'}),
+        new Blob(['baz2'], {type: 'text/html'}),
+      ),
+    ]
+    expect(items[0]).toHaveProperty('types', ['text/plain'])
+    expect(items[3]).toHaveProperty('types', ['text/plain', 'text/html'])
+    await expect(items[3].getType('text/html')).resolves.toBeInstanceOf(Blob)
+    await expect(
+      readBlobText(await items[3].getType('text/html')),
+    ).resolves.toBe('baz2')
+    await expect(items[3].getType('image/png')).rejects.toThrowError()
+
+    await window.navigator.clipboard.write(items)
+
+    await expect(window.navigator.clipboard.read()).resolves.toEqual(items)
+    await expect(window.navigator.clipboard.readText()).resolves.toBe(
+      'foobarbaz1',
+    )
+  })
+
+  test('reset clipboard', async () => {
+    await window.navigator.clipboard.writeText('foo')
+    resetClipboardStubOnView(window)
+    await expect(window.navigator.clipboard.readText()).resolves.toBe('')
+  })
+
+  test('detach clipboard', () => {
+    expect(window.navigator.clipboard).not.toBe(undefined)
+    detachClipboardStubFromView(window)
+    expect(window.navigator.clipboard).toBe(undefined)
+  })
+})

--- a/tests/utils/dataTransfer/DataTransfer.ts
+++ b/tests/utils/dataTransfer/DataTransfer.ts
@@ -1,0 +1,86 @@
+import {createDataTransfer} from '#src/utils'
+
+describe('create DataTransfer', () => {
+  test('plain string', () => {
+    const dt = createDataTransfer()
+    dt.setData('text/plain', 'foo')
+
+    expect(dt.getData('text/plain')).toBe('foo')
+
+    const callback = jest.fn()
+    dt.items[0].getAsString(callback)
+    expect(callback).toBeCalledWith('foo')
+  })
+
+  test('multi format', () => {
+    const dt = createDataTransfer()
+    dt.setData('text/plain', 'foo')
+    dt.setData('text/html', 'bar')
+
+    expect(dt.types).toEqual(['text/plain', 'text/html'])
+
+    expect(dt.getData('text/plain')).toBe('foo')
+    expect(dt.getData('text/html')).toBe('bar')
+    expect(dt.getData('text/*')).toBe('foo')
+    expect(dt.getData('text')).toBe('foo')
+
+    dt.clearData()
+    dt.setData('text', 'baz')
+    expect(dt.getData('text/plain')).toBe('baz')
+    expect(dt.getData('text')).toBe('baz')
+  })
+
+  test('overwrite item', () => {
+    const dt = createDataTransfer()
+    dt.setData('text/plain', 'foo')
+    dt.setData('text/plain', 'bar')
+
+    expect(dt.types).toEqual(['text/plain'])
+    expect(dt.getData('text')).toBe('bar')
+  })
+
+  test('files operation', () => {
+    const f0 = new File(['bar'], 'bar0.txt', {type: 'text/plain'})
+    const f1 = new File(['bar'], 'bar1.txt', {type: 'text/plain'})
+    const dt = createDataTransfer([f0, f1])
+    dt.setData('text/html', 'foo')
+
+    expect(dt.types).toEqual(['Files', 'text/html'])
+    expect(dt.files.length).toBe(2)
+  })
+
+  test('files item', () => {
+    const f0 = new File(['bar'], 'bar0.txt', {type: 'text/plain'})
+    const dt = createDataTransfer()
+    dt.setData('text/html', 'foo')
+    dt.items.add(f0)
+
+    expect(dt.types).toEqual(['text/html', 'text/plain'])
+
+    expect(dt.items[0].getAsFile()).toBe(null)
+    expect(dt.items[1].getAsFile()).toBe(f0)
+
+    const callback = jest.fn()
+    dt.items[1].getAsString(callback)
+    expect(callback).not.toBeCalled()
+  })
+
+  test('clear data', () => {
+    const f0 = new File(['bar'], 'bar0.txt', {type: 'text/plain'})
+    const dt = createDataTransfer()
+    dt.setData('text/html', 'foo')
+    dt.items.add(f0)
+
+    dt.clearData('text/plain')
+
+    expect(dt.types).toEqual(['text/html'])
+
+    dt.clearData('text/plain')
+
+    expect(dt.types).toEqual(['text/html'])
+
+    dt.clearData()
+
+    expect(dt.types).toEqual([])
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,
+    "target": "ES5",
     "baseUrl": ".",
     "paths": {
       "#src": ["./src/index"],


### PR DESCRIPTION
BREAKING CHANGE: The `userEvent.paste` API has new parameters.

**What**:

Replace `userEvent.paste(element, text, init, options)` API with:
```js
userEvent.paste('textToBePasted')
userEvent.paste(clipboardData) // DataTransfer object
userEvent.paste() // Read from Clipboard API
```

**Why**:

Closes #782 

**How**:

Implement logic as outlined in #782
This includes workarounds for the missing APIs in Jsdom.

`userEvent.setup()` replaces `window.navigator.clipboard` as the API is not available outside of secure context.
Uses `DataTransfer` and `ClipboardItem` if available, otherwise(Jsdom) it comes with stubs implementing most features.

A second parameter `options` exist to allow the usage on documents that are not `global.document`.
```
userEvent.paste(data, {document: myDocument})
userEvent.setup({document: myDocument}).paste(data) // or per setup
```

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
