### PR TITLE
fix: export types and commonjs bundle

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,10 +1,9 @@
 ;(async () => {
   const child = require('child_process')
-  const fs = require('fs')
   const {build} = require('esbuild')
 
   await build({
-    outdir: 'dist',
+    outfile: 'dist/index.mjs',
     format: 'esm',
     target: 'es6',
     bundle: true,
@@ -12,12 +11,14 @@
     entryPoints: ['src/index.ts'],
   })
 
-  fs.writeFileSync(
-    'dist/package.json',
-    JSON.stringify({
-      type: 'module',
-    }),
-  )
+  await build({
+    outfile: 'dist/index.cjs',
+    format: 'cjs',
+    target: 'node12',
+    bundle: true,
+    external: ['@testing-library/dom'],
+    entryPoints: ['src/index.ts'],
+  })
 
   child.execSync('yarn tsc -p tsconfig.build.json')
 })()

--- a/package.json
+++ b/package.json
@@ -25,8 +25,15 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.js",
-  "exports": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "build": "node build.js",
     "lint": "kcd-scripts lint",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,10 +2,9 @@
   "extends": "./tsconfig.json",
   "include": ["./src"],
   "compilerOptions": {
-    "outFile": "dist/index.d.ts",
+    "outDir": "dist/types",
     "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true,
-    "isolatedModules": false
+    "emitDeclarationOnly": true
   }
 }


### PR DESCRIPTION
**What**:

Add export as bundled CommonJS.

Fix types export.

**Why**:

Closes #813 
Closes #819 

**How**:

Bundle files in `dist/index.cjs` as CommonJS module.
Bundle files in `dist/index.mjs` as EcmaScript module.
Export types to `dist/types`.

Point `main` to CJS export.
Point `module` to ESM export.
Let `exports` resolve any import per `require` to CJS otherwise ESM.
Point `types` to `dist/types/index.d.ts`.

**Checklist**:
- [x] Ready to be merged
