### PR TITLE
fix(keyboard): parse escaped bracket followed by descriptor

### DIFF
--- a/src/utils/keyDef/readNextDescriptor.ts
+++ b/src/utils/keyDef/readNextDescriptor.ts
@@ -21,15 +21,7 @@ export function readNextDescriptor(text: string) {
 
   pos += startBracket.length
 
-  // `foo{{bar` is an escaped char at position 3,
-  // but `foo{{{>5}bar` should be treated as `{` pressed down for 5 keydowns.
-  const startBracketRepeated = startBracket
-    ? (text.match(new RegExp(`^\\${startBracket}+`)) as RegExpMatchArray)[0]
-        .length
-    : 0
-  const isEscapedChar =
-    startBracketRepeated === 2 ||
-    (startBracket === '{' && startBracketRepeated > 3)
+  const isEscapedChar = new RegExp(`^\\${startBracket}{2}`).test(text)
 
   const type = isEscapedChar ? '' : startBracket
 
@@ -64,7 +56,13 @@ function readTag(
 
   pos += releasePreviousModifier.length
 
-  const descriptor = text.slice(pos).match(/^\w+/)?.[0]
+  const escapedDescriptor = startBracket === '{' && text[pos] === '\\'
+
+  pos += Number(escapedDescriptor)
+
+  const descriptor = escapedDescriptor
+    ? text[pos]
+    : text.slice(pos).match(startBracket === '{' ? /^\w+|^[^}>/]/ : /^\w+/)?.[0]
 
   assertDescriptor(descriptor, text, pos)
 

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -78,8 +78,8 @@ it('type asynchronous', async () => {
 })
 
 it('error in async', async () => {
-  await expect(userEvent.keyboard('{!', {delay: 1})).rejects.toThrowError(
-    'Expected key descriptor but found "!" in "{!"',
+  await expect(userEvent.keyboard('[!', {delay: 1})).rejects.toThrowError(
+    'Expected key descriptor but found "!" in "[!"',
   )
 })
 


### PR DESCRIPTION
**What**:

Fix key descriptor parsing.

**Why**:

Closes #769 

**How**:

Always treat repeated brackets as escaped brackets.
Support describing keys per printable `key` inside `{` `}` brackets so that they can be used with modifiers.

`{{{ArrowLeft}`:  press+release `{`, then press+release `ArrowLeft`
`{\{>5}`: press `{` for 5 keydowns

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
