### PR TITLE
feat(keyboard): move cursor and delete content in contenteditable

### DIFF
--- a/src/utils/focus/cursor.ts
+++ b/src/utils/focus/cursor.ts
@@ -1,0 +1,169 @@
+import {isElementType} from '..'
+
+declare global {
+  interface Text {
+    nodeValue: string
+  }
+}
+
+export function getNextCursorPosition(
+  node: Node,
+  offset: number,
+  direction: -1 | 1,
+  inputType?: string,
+):
+  | {
+      node: Node
+      offset: number
+    }
+  | undefined {
+  // The behavior at text node zero offset is inconsistent.
+  // When walking backwards:
+  // Firefox always moves to zero offset and jumps over last offset.
+  // Chrome jumps over zero offset per default but over last offset when Shift is pressed.
+  // The cursor always moves to zero offset if the focus area (contenteditable or body) ends there.
+  // When walking foward both ignore zero offset.
+  // When walking over input elements the cursor moves before or after that element.
+  // When walking over line breaks the cursor moves inside any following text node.
+
+  if (
+    isTextNode(node) &&
+    offset + direction >= 0 &&
+    offset + direction <= node.nodeValue.length
+  ) {
+    return {node, offset: offset + direction}
+  }
+  const nextNode = getNextCharacterContentNode(node, offset, direction)
+  if (nextNode) {
+    if (isTextNode(nextNode)) {
+      return {
+        node: nextNode,
+        offset:
+          direction > 0
+            ? Math.min(1, nextNode.nodeValue.length)
+            : Math.max(nextNode.nodeValue.length - 1, 0),
+      }
+    } else if (isElementType(nextNode, 'br')) {
+      const nextPlusOne = getNextCharacterContentNode(
+        nextNode,
+        undefined,
+        direction,
+      )
+      if (!nextPlusOne) {
+        // The behavior when there is no possible cursor position beyond the line break is inconsistent.
+        // In Chrome outside of contenteditable moving before a leading line break is possible.
+        // A leading line break can still be removed per deleteContentBackward.
+        // A trailing line break on the other hand is not removed by deleteContentForward.
+        if (direction < 0 && inputType === 'deleteContentBackward') {
+          return {
+            node: nextNode.parentNode as Node,
+            offset: getOffset(nextNode),
+          }
+        }
+        return undefined
+      } else if (isTextNode(nextPlusOne)) {
+        return {
+          node: nextPlusOne,
+          offset: direction > 0 ? 0 : nextPlusOne.nodeValue.length,
+        }
+      } else if (direction < 0 && isElementType(nextPlusOne, 'br')) {
+        return {
+          node: nextNode.parentNode as Node,
+          offset: getOffset(nextNode),
+        }
+      } else {
+        return {
+          node: nextPlusOne.parentNode as Node,
+          offset: getOffset(nextPlusOne) + (direction > 0 ? 0 : 1),
+        }
+      }
+    } else {
+      return {
+        node: nextNode.parentNode as Node,
+        offset: getOffset(nextNode) + (direction > 0 ? 1 : 0),
+      }
+    }
+  }
+}
+
+function getNextCharacterContentNode(
+  node: Node,
+  offset: number | undefined,
+  direction: -1 | 1,
+) {
+  const nextOffset = Number(offset) + (direction < 0 ? -1 : 0)
+  if (
+    offset !== undefined &&
+    isElement(node) &&
+    nextOffset >= 0 &&
+    nextOffset < node.children.length
+  ) {
+    node = node.children[nextOffset]
+  }
+  return walkNodes(
+    node,
+    direction === 1 ? 'next' : 'previous',
+    isTreatedAsCharacterContent,
+  )
+}
+
+function isTreatedAsCharacterContent(node: Node): node is Text | HTMLElement {
+  if (isTextNode(node)) {
+    return true
+  }
+  if (isElement(node)) {
+    if (isElementType(node, ['input', 'textarea'])) {
+      return (node as HTMLInputElement).type !== 'hidden'
+    } else if (isElementType(node, 'br')) {
+      return true
+    }
+  }
+  return false
+}
+
+function getOffset(node: Node) {
+  let i = 0
+  while (node.previousSibling) {
+    i++
+    node = node.previousSibling
+  }
+  return i
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === 1
+}
+
+function isTextNode(node: Node): node is Text {
+  return node.nodeType === 3
+}
+
+function walkNodes<T extends Node>(
+  node: Node,
+  direction: 'previous' | 'next',
+  callback: (node: Node) => node is T,
+) {
+  for (;;) {
+    const sibling = node[`${direction}Sibling`]
+    if (sibling) {
+      node = getDescendant(sibling, direction === 'next' ? 'first' : 'last')
+      if (callback(node)) {
+        return node
+      }
+    } else if (
+      node.parentNode &&
+      node.parentNode !== node.ownerDocument?.body
+    ) {
+      node = node.parentNode
+    } else {
+      break
+    }
+  }
+}
+
+function getDescendant(node: Node, direction: 'first' | 'last') {
+  while (node.hasChildNodes()) {
+    node = node[`${direction}Child`] as ChildNode
+  }
+  return node
+}

--- a/src/utils/focus/cursor.ts
+++ b/src/utils/focus/cursor.ts
@@ -1,4 +1,4 @@
-import {isElementType} from '..'
+import {isContentEditable, isElementType} from '..'
 
 declare global {
   interface Text {
@@ -152,7 +152,9 @@ function walkNodes<T extends Node>(
       }
     } else if (
       node.parentNode &&
-      node.parentNode !== node.ownerDocument?.body
+      (!isElement(node.parentNode) ||
+        (!isContentEditable(node.parentNode) &&
+          node.parentNode !== node.ownerDocument?.body))
     ) {
       node = node.parentNode
     } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from './edit/setFiles'
 
 export * from './focus/blur'
 export * from './focus/copySelection'
+export * from './focus/cursor'
 export * from './focus/focus'
 export * from './focus/getActiveElement'
 export * from './focus/getTabDestination'

--- a/tests/keyboard/plugin/arrow.ts
+++ b/tests/keyboard/plugin/arrow.ts
@@ -1,46 +1,153 @@
 import userEvent from '#src'
+import {setSelection} from '#src/utils'
 import {setup} from '#testHelpers/utils'
 
-test('collapse selection to the left', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
-  element.focus()
-  element.setSelectionRange(2, 4)
+describe('in text input', () => {
+  test('collapse selection to the left', async () => {
+    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    element.focus()
+    element.setSelectionRange(2, 4)
 
-  await userEvent.keyboard('[ArrowLeft]')
+    await userEvent.keyboard('[ArrowLeft]')
 
-  expect(element.selectionStart).toBe(2)
-  expect(element.selectionEnd).toBe(2)
+    expect(element.selectionStart).toBe(2)
+    expect(element.selectionEnd).toBe(2)
+  })
+
+  test('collapse selection to the right', async () => {
+    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    element.focus()
+    element.setSelectionRange(2, 4)
+
+    await userEvent.keyboard('[ArrowRight]')
+
+    expect(element.selectionStart).toBe(4)
+    expect(element.selectionEnd).toBe(4)
+  })
+
+  test('move cursor left', async () => {
+    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    element.focus()
+    element.setSelectionRange(2, 2)
+
+    await userEvent.keyboard('[ArrowLeft]')
+
+    expect(element.selectionStart).toBe(1)
+    expect(element.selectionEnd).toBe(1)
+  })
+
+  test('move cursor right', async () => {
+    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    element.focus()
+    element.setSelectionRange(2, 2)
+
+    await userEvent.keyboard('[ArrowRight]')
+
+    expect(element.selectionStart).toBe(3)
+    expect(element.selectionEnd).toBe(3)
+  })
 })
 
-test('collapse selection to the right', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
-  element.focus()
-  element.setSelectionRange(2, 4)
+describe('in contenteditable', () => {
+  test('collapse selection to the left', async () => {
+    const {element} = setup(
+      `<div contenteditable><span>foo</span><span>bar</span></div>`,
+    )
+    setSelection({
+      anchorNode: element.firstChild?.firstChild as Text,
+      anchorOffset: 2,
+      focusNode: element.lastChild?.firstChild as Text,
+      focusOffset: 1,
+    })
 
-  await userEvent.keyboard('[ArrowRight]')
+    await userEvent.keyboard('[ArrowLeft]')
 
-  expect(element.selectionStart).toBe(4)
-  expect(element.selectionEnd).toBe(4)
-})
+    expect(element.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      element.firstChild?.firstChild,
+    )
+    expect(element.ownerDocument.getSelection()).toHaveProperty(
+      'focusOffset',
+      2,
+    )
+  })
 
-test('move cursor left', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
-  element.focus()
-  element.setSelectionRange(2, 2)
+  test('collapse selection to the right', async () => {
+    const {element} = setup(
+      `<div contenteditable><span>foo</span><span>bar</span></div>`,
+    )
+    setSelection({
+      anchorNode: element.firstChild?.firstChild as Text,
+      anchorOffset: 2,
+      focusNode: element.lastChild?.firstChild as Text,
+      focusOffset: 1,
+    })
 
-  await userEvent.keyboard('[ArrowLeft]')
+    await userEvent.keyboard('[ArrowRight]')
 
-  expect(element.selectionStart).toBe(1)
-  expect(element.selectionEnd).toBe(1)
-})
+    expect(element.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      element.lastChild?.firstChild,
+    )
+    expect(element.ownerDocument.getSelection()).toHaveProperty(
+      'focusOffset',
+      1,
+    )
+  })
 
-test('move cursor right', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
-  element.focus()
-  element.setSelectionRange(2, 2)
+  test('move cursor to the left', async () => {
+    const {
+      elements: [, div],
+    } = setup(
+      `<span>abc</span><div contenteditable><span>foo</span><span>bar</span></div><span>def</span>`,
+    )
+    setSelection({
+      focusNode: div.lastChild?.firstChild as Text,
+      focusOffset: 1,
+    })
 
-  await userEvent.keyboard('[ArrowRight]')
+    await userEvent.keyboard('[ArrowLeft][ArrowLeft]')
 
-  expect(element.selectionStart).toBe(3)
-  expect(element.selectionEnd).toBe(3)
+    expect(div.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      div.firstChild?.firstChild,
+    )
+    expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 2)
+
+    await userEvent.keyboard('[ArrowLeft][ArrowLeft][ArrowLeft][ArrowLeft]')
+
+    expect(div.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      div.firstChild?.firstChild,
+    )
+    expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 0)
+  })
+
+  test('move cursor to the right', async () => {
+    const {
+      elements: [, div],
+    } = setup(
+      `<span>abc</span><div contenteditable><span>foo</span><span>bar</span></div><span>def</span>`,
+    )
+    setSelection({
+      focusNode: div.firstChild?.firstChild as Text,
+      focusOffset: 2,
+    })
+
+    await userEvent.keyboard('[ArrowRight][ArrowRight]')
+
+    expect(div.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      div.lastChild?.firstChild,
+    )
+    expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 1)
+
+    await userEvent.keyboard('[ArrowRight][ArrowRight][ArrowRight][ArrowRight]')
+
+    expect(div.ownerDocument.getSelection()).toHaveProperty(
+      'focusNode',
+      div.lastChild?.firstChild,
+    )
+    expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 3)
+  })
 })

--- a/tests/utils/focus/cursor.ts
+++ b/tests/utils/focus/cursor.ts
@@ -191,9 +191,9 @@ cases<{
       expectedOffset: 1,
     },
     'at edge of focus area': {
-      html: `foobar`,
-      nodeSelector: 'text()',
-      offset: 6,
+      html: `foo<span contenteditable>bar</span>baz`,
+      nodeSelector: 'span/text()',
+      offset: 3,
       direction: 1,
       expectedSelector: undefined,
       expectedOffset: undefined,

--- a/tests/utils/focus/cursor.ts
+++ b/tests/utils/focus/cursor.ts
@@ -1,0 +1,210 @@
+import cases from 'jest-in-case'
+import {getNextCursorPosition} from '#src/utils'
+import {setup} from '#testHelpers/utils'
+
+cases<{
+  html: string
+  nodeSelector: string
+  offset: number
+  direction: -1 | 1
+  inputType?: string
+  expectedSelector?: string
+  expectedOffset?: number
+}>(
+  'get next cursor position',
+  ({
+    html,
+    nodeSelector,
+    offset,
+    direction,
+    inputType,
+    expectedSelector,
+    expectedOffset,
+  }) => {
+    const {element} = setup(`<div>${html}</div>`)
+    const node = document.evaluate(
+      nodeSelector,
+      element,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+    ).singleNodeValue
+    expect(node).toBeTruthy()
+    const expectedNode = expectedSelector
+      ? document.evaluate(
+          expectedSelector,
+          element,
+          null,
+          XPathResult.FIRST_ORDERED_NODE_TYPE,
+        ).singleNodeValue
+      : undefined
+    expect(expectedNode)[expectedSelector ? 'toBeTruthy' : 'toBeFalsy']()
+
+    document.getSelection()?.setPosition(node, offset)
+    const nextPosition = getNextCursorPosition(
+      node as Node,
+      offset,
+      direction,
+      inputType,
+    )
+
+    expect(nextPosition?.node).toBe(expectedNode)
+    if (expectedNode) {
+      expect(nextPosition).toHaveProperty('offset', expectedOffset)
+    }
+  },
+  {
+    'in text node forwards': {
+      html: `foobar`,
+      nodeSelector: 'text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: 'text()',
+      expectedOffset: 4,
+    },
+    'in text node backwards': {
+      html: `foobar`,
+      nodeSelector: 'text()',
+      offset: 3,
+      direction: -1,
+      expectedSelector: 'text()',
+      expectedOffset: 2,
+    },
+    'across text nodes forwards': {
+      html: `<span>foo</span><span>bar</span>`,
+      nodeSelector: '*[1]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: '*[2]/text()',
+      expectedOffset: 1,
+    },
+    'across text nodes backwards': {
+      html: `<span>foo</span><span>bar</span>`,
+      nodeSelector: '*[2]/text()',
+      offset: 0,
+      direction: -1,
+      expectedSelector: '*[1]/text()',
+      expectedOffset: 2,
+    },
+    'to start of body backwards': {
+      html: `foobar`,
+      nodeSelector: 'text()',
+      offset: 1,
+      direction: -1,
+      expectedSelector: 'text()',
+      expectedOffset: 0,
+    },
+    'to start of contenteditable backwards': {
+      html: `<span>foo</span><span contenteditable>bar</span>`,
+      nodeSelector: '*[@contenteditable]/text()',
+      offset: 1,
+      direction: -1,
+      expectedSelector: '*[@contenteditable]/text()',
+      expectedOffset: 0,
+    },
+    'over input forwards': {
+      html: `<span>foo</span><input type="checkbox"><span>bar</span>`,
+      nodeSelector: 'span[1]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: '.',
+      expectedOffset: 2,
+    },
+    'over input backwards': {
+      html: `<span>foo</span><input type="checkbox"><span>bar</span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 0,
+      direction: -1,
+      expectedSelector: '.',
+      expectedOffset: 1,
+    },
+    'over line break forwards to text node': {
+      html: `<span>foo</span><br/><span>bar</span>`,
+      nodeSelector: 'span[1]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: 'span[2]/text()',
+      expectedOffset: 0,
+    },
+    'over line break backwards to text node': {
+      html: `<span>foo</span><br/><span>bar</span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 0,
+      direction: -1,
+      expectedSelector: 'span[1]/text()',
+      expectedOffset: 3,
+    },
+    'over line break forwards to checkbox': {
+      html: `<span>foo</span><input type="checkbox"/><span></span><br/><span></span><input type="checkbox"/><span>bar</span>`,
+      nodeSelector: '.',
+      offset: 2,
+      direction: 1,
+      expectedSelector: '.',
+      expectedOffset: 5,
+    },
+    'over line break backwards to checkbox': {
+      html: `<span>foo</span><input type="checkbox"/><span></span><br/><span></span><input type="checkbox"/><span>bar</span>`,
+      nodeSelector: '.',
+      offset: 5,
+      direction: -1,
+      expectedSelector: '.',
+      expectedOffset: 2,
+    },
+    'over line break forwards to line break': {
+      html: `<span>foo</span><br/><div></div><br/><span>bar</span>`,
+      nodeSelector: 'span[1]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: '.',
+      expectedOffset: 3,
+    },
+    'over line break backwards to line break': {
+      html: `<span>foo</span><br/><div></div><br/><span>bar</span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 0,
+      direction: -1,
+      expectedSelector: '.',
+      expectedOffset: 3,
+    },
+    'over line break forwards at edge of focus area': {
+      html: `<span></span><br/><span>foo</span><br/><span></span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: undefined,
+      expectedOffset: undefined,
+    },
+    'over line break backwards at edge of focus area': {
+      html: `<span></span><br/><span>foo</span><br/><span></span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 0,
+      direction: -1,
+      expectedSelector: undefined,
+      expectedOffset: undefined,
+    },
+    'over line break backwards at edge of focus area when deleting': {
+      html: `<span></span><br/><span>foo</span><br/><span></span>`,
+      nodeSelector: 'span[2]/text()',
+      offset: 0,
+      direction: -1,
+      inputType: 'deleteContentBackward',
+      expectedSelector: '.',
+      expectedOffset: 1,
+    },
+    'at edge of focus area': {
+      html: `foobar`,
+      nodeSelector: 'text()',
+      offset: 6,
+      direction: 1,
+      expectedSelector: undefined,
+      expectedOffset: undefined,
+    },
+    'over comment': {
+      html: `<span>foo</span><!--comment--><span>bar</span>`,
+      nodeSelector: 'span[1]/text()',
+      offset: 3,
+      direction: 1,
+      expectedSelector: 'span[2]/text()',
+      expectedOffset: 1,
+    },
+  },
+)


### PR DESCRIPTION
**What**:

Support cursor movement and editing contenteditable from collapsed selection range a.k.a. a simple cursor when the movement/edit is outside of an already focused TextNode.

**Why**:
Closes #806 

**How**:

Calculate the next cursor position as observed in the browser.
Use `Range` API to manipulate the DOM.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
