### PR TITLE
feat(upload)!: replace element properties

### DIFF
--- a/src/setup/directApi.ts
+++ b/src/setup/directApi.ts
@@ -1,5 +1,4 @@
 import type {PointerOptions} from '../utils'
-import type {uploadInit} from '../utility'
 import type {PointerInput} from '../pointer'
 import type {UserEventApi} from '.'
 import {setupDirect} from './setup'
@@ -91,10 +90,9 @@ export function unhover(element: Element, options: PointerOptions = {}) {
 export function upload(
   element: HTMLElement,
   fileOrFiles: File | File[],
-  init?: uploadInit,
   options: Partial<Config> = {},
 ) {
-  return setupDirect(options).upload(element, fileOrFiles, init)
+  return setupDirect(options).upload(element, fileOrFiles)
 }
 
 export function tab(

--- a/src/utils/dataTransfer/FileList.ts
+++ b/src/utils/dataTransfer/FileList.ts
@@ -1,9 +1,19 @@
 // FileList can not be created per constructor.
 
 export function createFileList(files: File[]): FileList {
-  const f = [...files]
+  const list: FileList & Iterable<File> = {
+    ...files,
+    length: files.length,
+    item: (index: number) => list[index],
+    [Symbol.iterator]: function* nextFile() {
+      for (let i = 0; i < list.length; i++) {
+        yield list[i]
+      }
+    },
+  }
+  list.constructor = FileList
+  Object.setPrototypeOf(list, FileList.prototype)
+  Object.freeze(list)
 
-  Object.setPrototypeOf(f, FileList.prototype)
-
-  return f as unknown as FileList
+  return list
 }

--- a/src/utils/edit/setFiles.ts
+++ b/src/utils/edit/setFiles.ts
@@ -1,0 +1,77 @@
+// It is not possible to create a real FileList programmatically.
+// Therefore assigning `files` property with a programmatically created FileList results in an error.
+// Just assigning the property (as per fireEvent) breaks the interweaving with the `value` property.
+
+const fakeFiles = Symbol('files and value properties are mocked')
+
+declare global {
+  interface HTMLInputElement {
+    [fakeFiles]?: {
+      restore: () => void
+    }
+  }
+}
+
+export function setFiles(
+  el: HTMLInputElement & {type: 'file'},
+  files: FileList,
+) {
+  el[fakeFiles]?.restore()
+
+  const objectDescriptors = Object.getOwnPropertyDescriptors(el)
+  const prototypeDescriptors = Object.getOwnPropertyDescriptors(
+    Object.getPrototypeOf(el),
+  )
+
+  function restore() {
+    Object.defineProperties(el, {
+      files: {
+        ...prototypeDescriptors.files,
+        ...objectDescriptors.files,
+      },
+      value: {
+        ...prototypeDescriptors.value,
+        ...objectDescriptors.value,
+      },
+      type: {
+        ...prototypeDescriptors.type,
+        ...objectDescriptors.type,
+      },
+    })
+  }
+  el[fakeFiles] = {restore}
+
+  Object.defineProperties(el, {
+    files: {
+      ...prototypeDescriptors.files,
+      ...objectDescriptors.files,
+      get: () => files,
+    },
+    value: {
+      ...prototypeDescriptors.value,
+      ...objectDescriptors.value,
+      get: () => (files.length ? `C:\\fakepath\\${files[0].name}` : ''),
+      set(v: string) {
+        if (v === '') {
+          restore()
+        } else {
+          objectDescriptors.value.set?.call(el, v)
+        }
+      },
+    },
+    // eslint-disable-next-line accessor-pairs
+    type: {
+      ...prototypeDescriptors.type,
+      ...objectDescriptors.type,
+      set(v: string) {
+        if (v !== 'file') {
+          restore()
+          // In the browser the value will be empty.
+          // In Jsdom the value will be the same as
+          // before this element became file input - which might be empty.
+          ;(el as HTMLInputElement).type = v
+        }
+      },
+    },
+  })
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -203,6 +203,7 @@ cases<APICase>(
     upload: {
       api: 'upload',
       elementArg: 0,
+      args: [null, new File(['foo'], 'foo.txt')],
     },
   },
 )

--- a/tests/upload.ts
+++ b/tests/upload.ts
@@ -11,7 +11,7 @@ test('should fire the correct events for input', async () => {
   // value of the input programmatically. The value in the browser
   // set by a user would be: `C:\\fakepath\\${file.name}`
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: input[value=""]
+    Events fired on: input[value="C:\\\\fakepath\\\\hello.png"]
 
     input[value=""] - pointerover
     input[value=""] - pointerenter
@@ -30,8 +30,8 @@ test('should fire the correct events for input', async () => {
     input[value=""] - focusout
     input[value=""] - focus
     input[value=""] - focusin
-    input[value=""] - input
-    input[value=""] - change
+    input[value="C:\\\\fakepath\\\\hello.png"] - input
+    input[value="C:\\\\fakepath\\\\hello.png"] - change
   `)
 })
 
@@ -64,8 +64,8 @@ test('should fire the correct events with label', async () => {
     label[for="element"] - click: primary
     input#element[value=""] - click: primary
     input#element[value=""] - focusin
-    input#element[value=""] - input
-    input#element[value=""] - change
+    input#element[value="C:\\\\fakepath\\\\hello.png"] - input
+    input#element[value="C:\\\\fakepath\\\\hello.png"] - change
   `)
 })
 
@@ -187,7 +187,7 @@ test.each([
     />
   `)
 
-    await userEvent.upload(element, files, undefined, {applyAccept})
+    await userEvent.upload(element, files, {applyAccept})
 
     expect(element.files).toHaveLength(expectedLength)
   },
@@ -254,15 +254,4 @@ test('throw error if trying to use upload on an invalid element', async () => {
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `The associated INPUT element does not accept file uploads`,
   )
-})
-
-test('apply init options', async () => {
-  const {element, getEvents} = setup('<input type="file"/>')
-
-  await userEvent.upload(element, new File([], 'hello.png'), {
-    changeInit: {cancelable: true},
-  })
-
-  expect(getEvents('click')[0]).toHaveProperty('shiftKey', false)
-  expect(getEvents('change')[0]).toHaveProperty('cancelable', true)
 })

--- a/tests/utils/edit/setFiles.ts
+++ b/tests/utils/edit/setFiles.ts
@@ -1,0 +1,69 @@
+import {createFileList} from '#src/utils'
+import {setFiles} from '#src/utils/edit/setFiles'
+import {setup} from '#testHelpers/utils'
+
+test('set files', () => {
+  const {element} = setup<HTMLInputElement & {type: 'file'}>(
+    `<input type="file"/>`,
+  )
+
+  const list = createFileList([new File(['foo'], 'foo.txt')])
+  setFiles(element, list)
+
+  expect(element).toHaveProperty('files', list)
+  expect(element).toHaveValue('C:\\fakepath\\foo.txt')
+})
+
+test('switching type resets value', () => {
+  const {element} = setup<HTMLInputElement>(`<input type="text"/>`)
+
+  element.type = 'file'
+
+  expect(element).toHaveValue('')
+
+  const list = createFileList([new File(['foo'], 'foo.txt')])
+  setFiles(element as HTMLInputElement & {type: 'file'}, list)
+
+  element.type = 'file'
+
+  expect(element).toHaveValue('C:\\fakepath\\foo.txt')
+
+  element.type = 'text'
+
+  expect(element).toHaveValue('')
+  expect(element).toHaveProperty('type', 'text')
+})
+
+test('setting value resets `files`', () => {
+  const {element} = setup<HTMLInputElement & {type: 'file'}>(
+    `<input type="file"/>`,
+  )
+
+  const list = createFileList([new File(['foo'], 'foo.txt')])
+  setFiles(element, list)
+
+  // Everything but an empty string throws an error in the browser
+  expect(() => {
+    element.value = 'foo'
+  }).toThrow()
+
+  expect(element).toHaveProperty('files', list)
+
+  element.value = ''
+
+  expect(element).toHaveProperty('files', expect.objectContaining({length: 0}))
+})
+
+test('is save to call multiple times', () => {
+  const {element} = setup<HTMLInputElement & {type: 'file'}>(
+    `<input type="file"/>`,
+  )
+
+  const list = createFileList([new File(['foo'], 'foo.txt')])
+  setFiles(element, list)
+  setFiles(element, list)
+
+  expect(element).toHaveValue('C:\\fakepath\\foo.txt')
+  element.value = ''
+  expect(element).toHaveValue('')
+})


### PR DESCRIPTION
BREAKING CHANGE: `init` parameter has been removed from `userEvent.upload`.

**What**:

1. Replace properties on `<input type="file"/>` when changing it per `userEvent.upload`.
2. Remove `init` parameter.

**Why**:

The previous implementation changed the `element.files` properties through `fireEvent` and `event.target.files`.
That assigns the given property to the element.
As a result the element's `value`, `type` and `files` properties don't interact with each other any more like they do in the browser.

The `init` parameter has been removed for `MouseEvent` and there is no good reason to keep it here. See #784 

**How**:

We can not programmatically create a `FileList`.
The browser creates these from trusted events and both the browser and Jsdom prevent constructing it and also prevent calling the FileList prototype methods on an object which was not created by their internal mechanism.
They also prevent setting `element.files` to a value that is not a real `FileList`.

This PR therefore introduces a utility that, given one of our `FileList` stubs, replaces the relevant property descriptors on the element and mimicks the browser behavior.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
