### PR TITLE
fix(pointer): honor click handler on `<label/>`

### DIFF
--- a/src/pointer/pointerPress.ts
+++ b/src/pointer/pointerPress.ts
@@ -217,18 +217,14 @@ function up(
 
       const canClick = pointerType !== 'mouse' || button === 'primary'
       if (canClick && target === pressed.downTarget) {
-        fire('click')
+        const unpreventedClick = fire('click')
         if (clickCount === 2) {
           fire('dblclick')
         }
 
-        // If the click happens inside a `label` with a control, the control (or closes focusable) is focused.
-        const label = target.closest('label')
-        if (label?.control) {
-          focus(
-            findClosest(label.control, isFocusable) ??
-              target.ownerDocument.body,
-          )
+        const control = target.closest('label')?.control
+        if (unpreventedClick && control && isFocusable(control)) {
+          focus(control)
         }
       }
 

--- a/tests/pointer/select.ts
+++ b/tests/pointer/select.ts
@@ -319,10 +319,6 @@ describe('focus control when clicking label', () => {
 
     expect(label).not.toHaveFocus()
     expect(input).toHaveFocus()
-    expect(input).toHaveProperty('selectionStart', 0)
-
-    // TODO: click on label selects input value
-    // expect(input).toHaveProperty('selectionEnd', 3)
   })
 
   test('click handlers can prevent moving focus per label', async () => {

--- a/tests/pointer/select.ts
+++ b/tests/pointer/select.ts
@@ -329,9 +329,7 @@ describe('focus control when clicking label', () => {
 
     await userEvent.pointer({keys: '[MouseLeft]', target: label})
 
-    // TODO: honor click handler
-    // expect(input).not.toHaveFocus()
-    expect(input).toBeTruthy()
+    expect(input).not.toHaveFocus()
   })
 
   test('do not move focus to disabled control', async () => {


### PR DESCRIPTION
**What**:

Do not move focus to `label.control` if a click handler prevents default behavior.

Remove TODO for #805 as the behavior is not consistent across browsers.

**Why**:

Click handler can prevent default behavior for click on label in the browser.
Event handlers on `down`/`up` events seem to have no effect here.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
