### PR TITLE
fix(tab): order `tabIndex>0` before `tabIndex=0`

### DIFF
--- a/src/utils/focus/getTabDestination.ts
+++ b/src/utils/focus/getTabDestination.ts
@@ -18,10 +18,18 @@ export function getTabDestination(activeElement: Element, shift: boolean) {
 
   if (activeElement.getAttribute('tabindex') !== '-1') {
     // tabindex has no effect if the active element has tabindex="-1"
-    enabledElements.sort(
-      (a, b) =>
-        Number(a.getAttribute('tabindex')) - Number(b.getAttribute('tabindex')),
-    )
+    enabledElements.sort((a, b) => {
+      const i = Number(a.getAttribute('tabindex'))
+      const j = Number(b.getAttribute('tabindex'))
+      if (i === j) {
+        return 0
+      } else if (i === 0) {
+        return 1
+      } else if (j === 0) {
+        return -1
+      }
+      return i - j
+    })
   }
 
   const checkedRadio: Record<string, HTMLInputElement> = {}

--- a/tests/utils/focus/getTabDestination.ts
+++ b/tests/utils/focus/getTabDestination.ts
@@ -54,10 +54,7 @@ test('get next focusable element in tab order', () => {
         <input id="f" />
     `)
 
-  // TODO: the browser tabs through tabIndex>0 before tabIndex=0
-
-  // assertTabOrder([elE, elA, elB, elD, elF])
-  assertTabOrder([elB, elD, elF, elE, elA])
+  assertTabOrder([elE, elA, elB, elD, elF])
 
   expect(getTabDestination(elC, false)).toBe(elD)
   expect(getTabDestination(elC, true)).toBe(elB)
@@ -102,10 +99,7 @@ test('exclude anchors without `href` from tab order', () => {
         <a tabIndex="1"></a>
     `)
 
-  // TODO: the browser tabs through tabIndex>0 before tabIndex=0
-
-  // assertTabOrder([elC, elB])
-  assertTabOrder([elB, elC])
+  assertTabOrder([elC, elB])
 })
 
 test('skip consecutive radios of same group', () => {


### PR DESCRIPTION
**What**:

Change order of tabable elements.

**Why**:

Closes #807 

**Checklist**:
- [x] Tests
- [x] Ready to be merged
