### PR TITLE
docs: harmonize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <br />
 
-[**Read The Docs**](https://testing-library.com/docs/ecosystem-user-event) |
+[**Read The Docs**](https://testing-library.com/docs/user-event/intro) |
 [Edit the docs](https://github.com/testing-library/testing-library-docs)
 
 <br />

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ instead of filing an issue on GitHub.
 We most sincerely thank [the people who make this project
 possible][contributors]. Contributions of any kind are welcome! 💚
 
-## LICENSE
+## License
 
 [MIT](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
 
 <br />
 
-[**Read The Docs**](https://testing-library.com/docs/user-event/intro) |
-[Edit the docs](https://github.com/testing-library/testing-library-docs)
+[**Read The Docs**](https://testing-library.com/docs/user-event/intro)
 
 <br />
 </div>


### PR DESCRIPTION
* Update link to the docs so that it points to docs for this version.
* Remove "Edit the docs". Each docs page includes a link to the specific file to edit. The link to the docs repo in this README is just noise.
* Use same capitalization for License as for the other headers.

**Checklist**:
- [x] Ready to be merged
