### PR TITLE
fix(tab): skip elements with `visibility:hidden`

### DIFF
--- a/src/utils/misc/isVisible.ts
+++ b/src/utils/misc/isVisible.ts
@@ -8,8 +8,11 @@ export function isVisible(element: Element): boolean {
     el?.ownerDocument;
     el = el.parentElement
   ) {
-    const display = window.getComputedStyle(el).display
+    const {display, visibility} = window.getComputedStyle(el)
     if (display === 'none') {
+      return false
+    }
+    if (visibility === 'hidden') {
       return false
     }
   }

--- a/tests/tab.ts
+++ b/tests/tab.ts
@@ -564,3 +564,19 @@ test('calls FocusEvents with relatedTarget', async () => {
       ?.relatedTarget,
   ).toBe(element0)
 })
+
+test('should not focus on children of element with style `visiblity: hidden`', () => {
+  const {
+    elements: [inputA, , inputB],
+  } = setup(`
+    <input/>
+    <div style="visibility: hidden;">
+      <input/>
+    </div>
+    <input/>
+  `)
+
+  inputA.focus()
+  userEvent.tab()
+  expect(inputB).toHaveFocus()
+})

--- a/tests/utils/misc/isVisible.ts
+++ b/tests/utils/misc/isVisible.ts
@@ -9,6 +9,7 @@ test('check if element is visible', async () => {
     <input data-testid="styledHiddenInput" style="display: none">
     <input data-testid="styledDisplayedInput" hidden style="display: block"/>
     <div style="display: none"><input data-testid="childInput" /></div>
+    <input data-testid="styledVisibiliyHiddenInput" style="visibility: hidden">
   `)
 
   expect(isVisible(screen.getByTestId('visibleInput'))).toBe(true)
@@ -16,4 +17,7 @@ test('check if element is visible', async () => {
   expect(isVisible(screen.getByTestId('styledHiddenInput'))).toBe(false)
   expect(isVisible(screen.getByTestId('childInput'))).toBe(false)
   expect(isVisible(screen.getByTestId('hiddenInput'))).toBe(false)
+  expect(isVisible(screen.getByTestId('styledVisibiliyHiddenInput'))).toBe(
+    false,
+  )
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Calling `userEvent.tab` focuses on element with `visibility: hidden`, which is not expected.


**Why**:
It breaks use cases related to `visibility:hidden` and `userEvent.tab`

**How**:
<!-- How were these changes implemented? -->
It is fixed by checking whether the target element has style `visibility: hidden`.


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
This PR is identical to #797 , but targeting `beta`