### PR TITLE
fix(keyboard): submit form with `<button/>` on `[Enter]`

### DIFF
--- a/src/utils/misc/hasFormSubmit.ts
+++ b/src/utils/misc/hasFormSubmit.ts
@@ -1,8 +1,6 @@
 export const hasFormSubmit = (
   form: HTMLFormElement | null,
 ): form is HTMLFormElement =>
-  !!(
-    form &&
-    (form.querySelector('input[type="submit"]') ||
-      form.querySelector('button[type="submit"]'))
+  !!form?.querySelector(
+    'input[type="submit"], button:not([type]), button[type="submit"]',
   )

--- a/tests/keyboard/plugin/functional.ts
+++ b/tests/keyboard/plugin/functional.ts
@@ -96,11 +96,10 @@ cases(
       html: `<form><input/><input/><input type="submit"/></form>`,
       submit: true,
     },
-    // TODO: submit with button without type attribute
-    // 'with `<button/>`': {
-    //   html: `<form><input/><input/><button/></form>`,
-    //   submit: true,
-    // },
+    'with `<button/>`': {
+      html: `<form><input/><input/><button/></form>`,
+      submit: true,
+    },
     'with `<button type="submit"/>`': {
       html: `<form><input/><input/><button type="submit"/></form>`,
       submit: true,


### PR DESCRIPTION
**What**:

Given an `HTMLFormElement` that contains both an `HTMLInputElement` and a `HTMLButtonElement`, submit the form when `[Enter]` is pressed on the input element.

**Why**:
Closes #802 

**Checklist**:
- [x] Tests
- [x] Ready to be merged
