### PR TITLE
fix(pointer): blur `activeElement` on click outside of focusable

### DIFF
--- a/src/pointer/pointerPress.ts
+++ b/src/pointer/pointerPress.ts
@@ -3,7 +3,6 @@
 import {
   ApiLevel,
   assertPointerEvents,
-  findClosest,
   firePointerEvent,
   focus,
   isDisabled,
@@ -278,7 +277,7 @@ function mousedownDefaultBehavior({
   // The closest focusable element is focused when a `mousedown` would have been fired.
   // Even if there was no `mousedown` because the element was disabled.
   // A `mousedown` that preventsDefault cancels this though.
-  focus(findClosest(target, isFocusable) ?? target.ownerDocument.body)
+  focus(target)
 
   // TODO: What happens if a focus event handler interfers?
 

--- a/src/utility/upload.ts
+++ b/src/utility/upload.ts
@@ -38,9 +38,9 @@ export async function upload(
     .slice(0, input.multiple ? undefined : 1)
 
   // blur fires when the file selector pops up
-  blur(element)
+  blur(input)
   // focus fires when they make their selection
-  focus(element)
+  focus(input)
 
   // do not fire an input event if the file selection does not change
   if (

--- a/src/utils/focus/focus.ts
+++ b/src/utils/focus/focus.ts
@@ -1,17 +1,25 @@
 import {eventWrapper} from '../misc/eventWrapper'
+import {findClosest} from '../misc/findClosest'
 import {getActiveElement} from './getActiveElement'
 import {isFocusable} from './isFocusable'
 import {updateSelectionOnFocus} from './selection'
 
+/**
+ * Focus closest focusable element.
+ */
 function focus(element: Element) {
-  if (!isFocusable(element)) return
+  const target = findClosest(element, isFocusable)
 
-  const isAlreadyActive = getActiveElement(element.ownerDocument) === element
-  if (isAlreadyActive) return
+  const activeElement = getActiveElement(element.ownerDocument)
+  if ((target ?? element.ownerDocument.body) === activeElement) {
+    return
+  } else if (target) {
+    eventWrapper(() => target.focus())
+  } else {
+    eventWrapper(() => (activeElement as HTMLElement | null)?.blur())
+  }
 
-  eventWrapper(() => element.focus())
-
-  updateSelectionOnFocus(element)
+  updateSelectionOnFocus(target ?? element.ownerDocument.body)
 }
 
 export {focus}

--- a/src/utils/misc/findClosest.ts
+++ b/src/utils/misc/findClosest.ts
@@ -1,7 +1,7 @@
-export function findClosest(
+export function findClosest<T extends Element>(
   element: Element,
-  callback: (e: Element) => boolean,
-) {
+  callback: (e: Element) => e is T,
+): T | undefined {
   let el: Element | null = element
   do {
     if (callback(el)) {

--- a/tests/pointer/select.ts
+++ b/tests/pointer/select.ts
@@ -30,6 +30,19 @@ test('move focus to closest focusable element', async () => {
   expect(element).toHaveFocus()
 })
 
+test('blur when outside of focusable context', async () => {
+  const {
+    elements: [focusable, notFocusable],
+  } = setup(`
+    <div tabIndex="-1"></div>
+    <div></div>
+  `)
+  focusable.focus()
+
+  await userEvent.pointer({keys: '[MouseLeft>]', target: notFocusable})
+  expect(document.body).toHaveFocus()
+})
+
 test('mousedown handlers can prevent moving focus', async () => {
   const {element} = setup<HTMLInputElement>(`<input/>`)
   element.addEventListener('mousedown', e => e.preventDefault())

--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -65,6 +65,8 @@ test('relay click/upload on label to file input', async () => {
     label[for="element"] - click: primary
     input#element[value=""] - click: primary
     input#element[value=""] - focusin
+    input#element[value=""] - focusout
+    input#element[value=""] - focusin
     input#element[value="C:\\\\fakepath\\\\hello.png"] - input
     input#element[value="C:\\\\fakepath\\\\hello.png"] - change
   `)


### PR DESCRIPTION
**What**:

Focus `document.body` on `mousedown` outside of focusable.

**Why**:

Closes #832 

https://github.com/testing-library/user-event/blob/e74defe418a0527e23a7b6eac89f21004cf0a333/src/pointer/pointerPress.ts#L277-L279

When the mousedown happens (or would have happened) outside of a focusable context,
the focus is moved to `document.body`.

**How**:

Blur `activeElement` when `focus` helper is called with an element outside of focusable context.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
