### PR TITLE
fix(pointer): consider click context

### DIFF
--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -3,7 +3,8 @@ import {dispatchEvent} from '../dispatchEvent'
 import {behavior} from './registry'
 
 behavior.click = (event, target, config) => {
-  const control = target.closest('label')?.control
+  const context = target.closest('button,input,label,textarea')
+  const control = context && isElementType(context, 'label') && context.control
   if (control) {
     return () => {
       if (isFocusable(control)) {

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -191,6 +191,26 @@ test('multi touch does not click', async () => {
   expect(getEvents('click')).toHaveLength(0)
 })
 
+describe('label', () => {
+  test('click associated control per label', async () => {
+    const {element, getEvents} = setup(
+      `<label for="in">foo</label><input id="in"/>`,
+    )
+
+    await userEvent.pointer({keys: '[MouseLeft]', target: element})
+
+    expect(getEvents('click')).toHaveLength(2)
+  })
+
+  test('click nested control per label', async () => {
+    const {element, getEvents} = setup(`<label><input/></label>`)
+
+    await userEvent.pointer({keys: '[MouseLeft]', target: element})
+
+    expect(getEvents('click')).toHaveLength(2)
+  })
+})
+
 describe('check/uncheck control per click', () => {
   test('clicking changes checkbox', async () => {
     const {element} = setup('<input type="checkbox" />')


### PR DESCRIPTION
**What**:

Consider the ancestor elements when applying `click` behavior.

**Why**:

If a click happens inside a `<button>`, `<input>`, `<label>` or `<textarea>` element, this changes the default behavior.

Extending the code snippet that focused the associated control of a clicked label to also apply the click on the control
resulted in a loop if the control was nested inside that label.
Closes #848 
Closes #849 

**How**:

https://github.com/testing-library/user-event/blob/d3ce5265ec84d5e8e6675d7e2388c8d0343622af/src/event/behavior/click.ts#L6-L8

**Checklist**:
- [x] Tests
- [x] Ready to be merged
