### PR TITLE
fix(upload): fix order of events

### DIFF
--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -1,0 +1,25 @@
+import {blur, cloneEvent, focus, isElementType, isFocusable} from '../../utils'
+import {dispatchEvent} from '../dispatchEvent'
+import {behavior} from './registry'
+
+behavior.click = (event, target, config) => {
+  const control = target.closest('label')?.control
+  if (control) {
+    return () => {
+      if (isFocusable(control)) {
+        focus(control)
+      }
+      dispatchEvent(config, control, cloneEvent(event))
+    }
+  } else if (isElementType(target, 'input', {type: 'file'})) {
+    return () => {
+      // blur fires when the file selector pops up
+      blur(target)
+
+      target.dispatchEvent(new Event('fileDialog'))
+
+      // focus fires after the file selector has been closed
+      focus(target)
+    }
+  }
+}

--- a/src/event/behavior/index.ts
+++ b/src/event/behavior/index.ts
@@ -1,0 +1,4 @@
+import './click'
+
+export {behavior} from './registry'
+export type {BehaviorPlugin} from './registry'

--- a/src/event/behavior/registry.ts
+++ b/src/event/behavior/registry.ts
@@ -1,0 +1,15 @@
+import {Config} from '../../setup'
+import {EventType} from '../types'
+
+export interface BehaviorPlugin<Type extends EventType> {
+  (
+    event: DocumentEventMap[Type],
+    target: Element,
+    config: Config,
+  ): // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  void | (() => void)
+}
+
+export const behavior: {
+  [Type in EventType]?: BehaviorPlugin<Type>
+} = {}

--- a/src/event/dispatchEvent.ts
+++ b/src/event/dispatchEvent.ts
@@ -1,0 +1,33 @@
+import {Config} from '../setup'
+import {EventType} from './types'
+import {behavior, BehaviorPlugin} from './behavior'
+
+export function dispatchEvent(config: Config, target: Element, event: Event) {
+  const type = event.type as EventType
+  const behaviorImplementation = (
+    behavior[type] as BehaviorPlugin<EventType> | undefined
+  )?.(event, target, config)
+
+  if (behaviorImplementation) {
+    event.preventDefault()
+    let defaultPrevented = false
+    Object.defineProperty(event, 'defaultPrevented', {
+      get: () => defaultPrevented,
+    })
+    Object.defineProperty(event, 'preventDefault', {
+      value: () => {
+        defaultPrevented = event.cancelable
+      },
+    })
+
+    target.dispatchEvent(event)
+
+    if (!defaultPrevented as boolean) {
+      behaviorImplementation()
+    }
+
+    return !defaultPrevented
+  }
+
+  return target.dispatchEvent(event)
+}

--- a/src/event/index.ts
+++ b/src/event/index.ts
@@ -1,6 +1,7 @@
 import {Config} from '../setup'
 import {getUIEventModifiers} from '../utils'
 import {createEvent, EventTypeInit} from './createEvent'
+import {dispatchEvent} from './dispatchEvent'
 import {isKeyboardEvent, isMouseEvent} from './eventTypes'
 import {EventType, PointerCoords} from './types'
 import {wrapEvent} from './wrapEvent'
@@ -22,7 +23,7 @@ export function dispatchUIEvent<K extends EventType>(
 
   const event = createEvent(type, target, init)
 
-  return wrapEvent(() => target.dispatchEvent(event), target)
+  return wrapEvent(() => dispatchEvent(config, target, event), target)
 }
 
 export function bindDispatchUIEvent(config: Config) {

--- a/src/pointer/pointerPress.ts
+++ b/src/pointer/pointerPress.ts
@@ -6,7 +6,6 @@ import {
   focus,
   isDisabled,
   isElementType,
-  isFocusable,
   setLevelRef,
 } from '../utils'
 import {getUIValue, setUISelection} from '../document'
@@ -231,15 +230,10 @@ function up(
 
       const canClick = pointerType !== 'mouse' || button === 'primary'
       if (canClick && target === pressed.downTarget) {
-        const unpreventedClick = fire('click')
+        fire('click')
 
         if (clickCount === 2) {
           fire('dblclick')
-        }
-        if (unpreventedClick) {
-          clickDefaultBehavior({
-            target,
-          })
         }
       }
     }
@@ -366,11 +360,4 @@ function getTextRange(
       : pos +
         (text.substr(pos).match(/^[^\r\n]*/) as RegExpMatchArray)[0].length,
   ]
-}
-
-function clickDefaultBehavior({target}: {target: Element}) {
-  const control = target.closest('label')?.control
-  if (control && isFocusable(control)) {
-    focus(control)
-  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,6 +33,7 @@ export * from './keyboard/getUIEventModifiers'
 
 export * from './keyDef/readNextDescriptor'
 
+export * from './misc/cloneEvent'
 export * from './misc/eventWrapper'
 export * from './misc/findClosest'
 export * from './misc/getDocumentFromNode'

--- a/src/utils/misc/cloneEvent.ts
+++ b/src/utils/misc/cloneEvent.ts
@@ -1,0 +1,7 @@
+interface EventConstructor<E extends Event> {
+  new (type: string, init: EventInit): E
+}
+
+export function cloneEvent<E extends Event>(event: E) {
+  return new (event.constructor as EventConstructor<E>)(event.type, event)
+}

--- a/tests/event/dispatchEvent.ts
+++ b/tests/event/dispatchEvent.ts
@@ -1,0 +1,58 @@
+import {dispatchUIEvent} from '#src/event'
+import {behavior, BehaviorPlugin} from '#src/event/behavior'
+import {createConfig} from '#src/setup/setup'
+import {setup} from '#testHelpers/utils'
+
+jest.mock('#src/event/behavior', () => ({
+  behavior: {
+    click: jest.fn(),
+  },
+}))
+
+const mockPlugin = behavior.click as jest.MockedFunction<
+  BehaviorPlugin<'click'>
+>
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+test('keep default behavior', () => {
+  const {element} = setup(`<input type="checkbox"/>`)
+
+  dispatchUIEvent(createConfig(), element, 'click')
+
+  expect(mockPlugin).toBeCalledTimes(1)
+  expect(element).toBeChecked()
+})
+
+test('replace default behavior', () => {
+  const {element} = setup(`<input type="checkbox"/>`)
+
+  const mockBehavior = jest.fn()
+  mockPlugin.mockImplementationOnce(() => mockBehavior)
+
+  dispatchUIEvent(createConfig(), element, 'click')
+
+  expect(mockPlugin).toBeCalledTimes(1)
+  expect(element).not.toBeChecked()
+  expect(mockBehavior).toBeCalled()
+})
+
+test('prevent replaced default behavior', () => {
+  const {element} = setup(`<input type="checkbox"/>`)
+  element.addEventListener('click', e => {
+    expect(e).toHaveProperty('defaultPrevented', false)
+    e.preventDefault()
+    expect(e).toHaveProperty('defaultPrevented', true)
+  })
+
+  const mockBehavior = jest.fn()
+  mockPlugin.mockImplementationOnce(() => mockBehavior)
+
+  dispatchUIEvent(createConfig(), element, 'click')
+
+  expect(mockPlugin).toBeCalledTimes(1)
+  expect(element).not.toBeChecked()
+  expect(mockBehavior).not.toBeCalled()
+})

--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -73,6 +73,23 @@ test('relay click/upload on label to file input', async () => {
   `)
 })
 
+test('prevent file dialog per click event handler', async () => {
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+
+  const {
+    elements: [label, input],
+    eventWasFired,
+  } = setup<[HTMLLabelElement]>(`
+        <label for="element">Element</label>
+        <input type="file" id="element" />
+    `)
+  input.addEventListener('click', e => e.preventDefault())
+
+  await userEvent.upload(label, file)
+
+  expect(eventWasFired('input')).toBe(false)
+})
+
 test('upload multiple files', async () => {
   const files = [
     new File(['hello'], 'hello.png', {type: 'image/png'}),

--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -29,12 +29,13 @@ test('change file input', async () => {
     input[value=""] - pointerup
     input[value=""] - mouseup: primary
     input[value=""] - click: primary
+      "{CURSOR}" -> "C:\\\\fakepath\\\\hello.png{CURSOR}C:\\\\fakepath\\\\hello.png"
     input[value=""] - blur
     input[value=""] - focusout
-    input[value=""] - focus
-    input[value=""] - focusin
     input[value="C:\\\\fakepath\\\\hello.png"] - input
     input[value="C:\\\\fakepath\\\\hello.png"] - change
+    input[value="C:\\\\fakepath\\\\hello.png"] - focus
+    input[value="C:\\\\fakepath\\\\hello.png"] - focusin
   `)
 })
 
@@ -63,12 +64,12 @@ test('relay click/upload on label to file input', async () => {
     label[for="element"] - pointerup
     label[for="element"] - mouseup: primary
     label[for="element"] - click: primary
+    input#element[value=""] - focusin
     input#element[value=""] - click: primary
-    input#element[value=""] - focusin
     input#element[value=""] - focusout
-    input#element[value=""] - focusin
     input#element[value="C:\\\\fakepath\\\\hello.png"] - input
     input#element[value="C:\\\\fakepath\\\\hello.png"] - change
+    input#element[value="C:\\\\fakepath\\\\hello.png"] - focusin
   `)
 })
 


### PR DESCRIPTION
**What**:

Replace default behavior as part of the central event dispatching.

**Why**:

The order of events for `userEvent.upload` was incorrect.

When clicking the `<input type="file"/>` element in the browser:
1. The element is focused on `mousedown`
2. The file dialog is opened, which results in a `blur` event on the element.
3. The user selects one or more files, which results in an `input` and `change` event.
4. The file dialog is closed, which results in a `focus` event on the element.

Event handlers on the `click` event can prevent opening the file dialog in the browser.
The previous implementation did not honor `Event.defaultPrevented`.

**How**:

Implement default behavior as plugins to the central `dispatchUIEvent` introduced in #838 .

If a default behavior is implemented by this library, the default behavior implemented by the DOM implementation is disabled per `event.preventDefault()`.
Then `event.defaultPrevented` and `event.preventDefault()` are replaced so that event handlers can use them as usual.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
