### PR TITLE
wip: async APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,5 @@
-import {userEventApis, UserEventApis, setup, UserEvent} from './setup'
+import {userEventDefault} from './setup'
 
-const userEvent: UserEventApis & {
-  setup: typeof setup
-} = {
-  ...(Object.fromEntries(
-    Object.entries(userEventApis).map(([k, f]) => [
-      k,
-      (...a: unknown[]) =>
-        (f as (this: UserEvent, ...b: unknown[]) => unknown).apply(
-          userEvent,
-          a,
-        ),
-    ]),
-  ) as UserEventApis),
-  setup,
-}
-
-export default userEvent
+export default userEventDefault
 
 export type {keyboardKey} from './keyboard'

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -19,8 +19,9 @@ import {tab, tabOptions} from './tab'
 import {type, typeOptions} from './type'
 import {upload, uploadOptions} from './upload'
 import {PointerOptions, attachClipboardStubToView} from './utils'
+import {getDocumentFromNode} from './utils/misc/getDocumentFromNode'
 
-export const userEventApis = {
+const userEventApiImplementations = {
   clear,
   click,
   copy,
@@ -37,12 +38,112 @@ export const userEventApis = {
   type,
   unhover,
   upload,
+} as const
+
+/** Which is the options parameter? */
+const userEventApiOptionsParameter = {
+  clear: undefined,
+  click: 1,
+  copy: 0,
+  cut: 0,
+  dblClick: 1,
+  deselectOptions: 2,
+  hover: 1,
+  keyboard: 1,
+  paste: 1,
+  pointer: 1,
+  selectOptions: 2,
+  tab: 0,
+  tripleClick: 1,
+  type: 2,
+  unhover: 1,
+  upload: 3,
+} as const
+
+/** Which return values should be void when used per setup? */
+const userEventApiVoidReturn = {
+  keyboard,
+  pointer,
 }
-export type UserEventApis = typeof userEventApis
-type setup = ReturnType<typeof _setup>['setup']
-export type UserEvent = UserEventApis & {
-  setup: setup
+
+type ApiImpl = typeof userEventApiImplementations
+type ApiNames = keyof typeof userEventApiImplementations
+type PromisedValue<T> = T extends Promise<unknown> ? T : Promise<T>
+type AsyncApis = {
+  [k in ApiNames]: (
+    this: ThisType<ApiImpl[k]>,
+    ...args: Parameters<ApiImpl[k]>
+  ) => PromisedValue<ReturnType<ApiImpl[k]>>
 }
+
+export type UserEventApis = typeof userEventApiImplementations
+export type UserEvent = typeof userEventDefault | ReturnType<typeof setup>
+
+function setupDocument(node?: Node) {
+  const doc =
+    (node && getDocumentFromNode(node)) ??
+    (global.document as Document | undefined)
+
+  // Might be undefined in other environments
+  /* istanbul ignore else */
+  if (doc) {
+    prepareDocument(doc)
+  }
+
+  return doc
+}
+
+/**
+ * Start a "session" with userEvent.
+ * All APIs returned by this function share an input device state and a default configuration.
+ */
+function setup(options: SetupOptions = {}) {
+  setupDocument(options.document)
+
+  const view = options.document?.defaultView ?? window
+  attachClipboardStubToView(view)
+
+  return _setup(options, {
+    keyboardState: createKeyboardState(),
+    pointerState: createPointerState(),
+  })
+}
+
+function getDocumentFromOptions<K extends ApiNames>(
+  api: K,
+  args: Parameters<ApiImpl[K]>,
+) {
+  if (userEventApiOptionsParameter[api] !== undefined) {
+    return (
+      args[userEventApiOptionsParameter[api] as number] as
+        | {document: Document}
+        | undefined
+    )?.document
+  }
+}
+
+export const userEventDefault = {
+  ...Object.fromEntries(
+    Object.entries(userEventApiImplementations).map(([api, impl]) => {
+      function func(
+        this: ThisType<typeof impl>,
+        ...args: Parameters<typeof impl>
+      ) {
+        setupDocument(
+          args[0] instanceof Element
+            ? args[0]
+            : getDocumentFromOptions(api as ApiNames, args),
+        )
+
+        return (impl as (...a: unknown[]) => unknown).apply(this, args)
+      }
+      Object.defineProperty(func, 'name', {get: () => impl.name})
+
+      return [api, func]
+    }),
+  ),
+  setup,
+} as typeof userEventApiImplementations & {setup: typeof setup}
 
 type ClickOptions = Omit<clickOptions, 'clickCount'>
 
@@ -71,23 +172,6 @@ interface SetupOptions
     TypeOptions,
     UploadOptions {}
 
-/**
- * Start a "session" with userEvent.
- * All APIs returned by this function share an input device state and a default configuration.
- */
-export function setup(options: SetupOptions = {}) {
-  const doc = options.document ?? document
-  prepareDocument(doc)
-
-  const view = doc.defaultView ?? /* istanbul ignore next */ window
-  attachClipboardStubToView(view)
-
-  return _setup(options, {
-    keyboardState: createKeyboardState(),
-    pointerState: createPointerState(),
-  })
-}
-
 function _setup(
   {
     applyAccept,
@@ -109,120 +193,67 @@ function _setup(
     writeToClipboard = false,
   }: SetupOptions,
   {
-    keyboardState,
-    pointerState,
+    keyboardState = createKeyboardState(),
+    pointerState = createPointerState(),
   }: {
     keyboardState: keyboardState
     pointerState: pointerState
   },
-): UserEventApis & {
+): AsyncApis & {
   /**
    * Create a set of callbacks with different default settings but the same state.
    */
   setup(options: SetupOptions): ReturnType<typeof _setup>
 } {
-  const keyboardDefaults: KeyboardOptions = {
+  const defaultOptions = {
+    applyAccept,
     autoModify,
-    delay,
-    document,
-    keyboardMap,
-  }
-  const pointerDefaults: PointerOptions = {
-    skipPointerEventsCheck,
-  }
-  const pointerApiDefaults: PointerApiOptions = {
-    delay,
-    pointerMap,
-  }
-  const clickDefaults: clickOptions = {
-    skipHover,
-  }
-  const clipboardDefaults: ClipboardOptions = {
-    document,
-    writeToClipboard,
-  }
-  const typeDefaults: TypeOptions = {
     delay,
     skipAutoClose,
     skipClick,
+    skipHover,
+    skipPointerEventsCheck,
+    writeToClipboard,
+    keyboardMap,
+    pointerMap,
   }
-  const uploadDefaults: UploadOptions = {
-    applyAccept,
+  const overwriteOptions = {
+    document,
+    keyboardState,
+    pointerState,
   }
 
-  const userEvent: UserEvent = {
-    clear: (...args: Parameters<typeof clear>) => {
-      return clear.call(userEvent, ...args)
-    },
+  return {
+    ...Object.fromEntries(
+      Object.entries(userEventApiImplementations).map(([api, impl]) => {
+        function func(
+          this: ThisType<typeof impl>,
+          ...args: Parameters<typeof impl>
+        ) {
+          if (userEventApiOptionsParameter[api as ApiNames] !== undefined) {
+            const i = userEventApiOptionsParameter[api as ApiNames] as number
+            args[i] = {
+              ...defaultOptions,
+              ...(args[i] as {}),
+              ...overwriteOptions,
+            }
+          }
+          const ret = (impl as (...a: unknown[]) => unknown).apply(this, args)
+          return (ret instanceof Promise ? ret : Promise.resolve(ret)).then(v =>
+            api in userEventApiVoidReturn ? undefined : v,
+          )
+        }
+        Object.defineProperty(func, 'name', {get: () => impl.name})
 
-    click: (...args: Parameters<typeof click>) => {
-      args[1] = {...pointerDefaults, ...clickDefaults, ...args[1]}
-      return click.call(userEvent, ...args)
-    },
-
-    // copy needs typecasting because of the overloading
-    copy: ((...args: Parameters<typeof copy>) => {
-      args[0] = {...clipboardDefaults, ...args[0]}
-      return copy.call(userEvent, ...args)
-    }) as typeof copy,
-
-    // cut needs typecasting because of the overloading
-    cut: ((...args: Parameters<typeof cut>) => {
-      args[0] = {...clipboardDefaults, ...args[0]}
-      return cut.call(userEvent, ...args)
-    }) as typeof cut,
-
-    dblClick: (...args: Parameters<typeof dblClick>) => {
-      args[1] = {...pointerDefaults, ...clickDefaults, ...args[1]}
-      return dblClick.call(userEvent, ...args)
-    },
-
-    deselectOptions: (...args: Parameters<typeof deselectOptions>) => {
-      args[2] = {...pointerDefaults, ...args[2]}
-      return deselectOptions.call(userEvent, ...args)
-    },
-
-    hover: (...args: Parameters<typeof hover>) => {
-      args[1] = {...pointerDefaults, ...args[1]}
-      return hover.call(userEvent, ...args)
-    },
-
-    // keyboard needs typecasting because of the overloading
-    keyboard: ((...args: Parameters<typeof keyboard>) => {
-      args[1] = {...keyboardDefaults, ...args[1], keyboardState}
-      const ret = keyboard(...args) as keyboardState | Promise<keyboardState>
-      if (ret instanceof Promise) {
-        return ret.then(() => undefined)
-      }
-    }) as typeof keyboard,
-
-    // paste needs typecasting because of the overloading
-    paste: ((...args: Parameters<typeof paste>) => {
-      args[1] = {...clipboardDefaults, ...args[1]}
-      return paste.call(userEvent, ...args)
-    }) as typeof paste,
-
-    // pointer needs typecasting because of the overloading
-    pointer: ((...args: Parameters<typeof pointer>) => {
-      args[1] = {...pointerApiDefaults, ...args[1], pointerState, keyboardState}
-      const ret = pointer(...args) as pointerState | Promise<pointerState>
-      if (ret instanceof Promise) {
-        return ret.then(() => undefined)
-      }
-    }) as typeof pointer,
-
-    selectOptions: (...args: Parameters<typeof selectOptions>) => {
-      args[2] = {...pointerDefaults, ...args[2]}
-      return selectOptions.call(userEvent, ...args)
-    },
-
+        return [api, func]
+      }),
+    ),
     setup: (options: SetupOptions) => {
       return _setup(
         {
-          ...keyboardDefaults,
-          ...pointerDefaults,
-          ...clickDefaults,
+          ...defaultOptions,
           ...options,
+          ...overwriteOptions,
         },
         {
           keyboardState,
@@ -230,31 +261,5 @@ function _setup(
         },
       )
     },
-
-    tab: (...args: Parameters<typeof tab>) => {
-      return tab.call(userEvent, ...args)
-    },
-
-    tripleClick: (...args: Parameters<typeof tripleClick>) => {
-      return tripleClick.call(userEvent, ...args)
-    },
-
-    // type needs typecasting because of the overloading
-    type: ((...args: Parameters<typeof type>) => {
-      args[2] = {...typeDefaults, ...args[2]}
-      return type.call(userEvent, ...args)
-    }) as typeof type,
-
-    unhover: (...args: Parameters<typeof unhover>) => {
-      args[1] = {...pointerDefaults, ...args[1]}
-      return unhover.call(userEvent, ...args)
-    },
-
-    upload: (...args: Parameters<typeof upload>) => {
-      args[3] = {...uploadDefaults, ...args[3]}
-      return upload.call(userEvent, ...args)
-    },
-  }
-
-  return userEvent
+  } as AsyncApis & {setup: (options: SetupOptions) => ReturnType<typeof _setup>}
 }

--- a/src/utils/misc/getDocumentFromNode.ts
+++ b/src/utils/misc/getDocumentFromNode.ts
@@ -1,0 +1,7 @@
+export function getDocumentFromNode(el: Node) {
+  return isDocument(el) ? el : el.ownerDocument
+}
+
+function isDocument(node: Node): node is Document {
+  return node.nodeType === 9
+}

--- a/src/utils/setup/makeOptionalAsync.ts
+++ b/src/utils/setup/makeOptionalAsync.ts
@@ -1,0 +1,48 @@
+import {getConfig as getDOMTestingLibraryConfig} from '@testing-library/dom'
+
+interface PromiseAndReturn<T> {
+  promise: Promise<void>
+  returnValue: T
+}
+
+/**
+ * Create a function that might void an internal Promise
+ *
+ * If the implementation should create some return value
+ * that is returned by the sync version this must be returned alongside the Promise.
+ */
+export function makeOptionalAsync<
+  ReturnValue extends Promise<void> | PromiseAndReturn<unknown>,
+  Impl extends () => ReturnValue,
+>(
+  /**
+   * The asynchronous implementation or a wrapper returning the return data alongside the Promise.
+   */
+  implementation: Impl,
+  /**
+   * Determine if the implementation should be treated as sync and the Promise be voided.
+   */
+  treatAsSync: (this: ThisType<Impl>, ...args: Parameters<Impl>) => boolean,
+) {
+  function func(this: ThisType<Impl>, ...args: Parameters<Impl>) {
+    const implReturn = implementation.apply(this, args)
+
+    const promise =
+      implReturn instanceof Promise ? implReturn : implReturn.promise
+    const returnValue =
+      implReturn instanceof Promise ? void undefined : implReturn.returnValue
+
+    if (treatAsSync.apply(this, args)) {
+      // prevent users from dealing with UnhandledPromiseRejectionWarning in sync call
+      promise.catch(console.error)
+
+      return returnValue
+    } else {
+      return getDOMTestingLibraryConfig().asyncWrapper(() =>
+        promise.then(() => returnValue),
+      )
+    }
+  }
+  func.name = implementation.name
+  return func
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -288,7 +288,7 @@ test('maintain `keyboardState` through different api calls', async () => {
 
   const api = userEvent.setup()
 
-  expect(api.keyboard('{a>}{b>}')).toBe(undefined)
+  await expect(api.keyboard('{a>}{b>}')).resolves.toBe(undefined)
 
   expect(getSpy('keyboard')).toBeCalledTimes(1)
 
@@ -312,7 +312,9 @@ test('maintain `pointerState` through different api calls', async () => {
 
   const api = userEvent.setup()
 
-  expect(api.pointer({keys: '[MouseLeft>]', target: element})).toBe(undefined)
+  await expect(
+    api.pointer({keys: '[MouseLeft>]', target: element}),
+  ).resolves.toBe(undefined)
 
   expect(getSpy('pointer')).toBeCalledTimes(1)
   expect(getEvents('mousedown')).toHaveLength(1)


### PR DESCRIPTION
**What**:

Always return asynchronous APIs from `userEvent.setup`.

**Why**:
See #504 

**How**:

Take API parameters, inject default options from `setup` call and convert everything to a Promise if it isn't already.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
