### PR TITLE
refactor: refactor test setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,4 +18,7 @@ config.testMatch.push('<rootDir>/tests/**/*.+(js|jsx|ts|tsx)')
 // unless the file ends on `.test.{type}` so that we can add tests of our test utilities.
 config.testPathIgnorePatterns.push('/_.*(?<!\\.test\\.[jt]sx?)$')
 
+// Ignore declaration files
+config.testPathIgnorePatterns.push('\\.d\\.ts$')
+
 module.exports = config

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -11,5 +11,5 @@ expect.addSnapshotSerializer({
   print: val => String((<null | {snapshot?: string}>val)?.snapshot),
 })
 
-export {setup} from './setup'
+export {render, setup} from './setup'
 export {addEventListener, addListeners} from './listeners'

--- a/tests/_helpers/setup.ts
+++ b/tests/_helpers/setup.ts
@@ -1,6 +1,8 @@
 import {addListeners, EventHandlers} from './listeners'
+import userEvent from '#src'
+import {Options} from '#src/options'
 
-export function setup<Elements extends Element | Element[] = HTMLElement>(
+export function render<Elements extends Element | Element[] = HTMLElement>(
   ui: string,
   {
     eventHandlers,
@@ -29,5 +31,15 @@ export function setup<Elements extends Element | Element[] = HTMLElement>(
         eventHandlers,
       },
     ),
+  }
+}
+
+export function setup<Elements extends Element | Element[] = HTMLElement>(
+  ui: string,
+  {eventHandlers, ...options}: Parameters<typeof render>[1] & Options = {},
+) {
+  return {
+    user: userEvent.setup(options),
+    ...render<Elements>(ui, {eventHandlers}),
   }
 }

--- a/tests/clipboard/copy.ts
+++ b/tests/clipboard/copy.ts
@@ -60,6 +60,18 @@ test('copy selected text in contenteditable', async () => {
   await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
 })
 
+test('copy on empty selection does nothing', async () => {
+  const {element, getEvents, clearEventCalls, user} = setup(`<input/>`)
+  element.focus()
+  await window.navigator.clipboard.writeText('foo')
+  clearEventCalls()
+
+  await user.copy()
+
+  await expect(window.navigator.clipboard.readText()).resolves.toBe('foo')
+  expect(getEvents()).toHaveLength(0)
+})
+
 describe('without Clipboard API', () => {
   beforeEach(() => {
     Object.defineProperty(window.navigator, 'clipboard', {

--- a/tests/clipboard/copy.ts
+++ b/tests/clipboard/copy.ts
@@ -1,21 +1,25 @@
 import userEvent from '#src'
-import {setup} from '#testHelpers'
+import {render, setup} from '#testHelpers'
 
 test('copy selected value', async () => {
-  const {element, getEvents} = setup<HTMLInputElement>(
+  const {element, getEvents, user} = setup<HTMLInputElement>(
     `<input value="foo bar baz"/>`,
   )
   element.focus()
   element.setSelectionRange(4, 7)
 
-  const dt = await userEvent.copy()
+  const dt = await user.copy()
 
   expect(dt?.getData('text')).toBe('bar')
   expect(getEvents('copy')).toHaveLength(1)
+
+  await expect(window.navigator.clipboard.readText()).resolves.toBe('bar')
 })
 
 test('copy selected text outside of editable', async () => {
-  const {element, getEvents} = setup(`<div tabindex="-1">foo bar baz</div>`)
+  const {element, getEvents, user} = setup(
+    `<div tabindex="-1">foo bar baz</div>`,
+  )
   element.focus()
   document
     .getSelection()
@@ -26,14 +30,18 @@ test('copy selected text outside of editable', async () => {
       5,
     )
 
-  const dt = await userEvent.copy()
+  const dt = await user.copy()
 
   expect(dt?.getData('text')).toBe('oo b')
   expect(getEvents('copy')).toHaveLength(1)
+
+  await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
 })
 
 test('copy selected text in contenteditable', async () => {
-  const {element, getEvents} = setup(`<div contenteditable>foo bar baz</div>`)
+  const {element, getEvents, user} = setup(
+    `<div contenteditable>foo bar baz</div>`,
+  )
   element.focus()
   document
     .getSelection()
@@ -44,15 +52,24 @@ test('copy selected text in contenteditable', async () => {
       5,
     )
 
-  const dt = await userEvent.copy()
+  const dt = await user.copy()
 
   expect(dt?.getData('text')).toBe('oo b')
   expect(getEvents('copy')).toHaveLength(1)
+
+  await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
 })
 
-describe('write to clipboard', () => {
-  test('without Clipboard API', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+describe('without Clipboard API', () => {
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    })
+  })
+
+  test('reject if trying to use missing API', async () => {
+    const {element} = render<HTMLInputElement>(`<input value="foo bar baz"/>`)
     element.focus()
     element.setSelectionRange(4, 7)
 
@@ -63,64 +80,12 @@ describe('write to clipboard', () => {
     )
   })
 
-  test('copy selected value', async () => {
-    const {element, getEvents} = setup<HTMLInputElement>(
-      `<input value="foo bar baz"/>`,
-    )
+  test('skip using missing API', async () => {
+    const {element} = render<HTMLInputElement>(`<input value="foo bar baz"/>`)
     element.focus()
     element.setSelectionRange(4, 7)
 
-    const dt = userEvent.setup().copy()
-
-    await expect(dt).resolves.toBeTruthy()
-    expect((await dt)?.getData('text')).toBe('bar')
-
-    await expect(window.navigator.clipboard.readText()).resolves.toBe('bar')
-
-    expect(getEvents('copy')).toHaveLength(1)
-  })
-
-  test('copy selected text outside of editable', async () => {
-    const {element, getEvents} = setup(`<div tabindex="-1">foo bar baz</div>`)
-    element.focus()
-    document
-      .getSelection()
-      ?.setBaseAndExtent(
-        element.firstChild as Text,
-        1,
-        element.firstChild as Text,
-        5,
-      )
-
-    const dt = userEvent.setup().copy()
-
-    await expect(dt).resolves.toBeTruthy()
-    expect((await dt)?.getData('text')).toBe('oo b')
-
-    await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
-
-    expect(getEvents('copy')).toHaveLength(1)
-  })
-
-  test('copy selected text in contenteditable', async () => {
-    const {element, getEvents} = setup(`<div contenteditable>foo bar baz</div>`)
-    element.focus()
-    document
-      .getSelection()
-      ?.setBaseAndExtent(
-        element.firstChild as Text,
-        1,
-        element.firstChild as Text,
-        5,
-      )
-
-    const dt = userEvent.setup().copy()
-
-    await expect(dt).resolves.toBeTruthy()
-    expect((await dt)?.getData('text')).toBe('oo b')
-
-    await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
-
-    expect(getEvents('copy')).toHaveLength(1)
+    const dt = await userEvent.copy()
+    expect(dt?.getData('text/plain')).toBe('bar')
   })
 })

--- a/tests/clipboard/cut.ts
+++ b/tests/clipboard/cut.ts
@@ -64,6 +64,18 @@ test('cut selected text in contenteditable', async () => {
   await expect(window.navigator.clipboard.readText()).resolves.toBe('oo b')
 })
 
+test('cut on empty selection does nothing', async () => {
+  const {element, getEvents, clearEventCalls, user} = setup(`<input/>`)
+  element.focus()
+  await window.navigator.clipboard.writeText('foo')
+  clearEventCalls()
+
+  await user.cut()
+
+  await expect(window.navigator.clipboard.readText()).resolves.toBe('foo')
+  expect(getEvents()).toHaveLength(0)
+})
+
 describe('without Clipboard API', () => {
   beforeEach(() => {
     Object.defineProperty(window.navigator, 'clipboard', {

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -1,15 +1,32 @@
 import userEvent from '#src'
-import {setup} from '#testHelpers'
+import {render, setup} from '#testHelpers'
 
-test('should paste text in input', async () => {
-  const {element, getEventSnapshot} = setup('<input />')
+test('without clipboard API', async () => {
+  const {element, getEvents} = render(`<input/>`)
   element.focus()
 
-  const text = 'Hello, world!'
-  await userEvent.paste(text)
-  expect(element).toHaveValue(text)
-  expect(element).toHaveProperty('selectionStart', 13)
-  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+  await expect(userEvent.paste()).rejects.toMatchInlineSnapshot(
+    `[Error: \`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
+  )
+  expect(getEvents('paste')).toHaveLength(0)
+})
+
+test('paste with empty clipboard', async () => {
+  const {element, getEvents, user} = setup(`<input/>`)
+  element.focus()
+
+  await element.ownerDocument.defaultView?.navigator.clipboard.write([])
+
+  await user.paste()
+
+  expect(getEvents('paste')).toHaveLength(1)
+  expect(getEvents('input')).toHaveLength(0)
+})
+
+test.each([
+  [
+    `<input/>`,
+    `
     Events fired on: input[value="Hello, world!"]
 
     input[value=""] - focus
@@ -17,18 +34,11 @@ test('should paste text in input', async () => {
     input[value=""] - paste
     input[value=""] - beforeinput
     input[value="Hello, world!"] - input
-  `)
-})
-
-test('should paste text in textarea', async () => {
-  const {element, getEventSnapshot} = setup('<textarea />')
-  element.focus()
-
-  const text = 'Hello, world!'
-  await userEvent.paste(text)
-  expect(element).toHaveValue(text)
-  expect(element).toHaveProperty('selectionStart', 13)
-  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+  `,
+  ],
+  [
+    `<textarea/>`,
+    `
     Events fired on: textarea[value="Hello, world!"]
 
     textarea[value=""] - focus
@@ -36,14 +46,27 @@ test('should paste text in textarea', async () => {
     textarea[value=""] - paste
     textarea[value=""] - beforeinput
     textarea[value="Hello, world!"] - input
-  `)
+  `,
+  ],
+])('should paste text in %s', async (html, events) => {
+  const {element, getEventSnapshot, user} = setup(html)
+  element.focus()
+
+  const text = 'Hello, world!'
+  await element.ownerDocument.defaultView?.navigator.clipboard.writeText(text)
+
+  await user.paste()
+
+  expect(element).toHaveValue(text)
+  expect(element).toHaveProperty('selectionStart', 13)
+  expect(getEventSnapshot()).toMatchInlineSnapshot(events)
 })
 
 test('does not paste when readOnly', async () => {
-  const {element, getEventSnapshot} = setup('<input readonly />')
+  const {element, getEventSnapshot, user} = setup('<input readonly />')
   element.focus()
 
-  await userEvent.paste('hi')
+  await user.paste('hi')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value=""]
 
@@ -54,10 +77,10 @@ test('does not paste when readOnly', async () => {
 })
 
 test('does not paste when disabled', async () => {
-  const {element, getEventSnapshot} = setup('<input disabled />')
+  const {element, getEventSnapshot, user} = setup('<input disabled />')
   element.focus()
 
-  await userEvent.paste('hi')
+  await user.paste('hi')
   expect(getEventSnapshot()).toMatchInlineSnapshot(
     `No events were fired on: input[value=""]`,
   )
@@ -66,15 +89,15 @@ test('does not paste when disabled', async () => {
 test.each(['input', 'textarea'])(
   'should paste text in <%s> up to maxLength if provided',
   async type => {
-    const {element} = setup<HTMLInputElement | HTMLTextAreaElement>(
+    const {element, user} = setup<HTMLInputElement | HTMLTextAreaElement>(
       `<${type} maxlength="10" />`,
     )
 
-    await userEvent.type(element, 'superlongtext')
+    await user.type(element, 'superlongtext')
     expect(element).toHaveValue('superlongt')
 
     element.value = ''
-    await userEvent.paste('superlongtext')
+    await user.paste('superlongtext')
     expect(element).toHaveValue('superlongt')
   },
 )
@@ -82,61 +105,48 @@ test.each(['input', 'textarea'])(
 test.each(['input', 'textarea'])(
   'should append text in <%s> up to maxLength if provided',
   async type => {
-    const {element} = setup<HTMLInputElement | HTMLTextAreaElement>(
+    const {element, user} = setup<HTMLInputElement | HTMLTextAreaElement>(
       `<${type} maxlength="10" />`,
     )
 
-    await userEvent.type(element, 'superlong')
-    await userEvent.type(element, 'text')
+    await user.type(element, 'superlong')
+    await user.type(element, 'text')
     expect(element).toHaveValue('superlongt')
 
     element.value = ''
-    await userEvent.paste('superlongtext')
+    await user.paste('superlongtext')
     expect(element).toHaveValue('superlongt')
   },
 )
 
 test('should replace selected text all at once', async () => {
-  const {element} = setup<HTMLInputElement>('<input value="hello world" />')
+  const {element, user} = setup<HTMLInputElement>(
+    '<input value="hello world" />',
+  )
 
   const selectionStart = 'hello world'.search('world')
   const selectionEnd = selectionStart + 'world'.length
   element.focus()
   element.setSelectionRange(selectionStart, selectionEnd)
-  await userEvent.paste('friend')
+  await user.paste('friend')
   expect(element).toHaveValue('hello friend')
 })
 
-describe('paste from clipboard', () => {
-  test('without clipboard API', async () => {
-    const {element, getEvents} = setup(`<input/>`)
+describe('without Clipboard API', () => {
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    })
+  })
+
+  test('reject if trying to use missing API', async () => {
+    const {element, getEvents} = render(`<input/>`)
     element.focus()
 
     await expect(userEvent.paste()).rejects.toMatchInlineSnapshot(
       `[Error: \`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
     )
     expect(getEvents('paste')).toHaveLength(0)
-  })
-
-  test('with empty clipboard', async () => {
-    const {element, getEvents} = setup(`<input/>`)
-    element.focus()
-
-    await userEvent.setup().paste()
-    expect(getEvents('paste')).toHaveLength(1)
-    expect(getEvents('input')).toHaveLength(0)
-  })
-
-  test('with text in clipboard', async () => {
-    const {element, getEvents} = setup(`<input/>`)
-    element.focus()
-
-    userEvent.setup()
-
-    element.ownerDocument.defaultView?.navigator.clipboard.writeText('foo')
-    await userEvent.paste()
-    expect(getEvents('paste')).toHaveLength(1)
-    expect(getEvents('input')).toHaveLength(1)
-    expect(element).toHaveValue('foo')
   })
 })

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -1,16 +1,6 @@
 import userEvent from '#src'
 import {render, setup} from '#testHelpers'
 
-test('without clipboard API', async () => {
-  const {element, getEvents} = render(`<input/>`)
-  element.focus()
-
-  await expect(userEvent.paste()).rejects.toMatchInlineSnapshot(
-    `[Error: \`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
-  )
-  expect(getEvents('paste')).toHaveLength(0)
-})
-
 test('paste with empty clipboard', async () => {
   const {element, getEvents, user} = setup(`<input/>`)
   element.focus()

--- a/tests/convenience/click.ts
+++ b/tests/convenience/click.ts
@@ -1,4 +1,4 @@
-import userEvent, {PointerEventsCheckLevel} from '#src'
+import {PointerEventsCheckLevel} from '#src'
 import {setup} from '#testHelpers'
 
 describe.each([
@@ -7,9 +7,9 @@ describe.each([
   ['tripleClick', {clickCount: 3}],
 ] as const)('%s', (method, {clickCount}) => {
   test('click element', async () => {
-    const {element, getEvents} = setup(`<div></div>`)
+    const {element, getEvents, user} = setup(`<div></div>`)
 
-    await userEvent[method](element)
+    await user[method](element)
 
     expect(getEvents('mouseover')).toHaveLength(1)
     expect(getEvents('mousedown')).toHaveLength(clickCount)
@@ -18,30 +18,33 @@ describe.each([
   })
 
   test('throw when clicking element with pointer-events set to none', async () => {
-    const {element} = setup(`<div style="pointer-events: none"></div>`)
+    const {element, user} = setup(`<div style="pointer-events: none"></div>`)
 
-    await expect(userEvent[method](element)).rejects.toThrowError(
+    await expect(user[method](element)).rejects.toThrowError(
       /has or inherits pointer-events/i,
     )
   })
 
   test('skip check for pointer-events', async () => {
-    const {element, getEvents} = setup(
+    const {element, getEvents, user} = setup(
       `<div style="pointer-events: none"></div>`,
+      {
+        pointerEventsCheck: PointerEventsCheckLevel.Never,
+      },
     )
 
-    await userEvent[method](element, {
-      pointerEventsCheck: PointerEventsCheckLevel.Never,
-    })
+    await user[method](element)
 
     expect(getEvents('click')).toHaveLength(clickCount)
   })
 
   if (method === 'click') {
     test('skip hover', async () => {
-      const {element, getEvents} = setup(`<div></div>`)
+      const {element, getEvents, user} = setup(`<div></div>`, {
+        skipHover: true,
+      })
 
-      await userEvent[method](element, {skipHover: true})
+      await user[method](element)
 
       expect(getEvents('mouseover')).toHaveLength(0)
       expect(getEvents('click')).toHaveLength(1)

--- a/tests/convenience/tab.ts
+++ b/tests/convenience/tab.ts
@@ -1,11 +1,10 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('tab', async () => {
   const {
     elements: [elA, elB, elC],
+    user,
   } = setup(`<input id="a"/><input id="b"/><input id="c"/>`)
-  const user = userEvent.setup()
   elB.focus()
 
   await user.tab()
@@ -27,8 +26,4 @@ test('tab', async () => {
   // shift=true lifted the shift key
   await user.tab()
   expect(elB).toHaveFocus()
-
-  // call per directApi
-  await userEvent.tab()
-  expect(elC).toHaveFocus()
 })

--- a/tests/document/index.ts
+++ b/tests/document/index.ts
@@ -1,4 +1,4 @@
-import {setup} from '#testHelpers'
+import {render} from '#testHelpers'
 import {
   prepareDocument,
   getUIValue,
@@ -15,7 +15,7 @@ function prepare(element: Element) {
 }
 
 test('keep track of value in UI', async () => {
-  const {element} = setup<HTMLInputElement>(`<input type="number"/>`)
+  const {element} = render<HTMLInputElement>(`<input type="number"/>`)
   // The element has to either receive focus or be already focused when preparing.
   element.focus()
 
@@ -33,7 +33,9 @@ test('keep track of value in UI', async () => {
 })
 
 test('trigger `change` event if value changed since focus/set', async () => {
-  const {element, getEvents} = setup<HTMLInputElement>(`<input type="number"/>`)
+  const {element, getEvents} = render<HTMLInputElement>(
+    `<input type="number"/>`,
+  )
 
   prepare(element)
 
@@ -61,7 +63,7 @@ test('trigger `change` event if value changed since focus/set', async () => {
 })
 
 test('maintain selection range like UI', async () => {
-  const {element} = setup<HTMLInputElement>(`<input type="text" value="abc"/>`)
+  const {element} = render<HTMLInputElement>(`<input type="text" value="abc"/>`)
 
   prepare(element)
 
@@ -76,7 +78,7 @@ test('maintain selection range like UI', async () => {
 })
 
 test('maintain selection range on elements without support for selection range', async () => {
-  const {element} = setup<HTMLInputElement>(`<input type="number"/>`)
+  const {element} = render<HTMLInputElement>(`<input type="number"/>`)
 
   prepare(element)
 
@@ -90,7 +92,7 @@ test('maintain selection range on elements without support for selection range',
 })
 
 test('clear UI selection if selection is programmatically set', async () => {
-  const {element} = setup<HTMLInputElement>(`<input/>`)
+  const {element} = render<HTMLInputElement>(`<input/>`)
 
   prepare(element)
 

--- a/tests/event/behavior/keydown.ts
+++ b/tests/event/behavior/keydown.ts
@@ -1,16 +1,15 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test.each(['Backspace', 'Delete', 'End', 'Home', 'PageUp', 'PageDown'])(
   'implement no keydown behavior for [%s] outside of editable context',
   async code => {
-    const {element, getEvents, clearEventCalls} = setup(
+    const {element, getEvents, clearEventCalls, user} = setup(
       `<div tabIndex="1"></div>`,
     )
     element.focus()
     clearEventCalls()
 
-    await userEvent.keyboard(`[${code}>]`)
+    await user.keyboard(`[${code}>]`)
 
     expect(getEvents().map(e => e.type)).toEqual(['keydown'])
   },

--- a/tests/event/behavior/keyup.ts
+++ b/tests/event/behavior/keyup.ts
@@ -1,4 +1,3 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 describe('release [Space]', () => {
@@ -7,9 +6,8 @@ describe('release [Space]', () => {
     [`<button></button>`, true],
     [`<input/>`, false],
   ])('dispatch `click` on `%s`: %s', async (html, click) => {
-    const {element, clearEventCalls, eventWasFired} = setup(html)
+    const {element, clearEventCalls, eventWasFired, user} = setup(html)
     element.focus()
-    const user = userEvent.setup()
     await user.keyboard('[Space>]')
     clearEventCalls()
 

--- a/tests/event/dispatchEvent.ts
+++ b/tests/event/dispatchEvent.ts
@@ -1,7 +1,7 @@
 import {dispatchUIEvent} from '#src/event'
 import {behavior, BehaviorPlugin} from '#src/event/behavior'
 import {createConfig} from '#src/setup/setup'
-import {setup} from '#testHelpers'
+import {render} from '#testHelpers'
 
 jest.mock('#src/event/behavior', () => ({
   behavior: {
@@ -18,7 +18,7 @@ afterEach(() => {
 })
 
 test('keep default behavior', () => {
-  const {element} = setup(`<input type="checkbox"/>`)
+  const {element} = render(`<input type="checkbox"/>`)
 
   dispatchUIEvent(createConfig(), element, 'click')
 
@@ -27,7 +27,7 @@ test('keep default behavior', () => {
 })
 
 test('replace default behavior', () => {
-  const {element} = setup(`<input type="checkbox"/>`)
+  const {element} = render(`<input type="checkbox"/>`)
 
   const mockBehavior = jest.fn()
   mockPlugin.mockImplementationOnce(() => mockBehavior)
@@ -40,7 +40,7 @@ test('replace default behavior', () => {
 })
 
 test('prevent replaced default behavior', () => {
-  const {element} = setup(`<input type="checkbox"/>`)
+  const {element} = render(`<input type="checkbox"/>`)
   element.addEventListener('click', e => {
     expect(e).toHaveProperty('defaultPrevented', false)
     e.preventDefault()

--- a/tests/jest.d.ts
+++ b/tests/jest.d.ts
@@ -1,0 +1,7 @@
+declare namespace jest {
+  // eslint-disable-next-line
+  export interface MockContext<T, Y extends any[]> {
+    // mock.lastCall has been introduced in jest@27.5 but is still missing in @types/jest
+    lastCall: Y | undefined
+  }
+}

--- a/tests/keyboard/arrow.ts
+++ b/tests/keyboard/arrow.ts
@@ -1,47 +1,46 @@
-import userEvent from '#src'
 import {setSelection} from '#src/utils'
 import {setup} from '#testHelpers'
 
 describe('in text input', () => {
   test('collapse selection to the left', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    const {element, user} = setup<HTMLInputElement>(`<input value="foobar"/>`)
     element.focus()
     element.setSelectionRange(2, 4)
 
-    await userEvent.keyboard('[ArrowLeft]')
+    await user.keyboard('[ArrowLeft]')
 
     expect(element.selectionStart).toBe(2)
     expect(element.selectionEnd).toBe(2)
   })
 
   test('collapse selection to the right', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    const {element, user} = setup<HTMLInputElement>(`<input value="foobar"/>`)
     element.focus()
     element.setSelectionRange(2, 4)
 
-    await userEvent.keyboard('[ArrowRight]')
+    await user.keyboard('[ArrowRight]')
 
     expect(element.selectionStart).toBe(4)
     expect(element.selectionEnd).toBe(4)
   })
 
   test('move cursor left', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    const {element, user} = setup<HTMLInputElement>(`<input value="foobar"/>`)
     element.focus()
     element.setSelectionRange(2, 2)
 
-    await userEvent.keyboard('[ArrowLeft]')
+    await user.keyboard('[ArrowLeft]')
 
     expect(element.selectionStart).toBe(1)
     expect(element.selectionEnd).toBe(1)
   })
 
   test('move cursor right', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="foobar"/>`)
+    const {element, user} = setup<HTMLInputElement>(`<input value="foobar"/>`)
     element.focus()
     element.setSelectionRange(2, 2)
 
-    await userEvent.keyboard('[ArrowRight]')
+    await user.keyboard('[ArrowRight]')
 
     expect(element.selectionStart).toBe(3)
     expect(element.selectionEnd).toBe(3)
@@ -50,7 +49,7 @@ describe('in text input', () => {
 
 describe('in contenteditable', () => {
   test('collapse selection to the left', async () => {
-    const {element} = setup(
+    const {element, user} = setup(
       `<div contenteditable><span>foo</span><span>bar</span></div>`,
     )
     setSelection({
@@ -60,7 +59,7 @@ describe('in contenteditable', () => {
       focusOffset: 1,
     })
 
-    await userEvent.keyboard('[ArrowLeft]')
+    await user.keyboard('[ArrowLeft]')
 
     expect(element.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',
@@ -73,7 +72,7 @@ describe('in contenteditable', () => {
   })
 
   test('collapse selection to the right', async () => {
-    const {element} = setup(
+    const {element, user} = setup(
       `<div contenteditable><span>foo</span><span>bar</span></div>`,
     )
     setSelection({
@@ -83,7 +82,7 @@ describe('in contenteditable', () => {
       focusOffset: 1,
     })
 
-    await userEvent.keyboard('[ArrowRight]')
+    await user.keyboard('[ArrowRight]')
 
     expect(element.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',
@@ -98,6 +97,7 @@ describe('in contenteditable', () => {
   test('move cursor to the left', async () => {
     const {
       elements: [, div],
+      user,
     } = setup(
       `<span>abc</span><div contenteditable><span>foo</span><span>bar</span></div><span>def</span>`,
     )
@@ -106,7 +106,7 @@ describe('in contenteditable', () => {
       focusOffset: 1,
     })
 
-    await userEvent.keyboard('[ArrowLeft][ArrowLeft]')
+    await user.keyboard('[ArrowLeft][ArrowLeft]')
 
     expect(div.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',
@@ -114,7 +114,7 @@ describe('in contenteditable', () => {
     )
     expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 2)
 
-    await userEvent.keyboard('[ArrowLeft][ArrowLeft][ArrowLeft][ArrowLeft]')
+    await user.keyboard('[ArrowLeft][ArrowLeft][ArrowLeft][ArrowLeft]')
 
     expect(div.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',
@@ -126,6 +126,7 @@ describe('in contenteditable', () => {
   test('move cursor to the right', async () => {
     const {
       elements: [, div],
+      user,
     } = setup(
       `<span>abc</span><div contenteditable><span>foo</span><span>bar</span></div><span>def</span>`,
     )
@@ -134,7 +135,7 @@ describe('in contenteditable', () => {
       focusOffset: 2,
     })
 
-    await userEvent.keyboard('[ArrowRight][ArrowRight]')
+    await user.keyboard('[ArrowRight][ArrowRight]')
 
     expect(div.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',
@@ -142,7 +143,7 @@ describe('in contenteditable', () => {
     )
     expect(div.ownerDocument.getSelection()).toHaveProperty('focusOffset', 1)
 
-    await userEvent.keyboard('[ArrowRight][ArrowRight][ArrowRight][ArrowRight]')
+    await user.keyboard('[ArrowRight][ArrowRight][ArrowRight][ArrowRight]')
 
     expect(div.ownerDocument.getSelection()).toHaveProperty(
       'focusNode',

--- a/tests/keyboard/character.ts
+++ b/tests/keyboard/character.ts
@@ -1,34 +1,33 @@
 import cases from 'jest-in-case'
 import {getUIValue} from '#src/document/value'
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('type character into input', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="aXd"/>`)
+  const {element, user} = setup<HTMLInputElement>(`<input value="aXd"/>`)
   element.focus()
   element.selectionStart = 1
   element.selectionEnd = 2
 
-  await userEvent.keyboard('bc')
+  await user.keyboard('bc')
 
   expect(element).toHaveValue('abcd')
 })
 
 test('overwrite input with same value', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="1"/>`)
+  const {element, user} = setup<HTMLInputElement>(`<input value="1"/>`)
   element.select()
   element.focus()
 
-  await userEvent.keyboard('11123')
+  await user.keyboard('11123')
 
   expect(element).toHaveValue('11123')
 })
 
 test('edit `<input type="date"/>`', async () => {
-  const {element} = setup('<input type="date" />')
+  const {element, user} = setup('<input type="date" />')
   element.focus()
 
-  await userEvent.keyboard('2020-06-29')
+  await user.keyboard('2020-06-29')
 
   expect(element).toHaveValue('2020-06-29')
 })
@@ -36,10 +35,10 @@ test('edit `<input type="date"/>`', async () => {
 cases(
   'edit `<input type="time"/>`',
   async ({input, value}) => {
-    const {element} = setup('<input type="time" />')
+    const {element, user} = setup('<input type="time" />')
     element.focus()
 
-    await userEvent.keyboard(input)
+    await user.keyboard(input)
 
     expect(element).toHaveValue(value)
   },
@@ -54,18 +53,18 @@ cases(
 )
 
 test('type character into textarea', async () => {
-  const {element} = setup<HTMLInputElement>(`<textarea>aXd</textarea>`)
+  const {element, user} = setup<HTMLInputElement>(`<textarea>aXd</textarea>`)
   element.focus()
   element.selectionStart = 1
   element.selectionEnd = 2
 
-  await userEvent.keyboard('bc')
+  await user.keyboard('bc')
 
   expect(element).toHaveValue('abcd')
 })
 
 test('type characters into contenteditable', async () => {
-  const {element} = setup('<div contenteditable=true>aXd</div>')
+  const {element, user} = setup('<div contenteditable=true>aXd</div>')
   element.focus()
   element.ownerDocument
     .getSelection()
@@ -76,7 +75,7 @@ test('type characters into contenteditable', async () => {
       2,
     )
 
-  await userEvent.keyboard('bc')
+  await user.keyboard('bc')
 
   expect(element).toHaveTextContent('abcd')
 })
@@ -93,21 +92,21 @@ test.each([
   [`<div tabIndex="-1"/>`],
   [`<div tabIndex="-1" contenteditable="false"/>`],
 ])('do not change non-editable element: %s', async html => {
-  const {element, getEvents} = setup(html)
+  const {element, getEvents, user} = setup(html)
   element.focus()
 
   const value = (element as HTMLInputElement).value
 
-  await userEvent.keyboard('x')
+  await user.keyboard('x')
 
   expect(getEvents('input')).toHaveLength(0)
   expect(element).toHaveProperty('value', value)
 })
 
 test('type [Enter] in textarea', async () => {
-  const {element, getEvents} = setup(`<textarea>f</textarea>`)
+  const {element, getEvents, user} = setup(`<textarea>f</textarea>`)
 
-  await userEvent.type(element, 'oo[Enter]bar[ShiftLeft>][Enter]baz')
+  await user.type(element, 'oo[Enter]bar[ShiftLeft>][Enter]baz')
 
   expect(element).toHaveValue('foo\nbar\nbaz')
   expect(getEvents('input')[2]).toHaveProperty('inputType', 'insertLineBreak')
@@ -115,9 +114,11 @@ test('type [Enter] in textarea', async () => {
 })
 
 test('type [Enter] in contenteditable', async () => {
-  const {element, getEvents} = setup(`<div contenteditable="true">f</div>`)
+  const {element, getEvents, user} = setup(
+    `<div contenteditable="true">f</div>`,
+  )
 
-  await userEvent.type(element, 'oo[Enter]bar[ShiftLeft>][Enter]baz')
+  await user.type(element, 'oo[Enter]bar[ShiftLeft>][Enter]baz')
 
   expect(element).toHaveTextContent('foo bar baz')
   expect(element.firstChild).toHaveProperty('nodeValue', 'foo\nbar\nbaz')
@@ -136,12 +137,12 @@ test.each([
 ])(
   'type invalid values into <input type="number"/>',
   async (text, expectedValue, expectedUiValue, expectedInputEvents) => {
-    const {element, getEvents} = setup<HTMLInputElement>(
+    const {element, getEvents, user} = setup<HTMLInputElement>(
       `<input type="number"/>`,
     )
     element.focus()
 
-    await userEvent.keyboard(text)
+    await user.keyboard(text)
 
     expect(element).toHaveValue(expectedValue)
     expect(getUIValue(element)).toBe(expectedUiValue)

--- a/tests/keyboard/combination.ts
+++ b/tests/keyboard/combination.ts
@@ -1,12 +1,13 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('select input per `Control+A`', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
   element.focus()
   element.selectionStart = 5
 
-  await userEvent.keyboard('{Control>}a')
+  await user.keyboard('{Control>}a')
 
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 11)

--- a/tests/keyboard/control.ts
+++ b/tests/keyboard/control.ts
@@ -1,25 +1,26 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('press [Home] in textarea', async () => {
-  const {element} = setup<HTMLTextAreaElement>(
+  const {element, user} = setup<HTMLTextAreaElement>(
     `<textarea>foo\nbar\baz</textarea>`,
   )
   element.focus()
   element.setSelectionRange(2, 4)
 
-  await userEvent.keyboard('[Home]')
+  await user.keyboard('[Home]')
 
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 0)
 })
 
 test('press [Home] in contenteditable', async () => {
-  const {element} = setup(`<div contenteditable="true">foo\nbar\baz</div>`)
+  const {element, user} = setup(
+    `<div contenteditable="true">foo\nbar\baz</div>`,
+  )
   element.focus()
   document.getSelection()?.setPosition(element.firstChild, 2)
 
-  await userEvent.keyboard('[Home]')
+  await user.keyboard('[Home]')
 
   const selection = document.getSelection()
   expect(selection).toHaveProperty('focusNode', element.firstChild)
@@ -27,24 +28,26 @@ test('press [Home] in contenteditable', async () => {
 })
 
 test('press [End] in textarea', async () => {
-  const {element} = setup<HTMLTextAreaElement>(
+  const {element, user} = setup<HTMLTextAreaElement>(
     `<textarea>foo\nbar\baz</textarea>`,
   )
   element.focus()
   element.setSelectionRange(2, 4)
 
-  await userEvent.keyboard('[End]')
+  await user.keyboard('[End]')
 
   expect(element).toHaveProperty('selectionStart', 10)
   expect(element).toHaveProperty('selectionEnd', 10)
 })
 
 test('press [End] in contenteditable', async () => {
-  const {element} = setup(`<div contenteditable="true">foo\nbar\baz</div>`)
+  const {element, user} = setup(
+    `<div contenteditable="true">foo\nbar\baz</div>`,
+  )
   element.focus()
   document.getSelection()?.setPosition(element.firstChild, 2)
 
-  await userEvent.keyboard('[End]')
+  await user.keyboard('[End]')
 
   const selection = document.getSelection()
   expect(selection).toHaveProperty('focusNode', element.firstChild)
@@ -52,45 +55,49 @@ test('press [End] in contenteditable', async () => {
 })
 
 test('move cursor on [PageUp]', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
   element.focus()
   element.setSelectionRange(2, 4)
 
-  await userEvent.keyboard('[PageUp]')
+  await user.keyboard('[PageUp]')
 
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 0)
 })
 
 test('move cursor on [PageDown]', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
   element.focus()
   element.setSelectionRange(2, 4)
 
-  await userEvent.keyboard('[PageDown]')
+  await user.keyboard('[PageDown]')
 
   expect(element).toHaveProperty('selectionStart', 11)
   expect(element).toHaveProperty('selectionEnd', 11)
 })
 
 test('delete content per Delete', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="abcd"/>`)
+  const {element, user} = setup<HTMLInputElement>(`<input value="abcd"/>`)
   element.focus()
   element.setSelectionRange(1, 2)
 
-  await userEvent.keyboard('[Delete]')
+  await user.keyboard('[Delete]')
 
   expect(element).toHaveValue('acd')
 
-  await userEvent.keyboard('[Delete]')
+  await user.keyboard('[Delete]')
 
   expect(element).toHaveValue('ad')
 })
 
 test('use [Delete] on number input', async () => {
-  const {element} = setup(`<input type="number"/>`)
+  const {element, user} = setup(`<input type="number"/>`)
 
-  await userEvent.type(
+  await user.type(
     element,
     '1e-5[ArrowLeft][Delete]6[ArrowLeft][ArrowLeft][ArrowLeft][Delete][Delete]',
   )
@@ -99,29 +106,30 @@ test('use [Delete] on number input', async () => {
 })
 
 test('use [Delete] on contenteditable', async () => {
-  const {element} = setup(`<div contenteditable>foo bar baz</div>`)
+  const {element, user} = setup(`<div contenteditable>foo bar baz</div>`)
   const text = element.firstChild as Text
   element.focus()
   document.getSelection()?.setBaseAndExtent(text, 1, text, 9)
 
-  await userEvent.keyboard('[Delete]')
+  await user.keyboard('[Delete]')
 
   expect(element).toHaveTextContent('faz')
 })
 
 test('do not fire input events if delete content does nothing', async () => {
-  const {element, getEvents} = setup<HTMLInputElement>(`<input type="foo"/>`)
+  const {element, getEvents, user} =
+    setup<HTMLInputElement>(`<input type="foo"/>`)
   element.focus()
   element.setSelectionRange(3, 3)
 
-  await userEvent.keyboard('[Delete]')
+  await user.keyboard('[Delete]')
 
   expect(getEvents('input')).toHaveLength(0)
 
   element.setSelectionRange(0, 0)
   element.readOnly = true
 
-  await userEvent.keyboard('[Delete]')
+  await user.keyboard('[Delete]')
 
   expect(getEvents('input')).toHaveLength(0)
 })

--- a/tests/keyboard/keyboardAction.ts
+++ b/tests/keyboard/keyboardAction.ts
@@ -1,8 +1,8 @@
 import userEvent from '#src'
-import {setup} from '#testHelpers'
+import {render, setup} from '#testHelpers'
 
 test('no character input if `altKey` or `ctrlKey` is pressed', async () => {
-  const {element, eventWasFired} = setup(`<input/>`)
+  const {element, eventWasFired} = render(`<input/>`)
   element.focus()
 
   await userEvent.keyboard('[ControlLeft>]g')
@@ -17,7 +17,7 @@ test('no character input if `altKey` or `ctrlKey` is pressed', async () => {
 })
 
 test('do not leak repeatKey in state', async () => {
-  const {element} = setup(`<input/>`)
+  const {element} = render(`<input/>`)
   ;(element as HTMLInputElement).focus()
 
   const keyboardState = await userEvent.keyboard('{a>2}')
@@ -26,12 +26,12 @@ test('do not leak repeatKey in state', async () => {
 
 describe('pressing and releasing keys', () => {
   it('fires event with releasing key twice', async () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
+    const {element, getEventSnapshot, clearEventCalls, user} = setup(`<input/>`)
 
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    await userEvent.keyboard('{ArrowLeft>}{ArrowLeft}')
+    await user.keyboard('{ArrowLeft>}{ArrowLeft}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value=""]
@@ -44,12 +44,12 @@ describe('pressing and releasing keys', () => {
   })
 
   it('fires event without releasing key', async () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
+    const {element, getEventSnapshot, clearEventCalls, user} = setup(`<input/>`)
 
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    await userEvent.keyboard('{a>}')
+    await user.keyboard('{a>}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value="a"]
@@ -62,11 +62,11 @@ describe('pressing and releasing keys', () => {
   })
 
   it('fires event multiple times without releasing key', async () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
+    const {element, getEventSnapshot, clearEventCalls, user} = setup(`<input/>`)
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    await userEvent.keyboard('{a>2}')
+    await user.keyboard('{a>2}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value="aa"]
@@ -83,11 +83,11 @@ describe('pressing and releasing keys', () => {
   })
 
   it('fires event multiple times and releases key', async () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
+    const {element, getEventSnapshot, clearEventCalls, user} = setup(`<input/>`)
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    await userEvent.keyboard('{a>2/}')
+    await user.keyboard('{a>2/}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value="aa"]
@@ -105,11 +105,11 @@ describe('pressing and releasing keys', () => {
   })
 
   it('fires event multiple times for multiple keys', async () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
+    const {element, getEventSnapshot, clearEventCalls, user} = setup(`<input/>`)
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    await userEvent.keyboard('{a>2}{b>2/}{c>2}{/a}')
+    await user.keyboard('{a>2}{b>2/}{c>2}{/a}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value="aabbcc"]
@@ -146,22 +146,22 @@ describe('pressing and releasing keys', () => {
 
 describe('prevent default behavior', () => {
   test('per keydown handler', async () => {
-    const {element, getEvents} = setup(`<input/>`)
+    const {element, getEvents, user} = setup(`<input/>`)
     element.focus()
     element.addEventListener('keydown', e => e.preventDefault())
 
-    await userEvent.keyboard('x')
+    await user.keyboard('x')
 
     expect(getEvents('input')).toHaveLength(0)
     expect(element).toHaveValue('')
   })
 
   test('per keypress handler', async () => {
-    const {element, getEvents} = setup(`<input/>`)
+    const {element, getEvents, user} = setup(`<input/>`)
     element.focus()
     element.addEventListener('keypress', e => e.preventDefault())
 
-    await userEvent.keyboard('x')
+    await user.keyboard('x')
 
     expect(getEvents('input')).toHaveLength(0)
     expect(element).toHaveValue('')
@@ -169,10 +169,10 @@ describe('prevent default behavior', () => {
 })
 
 test('do not call setTimeout with delay `null`', async () => {
-  setup(`<div></div>`)
+  const {user} = setup(`<div></div>`)
   const spy = jest.spyOn(global, 'setTimeout')
-  await userEvent.keyboard('ab')
+  await user.keyboard('ab')
   expect(spy).toBeCalledTimes(1)
-  await userEvent.keyboard('cd', {delay: null})
+  await user.setup({delay: null}).keyboard('cd')
   expect(spy).toBeCalledTimes(1)
 })

--- a/tests/keyboard/modifiers.ts
+++ b/tests/keyboard/modifiers.ts
@@ -1,4 +1,3 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test.each([
@@ -7,8 +6,7 @@ test.each([
   ['Alt', 'altKey'],
   ['Meta', 'metaKey'],
 ])('Trigger modifier: %s', async (key, modifier) => {
-  const {element, getEvents} = setup(`<div tabIndex="-1"></div>`)
-  const user = userEvent.setup()
+  const {element, getEvents, user} = setup(`<div tabIndex="-1"></div>`)
   element.focus()
 
   await user.keyboard(`{${key}>}`)
@@ -29,8 +27,7 @@ test.each([
 test.each([['AltGraph'], ['Fn'], ['Symbol']])(
   'Trigger modifier: %s',
   async key => {
-    const {element, getEvents} = setup(`<div tabIndex="-1"></div>`)
-    const user = userEvent.setup()
+    const {element, getEvents, user} = setup(`<div tabIndex="-1"></div>`)
     element.focus()
 
     await user.keyboard(`{${key}>}`)
@@ -56,8 +53,7 @@ test.each([
   ['ScrollLock'],
   ['SymbolLock'],
 ])('Switch lock modifier: %s', async key => {
-  const {element, getEvents} = setup(`<div tabIndex="-1"></div>`)
-  const user = userEvent.setup()
+  const {element, getEvents, user} = setup(`<div tabIndex="-1"></div>`)
   element.focus()
 
   await user.keyboard(`{${key}}`)

--- a/tests/pointer/drag.ts
+++ b/tests/pointer/drag.ts
@@ -1,10 +1,9 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('drag sequence', async () => {
-  const {element, getClickEventsSnapshot} = setup(`<div></div>`)
+  const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
 
-  await userEvent.pointer([
+  await user.pointer([
     {keys: '[MouseLeft>]', target: element},
     {coords: {x: 20, y: 20}},
     '[/MouseLeft]',
@@ -22,9 +21,9 @@ test('drag sequence', async () => {
 })
 
 test('drag touch', async () => {
-  const {element, getClickEventsSnapshot} = setup(`<div></div>`)
+  const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
 
-  await userEvent.pointer([
+  await user.pointer([
     {keys: '[TouchA>]', target: element},
     {pointerName: 'TouchA', coords: {x: 20, y: 20}},
     '[/TouchA]',

--- a/tests/pointer/move.ts
+++ b/tests/pointer/move.ts
@@ -1,10 +1,9 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('hover to other element', async () => {
-  const {elements, getEventSnapshot} = setup(`<div></div><div></div>`)
+  const {elements, getEventSnapshot, user} = setup(`<div></div><div></div>`)
 
-  await userEvent.pointer([
+  await user.pointer([
     {target: elements[0], coords: {x: 20, y: 20}},
     {target: elements[1], coords: {x: 40, y: 40}},
   ])
@@ -28,9 +27,9 @@ test('hover to other element', async () => {
 })
 
 test('hover inside element', async () => {
-  const {element, getEventSnapshot} = setup(`<div><a></a><p></p></div>`)
+  const {element, getEventSnapshot, user} = setup(`<div><a></a><p></p></div>`)
 
-  await userEvent.pointer([
+  await user.pointer([
     {target: element},
     {target: element.firstChild as Element},
     {target: element.lastChild as Element},
@@ -70,9 +69,9 @@ test('hover inside element', async () => {
 })
 
 test('move touch over elements', async () => {
-  const {element, getEventSnapshot} = setup(`<div><a></a><p></p></div>`)
+  const {element, getEventSnapshot, user} = setup(`<div><a></a><p></p></div>`)
 
-  await userEvent.pointer([
+  await user.pointer([
     {keys: '[TouchA>]', target: element},
     {pointerName: 'TouchA', target: element.firstChild as Element},
     {pointerName: 'TouchA', target: element.lastChild as Element},

--- a/tests/pointer/select.ts
+++ b/tests/pointer/select.ts
@@ -1,4 +1,3 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 // On an unprevented mousedown the browser moves the cursor to the closest character.
@@ -7,59 +6,62 @@ import {setup} from '#testHelpers'
 // We treat any mousedown as if it happened on the space after the last character.
 
 test('single mousedown moves cursor to the end', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
 
-  await userEvent.pointer({keys: '[MouseLeft>]', target: element})
+  await user.pointer({keys: '[MouseLeft>]', target: element})
 
   expect(element).toHaveFocus()
   expect(element).toHaveProperty('selectionStart', 11)
 })
 
 test('move focus to closest focusable element', async () => {
-  const {element} = setup(`
+  const {element, user} = setup(`
     <div tabIndex="0">
       <div>this is not focusable</div>
       <button>this is focusable</button>
     </div>
   `)
 
-  await userEvent.pointer({keys: '[MouseLeft>]', target: element.children[1]})
+  await user.pointer({keys: '[MouseLeft>]', target: element.children[1]})
   expect(element.children[1]).toHaveFocus()
 
-  await userEvent.pointer({keys: '[TouchA]', target: element.children[0]})
+  await user.pointer({keys: '[TouchA]', target: element.children[0]})
   expect(element).toHaveFocus()
 })
 
 test('blur when outside of focusable context', async () => {
   const {
     elements: [focusable, notFocusable],
+    user,
   } = setup(`
     <div tabIndex="-1"></div>
     <div></div>
   `)
   focusable.focus()
 
-  await userEvent.pointer({keys: '[MouseLeft>]', target: notFocusable})
+  await user.pointer({keys: '[MouseLeft>]', target: notFocusable})
   expect(document.body).toHaveFocus()
 })
 
 test('mousedown handlers can prevent moving focus', async () => {
-  const {element} = setup<HTMLInputElement>(`<input/>`)
+  const {element, user} = setup<HTMLInputElement>(`<input/>`)
   element.addEventListener('mousedown', e => e.preventDefault())
 
-  await userEvent.pointer({keys: '[MouseLeft>]', target: element})
-  await userEvent.pointer({keys: '[TouchA]', target: element})
+  await user.pointer({keys: '[MouseLeft>]', target: element})
+  await user.pointer({keys: '[TouchA]', target: element})
 
   expect(element).not.toHaveFocus()
   expect(element).toHaveProperty('selectionStart', 0)
 })
 
 test('single mousedown moves cursor to the last text', async () => {
-  const {element} = setup<HTMLInputElement>(
+  const {element, user} = setup<HTMLInputElement>(
     `<div contenteditable>foo bar baz</div>`,
   )
 
-  await userEvent.pointer({keys: '[MouseLeft>]', target: element})
+  await user.pointer({keys: '[MouseLeft>]', target: element})
 
   expect(element).toHaveFocus()
   expect(document.getSelection()).toHaveProperty(
@@ -70,14 +72,16 @@ test('single mousedown moves cursor to the last text', async () => {
 })
 
 test('double mousedown selects a word or a sequence of whitespace', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
 
-  await userEvent.pointer({keys: '[MouseLeft][MouseLeft>]', target: element})
+  await user.pointer({keys: '[MouseLeft][MouseLeft>]', target: element})
 
   expect(element).toHaveProperty('selectionStart', 8)
   expect(element).toHaveProperty('selectionEnd', 11)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft>]',
     target: element,
     offset: 0,
@@ -86,7 +90,7 @@ test('double mousedown selects a word or a sequence of whitespace', async () => 
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 3)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft]',
     target: element,
     offset: 11,
@@ -97,16 +101,18 @@ test('double mousedown selects a word or a sequence of whitespace', async () => 
 
   element.value = 'foo bar  '
 
-  await userEvent.pointer({keys: '[MouseLeft][MouseLeft>]', target: element})
+  await user.pointer({keys: '[MouseLeft][MouseLeft>]', target: element})
 
   expect(element).toHaveProperty('selectionStart', 7)
   expect(element).toHaveProperty('selectionEnd', 9)
 })
 
 test('triple mousedown selects whole line', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft][MouseLeft>]',
     target: element,
   })
@@ -114,7 +120,7 @@ test('triple mousedown selects whole line', async () => {
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 11)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft][MouseLeft>]',
     target: element,
     offset: 0,
@@ -123,7 +129,7 @@ test('triple mousedown selects whole line', async () => {
   expect(element).toHaveProperty('selectionStart', 0)
   expect(element).toHaveProperty('selectionEnd', 11)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft][MouseLeft>]',
     target: element,
     offset: 11,
@@ -134,9 +140,11 @@ test('triple mousedown selects whole line', async () => {
 })
 
 test('mousemove with pressed button extends selection', async () => {
-  const {element} = setup<HTMLInputElement>(`<input value="foo bar baz"/>`)
+  const {element, user} = setup<HTMLInputElement>(
+    `<input value="foo bar baz"/>`,
+  )
 
-  const pointerState = await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft>]',
     target: element,
     offset: 6,
@@ -145,34 +153,34 @@ test('mousemove with pressed button extends selection', async () => {
   expect(element).toHaveProperty('selectionStart', 4)
   expect(element).toHaveProperty('selectionEnd', 7)
 
-  await userEvent.pointer({offset: 2}, {pointerState})
+  await user.pointer({offset: 2})
 
   expect(element).toHaveProperty('selectionStart', 2)
   expect(element).toHaveProperty('selectionEnd', 7)
 
-  await userEvent.pointer({offset: 10}, {pointerState})
+  await user.pointer({offset: 10})
 
   expect(element).toHaveProperty('selectionStart', 4)
   expect(element).toHaveProperty('selectionEnd', 10)
 
-  await userEvent.pointer({}, {pointerState})
+  await user.pointer({})
 
   expect(element).toHaveProperty('selectionStart', 4)
   expect(element).toHaveProperty('selectionEnd', 11)
 
-  await userEvent.pointer({offset: 5}, {pointerState})
+  await user.pointer({offset: 5})
 
   expect(element).toHaveProperty('selectionStart', 4)
   expect(element).toHaveProperty('selectionEnd', 7)
 })
 
 test('selection is moved on non-input elements', async () => {
-  const {element} = setup(
+  const {element, user} = setup(
     `<section><a></a><span>foo</span> <span>bar</span> <span>baz</span></section>`,
   )
   const span = element.querySelectorAll('span')
 
-  const pointerState = await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft][MouseLeft>]',
     target: element,
     offset: 6,
@@ -193,7 +201,7 @@ test('selection is moved on non-input elements', async () => {
   )
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty('endOffset', 3)
 
-  await userEvent.pointer({offset: 2}, {pointerState})
+  await user.pointer({offset: 2})
 
   expect(document.getSelection()?.toString()).toBe('o bar')
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty(
@@ -210,7 +218,7 @@ test('selection is moved on non-input elements', async () => {
   )
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty('endOffset', 3)
 
-  await userEvent.pointer({offset: 10}, {pointerState})
+  await user.pointer({offset: 10})
 
   expect(document.getSelection()?.toString()).toBe('bar ba')
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty(
@@ -227,7 +235,7 @@ test('selection is moved on non-input elements', async () => {
   )
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty('endOffset', 2)
 
-  await userEvent.pointer({}, {pointerState})
+  await user.pointer({})
 
   expect(document.getSelection()?.toString()).toBe('bar baz')
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty(
@@ -246,19 +254,19 @@ test('selection is moved on non-input elements', async () => {
 })
 
 test('`node` overrides the text offset approximation', async () => {
-  const {element} = setup(
+  const {element, user} = setup(
     `<section><div><span>foo</span> <span>bar</span></div> <span>baz</span></section>`,
   )
   const div = element.firstChild as HTMLDivElement
   const span = element.querySelectorAll('span')
 
-  const pointerState = await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft>]',
     target: element,
     node: span[0].firstChild as Node,
     offset: 1,
   })
-  await userEvent.pointer({node: div, offset: 3}, {pointerState})
+  await user.pointer({node: div, offset: 3})
 
   expect(document.getSelection()?.toString()).toBe('oo bar')
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty(
@@ -275,7 +283,7 @@ test('`node` overrides the text offset approximation', async () => {
   )
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty('endOffset', 3)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft]',
     target: element,
     node: span[0].firstChild as Node,
@@ -295,7 +303,7 @@ test('`node` overrides the text offset approximation', async () => {
   )
   expect(document.getSelection()?.getRangeAt(0)).toHaveProperty('endOffset', 3)
 
-  await userEvent.pointer({
+  await user.pointer({
     keys: '[MouseLeft]',
     target: element,
     node: span[0] as Node,
@@ -320,16 +328,17 @@ describe('focus control when clicking label', () => {
   test('click event on label moves focus to control', async () => {
     const {
       elements: [input, label],
+      user,
     } = setup(`<input id="a" value="foo"/><label for="a" tabindex="-1"/>`)
 
-    const pointerState = await userEvent.pointer({
+    await user.pointer({
       keys: '[MouseLeft>]',
       target: label,
     })
 
     expect(label).toHaveFocus()
 
-    await userEvent.pointer('[/MouseLeft]', {pointerState})
+    await user.pointer('[/MouseLeft]')
 
     expect(label).not.toHaveFocus()
     expect(input).toHaveFocus()
@@ -338,10 +347,11 @@ describe('focus control when clicking label', () => {
   test('click handlers can prevent moving focus per label', async () => {
     const {
       elements: [input, label],
+      user,
     } = setup(`<input id="a"/><label for="a" tabindex="-1"/>`)
     label.addEventListener('click', e => e.preventDefault())
 
-    await userEvent.pointer({keys: '[MouseLeft]', target: label})
+    await user.pointer({keys: '[MouseLeft]', target: label})
 
     expect(input).not.toHaveFocus()
   })
@@ -349,9 +359,10 @@ describe('focus control when clicking label', () => {
   test('do not move focus to disabled control', async () => {
     const {
       elements: [input, label],
+      user,
     } = setup(`<input id="a" disabled/><label for="a" tabindex="-1"/>`)
 
-    await userEvent.pointer({keys: '[MouseLeft]', target: label})
+    await user.pointer({keys: '[MouseLeft]', target: label})
 
     expect(label).toHaveFocus()
     expect(input).not.toHaveFocus()

--- a/tests/react/keyboard.tsx
+++ b/tests/react/keyboard.tsx
@@ -24,13 +24,14 @@ test.each([0, 1])('maintain cursor position on controlled input', async () => {
 test('trigger Synthetic `keypress` event for printable characters', async () => {
   const onKeyPress = jest.fn<unknown, [React.KeyboardEvent]>()
   render(<input onKeyPress={onKeyPress} />)
+  const user = userEvent.setup()
   screen.getByRole('textbox').focus()
 
-  await userEvent.keyboard('a')
+  await user.keyboard('a')
   expect(onKeyPress).toHaveBeenCalledTimes(1)
   expect(onKeyPress.mock.calls[0][0]).toHaveProperty('charCode', 97)
 
-  await userEvent.keyboard('[Enter]')
+  await user.keyboard('[Enter]')
   expect(onKeyPress).toHaveBeenCalledTimes(2)
   expect(onKeyPress.mock.calls[1][0]).toHaveProperty('charCode', 13)
 })

--- a/tests/react/type.tsx
+++ b/tests/react/type.tsx
@@ -8,8 +8,9 @@ test('trigger onChange SyntheticEvent on input', async () => {
   const changeHandler = jest.fn()
 
   render(<input onInput={inputHandler} onChange={changeHandler} />)
+  const user = userEvent.setup()
 
-  await userEvent.type(screen.getByRole('textbox'), 'abcdef')
+  await user.type(screen.getByRole('textbox'), 'abcdef')
 
   expect(inputHandler).toHaveBeenCalledTimes(6)
   expect(changeHandler).toHaveBeenCalledTimes(6)
@@ -39,14 +40,15 @@ describe('typing in a controlled input', () => {
 
     return {
       element,
+      user: userEvent.setup(),
       ...addListeners(element),
     }
   }
 
   test('typing in empty controlled input', async () => {
-    const {element, getEventSnapshot} = setupDollarInput()
+    const {element, getEventSnapshot, user} = setupDollarInput()
 
-    await userEvent.type(element, '23')
+    await user.type(element, '23')
 
     expect(element).toHaveValue('$23')
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
@@ -80,9 +82,11 @@ describe('typing in a controlled input', () => {
   })
 
   test('typing in the middle of a controlled input', async () => {
-    const {element, getEventSnapshot} = setupDollarInput({initialValue: '$23'})
+    const {element, getEventSnapshot, user} = setupDollarInput({
+      initialValue: '$23',
+    })
 
-    await userEvent.type(element, '1', {initialSelectionStart: 2})
+    await user.type(element, '1', {initialSelectionStart: 2})
 
     expect(element).toHaveValue('$213')
     expect(element).toHaveProperty('selectionStart', 3)
@@ -117,9 +121,11 @@ describe('typing in a controlled input', () => {
   })
 
   test('ignored {backspace} in controlled input', async () => {
-    const {element, getEventSnapshot} = setupDollarInput({initialValue: '$23'})
+    const {element, getEventSnapshot, user} = setupDollarInput({
+      initialValue: '$23',
+    })
 
-    await userEvent.type(element, '{backspace}', {
+    await user.type(element, '{backspace}', {
       initialSelectionStart: 1,
       initialSelectionEnd: 1,
     })
@@ -131,7 +137,7 @@ describe('typing in a controlled input', () => {
     // the selection start and end to the end of the input
     expect(element.selectionStart).toBe(element.value.length)
     expect(element.selectionEnd).toBe(element.value.length)
-    await userEvent.type(element, '4')
+    await user.type(element, '4')
 
     expect(element).toHaveValue('$234')
     // the backslash in the inline snapshot is to escape the $ before {CURSOR}
@@ -158,10 +164,6 @@ describe('typing in a controlled input', () => {
       input[value="23"] - input
         "{CURSOR}23" -> "$23{CURSOR}"
       input[value="$23"] - keyup: Backspace
-      input[value="$23"] - pointerover
-      input[value="$23"] - pointerenter
-      input[value="$23"] - mouseover
-      input[value="$23"] - mouseenter
       input[value="$23"] - pointermove
       input[value="$23"] - mousemove
       input[value="$23"] - pointerdown

--- a/tests/setup/_mockApis.ts
+++ b/tests/setup/_mockApis.ts
@@ -1,0 +1,54 @@
+import type {UserEventApi} from '#src/setup'
+
+// The following hacky mocking allows us to spy on imported API functions.
+// This way we can test assertions on the wiring of arguments without repeating tests of each API implementation.
+
+// `const` are not initialized when mocking is executed, but `function` are when prefixed with `mock`
+function mockApis() {}
+// access the `function` as object
+type mockApisRefHack = (() => void) &
+  {
+    [name in keyof UserEventApi]: {
+      mock: jest.MockedFunction<UserEventApi[keyof UserEventApi]>
+      real: UserEventApi[name]
+    }
+  }
+
+// make the tests more readable by applying the typecast here
+export function getSpy(k: keyof UserEventApi) {
+  return (mockApis as mockApisRefHack)[k].mock
+}
+export function getReal(k: keyof UserEventApi) {
+  return (mockApis as mockApisRefHack)[k].real
+}
+
+jest.mock('#src/setup/api', () => {
+  const real: UserEventApi & {__esModule: true} =
+    jest.requireActual('#src/setup/api')
+  const fake: Record<string, jest.Mock> = {}
+  // eslint-disable-next-line guard-for-in
+  for (const key in real) {
+    const mock = jest.fn()
+
+    Object.defineProperty(mock, 'name', {
+      get: () => `mock-${key}`,
+    })
+
+    Object.defineProperty(mockApis, key, {
+      get: () => ({
+        mock,
+        real: real[key as keyof UserEventApi],
+      }),
+    })
+
+    fake[key] = mock
+  }
+  return {
+    __esmodule: true,
+    ...fake,
+  }
+})
+
+afterEach(async () => {
+  jest.clearAllMocks()
+})

--- a/tests/setup/index.ts
+++ b/tests/setup/index.ts
@@ -1,261 +1,159 @@
-import cases from 'jest-in-case'
+import {getSpy} from './_mockApis'
 import userEvent from '#src'
-import {UserEventApi} from '#src/setup'
+import {Config, Instance, UserEventApi} from '#src/setup'
 import {setup} from '#testHelpers'
 
-/// start of mocking
-
-// The following hacky mocking allows us to spy on imported API functions.
-// The API imports are replaced with a mock with the real API as implementation.
-// This way we can run the real APIs here and without repeating tests of each API implementation,
-// we still can test assertions on the wiring of arguments.
-
-// Disable eslint rules that are not worth it here as they heavily reduce readability
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable import/order */
-
-// List of API modules imported by `setup`
-import '#src/clipboard'
-import '#src/convenience'
-import '#src/keyboard'
-import '#src/pointer'
-import '#src/utility'
-
-// `const` are not initialized when mocking is executed, but `function` are when prefixed with `mock`
-function mockSpies() {}
-type mockSpiesEntry<T extends keyof UserEventApi = keyof UserEventApi> = {
-  mock: jest.Mock<ReturnType<UserEventApi[T]>>
-  real: UserEventApi[T]
-}
-
-// access the `function` as object
-interface mockSpiesRefHack extends Record<keyof UserEventApi, mockSpiesEntry> {
-  (): void
-}
-// make the tests more readable by applying the typecast here
-function getSpy(k: keyof UserEventApi) {
-  return (mockSpies as mockSpiesRefHack)[k].mock
-}
-function getReal(k: keyof UserEventApi) {
-  return (mockSpies as mockSpiesRefHack)[k].real
-}
-
-/**
- * Mock an API module by replacing some of the exports with spies.
- */
-function mockApis(modulePath: string, vars: string[]) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const real = jest.requireActual(modulePath)
-  const fake: Record<string, jest.Mock> = {}
-  for (const key of vars) {
-    const mock = jest.fn()
-    ;(mockSpies as mockSpiesRefHack)[key as keyof UserEventApi] = {
-      mock,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      real: real[key],
-    }
-    fake[key] = mock
-  }
-  return {
-    __esmodule: true,
-    ...real,
-    ...fake,
+type ApiDeclarations = {
+  [api in keyof UserEventApi]: {
+    args?: unknown[]
+    elementArg?: number
+    elementHtml?: string
+    optionsArg?: number
   }
 }
 
-// List of API functions per module
-jest.mock('#src/clipboard', () =>
-  mockApis('#src/clipboard', ['copy', 'cut', 'paste']),
-)
-jest.mock('#src/convenience', () =>
-  mockApis('#src/convenience', [
-    'click',
-    'dblClick',
-    'hover',
-    'tab',
-    'tripleClick',
-    'unhover',
-  ]),
-)
-jest.mock('#src/keyboard', () => mockApis('#src/keyboard', ['keyboard']))
-jest.mock('#src/pointer', () => mockApis('#src/pointer', ['pointer']))
-jest.mock('#src/utility', () =>
-  mockApis('#src/utility', [
-    'clear',
-    'deselectOptions',
-    'selectOptions',
-    'type',
-    'upload',
-  ]),
-)
+const apiDeclarations: ApiDeclarations = {
+  clear: {elementArg: 0},
+  click: {
+    elementArg: 0,
+  },
+  copy: {},
+  cut: {},
+  dblClick: {
+    elementArg: 0,
+  },
+  hover: {
+    elementArg: 0,
+  },
+  unhover: {
+    elementArg: 0,
+  },
+  keyboard: {
+    args: ['foo'],
+  },
+  paste: {
+    args: ['foo'],
+  },
+  pointer: {
+    args: ['foo'],
+  },
+  selectOptions: {
+    args: [null, ['foo']],
+    elementArg: 0,
+    elementHtml: `<select multiple><option>foo</option></select>`,
+  },
+  deselectOptions: {
+    args: [null, ['foo']],
+    elementArg: 0,
+    elementHtml: `<select multiple><option>foo</option></select>`,
+  },
+  tab: {
+    optionsArg: 0,
+  },
+  tripleClick: {
+    elementArg: 0,
+  },
+  type: {
+    args: [null, 'foo'],
+    elementArg: 0,
+    optionsArg: 2,
+  },
+  upload: {
+    args: [null, new File(['foo'], 'foo.txt')],
+    elementArg: 0,
+    elementHtml: `<input type="file"/>`,
+  },
+}
+const apiDeclarationsEntries = Object.entries(apiDeclarations) as Array<
+  [keyof ApiDeclarations, ApiDeclarations[keyof ApiDeclarations]]
+>
 
-beforeEach(async () => {
-  jest.clearAllMocks()
-
-  // Apply the mock implementation. Any earlier implementation would be removed per `resetAllMocks`.
-  for (const key of Object.keys(mockSpies as mockSpiesRefHack)) {
-    getSpy(key as keyof UserEventApi).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-explicit-any
-      getReal(key as keyof UserEventApi) as any,
-    )
+const opt = Symbol('testOption')
+declare module '#src/setup' {
+  export interface Config {
+    [opt]?: true
   }
-})
-
-/// end of mocking
-
-type APICase<T = keyof UserEventApi> = {
-  api: T
-  args?: unknown[]
-  elementArg?: number
+}
+declare module '#src/options' {
+  export interface Options {
+    [opt]?: true
+  }
 }
 
-cases<APICase>(
-  'apply option defaults',
-  async ({api, args = [], elementArg}) => {
-    const {element} = setup<HTMLInputElement>(
-      ['selectOptions', 'deselectOptions'].includes(api)
-        ? `<select multiple><option>foo</option></select>`
-        : api === 'upload'
-        ? `<input type="file"/>`
-        : `<input/>`,
-    )
+test.each(apiDeclarationsEntries)(
+  'call `%s` api on instance',
+  async (name, {args = [], elementArg, elementHtml = `<input/>`}) => {
+    const {element} = setup<HTMLInputElement>(elementHtml)
     element.focus()
 
     if (elementArg !== undefined) {
       args[elementArg] = element
     }
 
-    const apis = userEvent.setup()
+    type CallWithConfig = {config?: Config}
+    const spy = getSpy(name)
+    spy.mockImplementation(async function testApi(this: Instance) {
+      ;(spy.mock.calls[spy.mock.calls.length - 1] as CallWithConfig).config =
+        this[Config]
+      expect(this[Config][opt]).toBe(true)
+    })
 
-    // The wrapped API gets the name from the implementation
-    // which in this case is the mock from above wrapping the original implementation.
-    expect(apis[api]).toHaveProperty('name', 'mockConstructor')
+    const apis = userEvent.setup({[opt]: true})
 
-    await (apis[api] as Function)(...args)
+    expect(apis[name]).toHaveProperty('name', `mock-${name}`)
 
-    const spy = getSpy(api)
+    await (apis[name] as Function)(...args)
+
     expect(spy).toBeCalledTimes(1)
 
     const subApis = apis.setup({})
 
-    await (subApis[api] as Function)(...args)
+    await (subApis[name] as Function)(...args)
 
     expect(spy).toBeCalledTimes(2)
-  },
-  {
-    clear: {api: 'clear', elementArg: 0},
-    click: {
-      api: 'click',
-      elementArg: 0,
-    },
-    copy: {
-      api: 'copy',
-    },
-    cut: {
-      api: 'cut',
-    },
-    dblClick: {
-      api: 'dblClick',
-      elementArg: 0,
-    },
-    hover: {
-      api: 'hover',
-      elementArg: 0,
-    },
-    unhover: {
-      api: 'unhover',
-      elementArg: 0,
-    },
-    keyboard: {
-      api: 'keyboard',
-      args: ['foo'],
-    },
-    paste: {
-      api: 'paste',
-      args: ['foo'],
-    },
-    pointer: {
-      api: 'pointer',
-      args: ['foo'],
-    },
-    selectOptions: {
-      api: 'selectOptions',
-      args: [null, ['foo']],
-      elementArg: 0,
-    },
-    deSelectOptions: {
-      api: 'deselectOptions',
-      args: [null, ['foo']],
-      elementArg: 0,
-    },
-    tab: {
-      api: 'tab',
-    },
-    tripleClick: {
-      api: 'tripleClick',
-      elementArg: 0,
-    },
-    type: {
-      api: 'type',
-      args: [null, 'foo'],
-      elementArg: 0,
-    },
-    upload: {
-      api: 'upload',
-      elementArg: 0,
-      args: [null, new File(['foo'], 'foo.txt')],
-    },
+    expect(
+      (spy.mock.calls[1] as CallWithConfig).config?.keyboardState,
+    ).toBeTruthy()
+    expect((spy.mock.calls[1] as CallWithConfig).config?.keyboardState).toBe(
+      (spy.mock.calls[0] as CallWithConfig).config?.keyboardState,
+    )
+    expect(
+      (spy.mock.calls[1] as CallWithConfig).config?.pointerState,
+    ).toBeTruthy()
+    expect((spy.mock.calls[1] as CallWithConfig).config?.pointerState).toBe(
+      (spy.mock.calls[0] as CallWithConfig).config?.pointerState,
+    )
   },
 )
 
-test('maintain `keyboardState` through different api calls', async () => {
-  const {element, getEvents} = setup<HTMLInputElement>(`<input/>`)
-  element.focus()
+test.each(apiDeclarationsEntries)(
+  'call `%s` api as directApi',
+  async (
+    name,
+    {args = [], elementArg, elementHtml = `<input/>`, optionsArg},
+  ) => {
+    const {element} = setup<HTMLInputElement>(elementHtml)
+    element.focus()
 
-  const api = userEvent.setup()
+    if (elementArg !== undefined) {
+      args[elementArg] = element
+    }
+    args.push({[opt]: true})
 
-  await expect(api.keyboard('{a>}{b>}')).resolves.toBe(undefined)
+    const internalArgs =
+      optionsArg === undefined ? args.slice(0, -1) : [...args]
 
-  expect(getSpy('keyboard')).toBeCalledTimes(1)
+    const spy = getSpy(name)
+    spy.mockImplementation(async function testApi(this: Instance) {
+      // TODO: add options param to these direct APIs
+      if (!['clear', 'tab'].includes(name)) {
+        expect(this[Config][opt]).toBe(true)
+      }
+    })
 
-  expect(element).toHaveValue('ab')
-  expect(getEvents('keyup')).toHaveLength(0)
+    await (userEvent[name] as Function)(...args)
 
-  await expect(api.setup({delay: 1}).keyboard('{/a}')).resolves.toBe(undefined)
-
-  expect(element).toHaveValue('ab')
-  expect(getEvents('keyup')).toHaveLength(1)
-
-  await api.setup({delay: 0}).keyboard('b')
-
-  expect(element).toHaveValue('abb')
-  // if the state is shared through api the already pressed `b` is automatically released
-  expect(getEvents('keyup')).toHaveLength(3)
-})
-
-test('maintain `pointerState` through different api calls', async () => {
-  const {element, getEvents} = setup<HTMLInputElement>(`<input/>`)
-
-  const api = userEvent.setup()
-
-  await expect(
-    api.pointer({keys: '[MouseLeft>]', target: element}),
-  ).resolves.toBe(undefined)
-
-  expect(getSpy('pointer')).toBeCalledTimes(1)
-  expect(getEvents('mousedown')).toHaveLength(1)
-  expect(getEvents('mouseup')).toHaveLength(0)
-
-  await expect(api.setup({delay: 1}).pointer('[/MouseLeft]')).resolves.toBe(
-    undefined,
-  )
-
-  expect(getSpy('pointer')).toBeCalledTimes(2)
-  expect(getEvents('mousedown')).toHaveLength(1)
-  expect(getEvents('mouseup')).toHaveLength(1)
-
-  await api.setup({delay: 0}).pointer({target: element.ownerDocument.body})
-
-  expect(getSpy('pointer')).toBeCalledTimes(3)
-  expect(getEvents('mouseleave')).toHaveLength(1)
-})
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith(...internalArgs)
+  },
+)

--- a/tests/setup/index.ts
+++ b/tests/setup/index.ts
@@ -1,7 +1,7 @@
 import {getSpy} from './_mockApis'
 import userEvent from '#src'
 import {Config, Instance, UserEventApi} from '#src/setup'
-import {setup} from '#testHelpers'
+import {render} from '#testHelpers'
 
 type ApiDeclarations = {
   [api in keyof UserEventApi]: {
@@ -83,7 +83,7 @@ declare module '#src/options' {
 test.each(apiDeclarationsEntries)(
   'call `%s` api on instance',
   async (name, {args = [], elementArg, elementHtml = `<input/>`}) => {
-    const {element} = setup<HTMLInputElement>(elementHtml)
+    const {element} = render<HTMLInputElement>(elementHtml)
     element.focus()
 
     if (elementArg !== undefined) {
@@ -132,7 +132,7 @@ test.each(apiDeclarationsEntries)(
     name,
     {args = [], elementArg, elementHtml = `<input/>`, optionsArg},
   ) => {
-    const {element} = setup<HTMLInputElement>(elementHtml)
+    const {element} = render<HTMLInputElement>(elementHtml)
     element.focus()
 
     if (elementArg !== undefined) {

--- a/tests/utility/clear.ts
+++ b/tests/utility/clear.ts
@@ -1,10 +1,9 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 describe('clear elements', () => {
   test('clear text input', async () => {
-    const {element, getEventSnapshot} = setup('<input value="hello" />')
-    await userEvent.clear(element)
+    const {element, getEventSnapshot, user} = setup('<input value="hello" />')
+    await user.clear(element)
     expect(element).toHaveValue('')
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: input[value=""]
@@ -18,8 +17,10 @@ describe('clear elements', () => {
   })
 
   test('clear textarea', async () => {
-    const {element, getEventSnapshot} = setup('<textarea>hello</textarea>')
-    await userEvent.clear(element)
+    const {element, getEventSnapshot, user} = setup(
+      '<textarea>hello</textarea>',
+    )
+    await user.clear(element)
     expect(element).toHaveValue('')
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: textarea[value=""]
@@ -33,10 +34,10 @@ describe('clear elements', () => {
   })
 
   test('clear contenteditable', async () => {
-    const {element, getEventSnapshot} = setup(
+    const {element, getEventSnapshot, user} = setup(
       '<div contenteditable>hello</div>',
     )
-    await userEvent.clear(element)
+    await user.clear(element)
     expect(element).toBeEmptyDOMElement()
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
       Events fired on: div
@@ -51,18 +52,19 @@ describe('clear elements', () => {
   test('clear inputs that cannot (programmatically) have a selection', async () => {
     const {
       elements: [email, password, number],
+      user,
     } = setup(`
       <input value="a@b.c" type="email" />
       <input value="pswrd" type="password" />
       <input value="12" type="number" />
     `)
-    await userEvent.clear(email)
+    await user.clear(email)
     expect(email).toHaveValue('')
 
-    await userEvent.clear(password)
+    await user.clear(password)
     expect(password).toHaveValue('')
 
-    await userEvent.clear(number)
+    await user.clear(number)
     expect(number).toHaveValue(null)
   })
 })
@@ -71,6 +73,7 @@ describe('throw error when clear is impossible', () => {
   test('only editable elements can be cleared', async () => {
     const {
       elements: [disabled, readonly, div],
+      user,
     } = setup(`
       <input value="hello" disabled/>
       <input value="hello" readonly/>
@@ -78,35 +81,33 @@ describe('throw error when clear is impossible', () => {
     `)
 
     await expect(
-      userEvent.clear(disabled),
+      user.clear(disabled),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `clear()\` is only supported on editable elements.`,
     )
     await expect(
-      userEvent.clear(readonly),
+      user.clear(readonly),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `clear()\` is only supported on editable elements.`,
     )
-    await expect(
-      userEvent.clear(div),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
+    await expect(user.clear(div)).rejects.toThrowErrorMatchingInlineSnapshot(
       `clear()\` is only supported on editable elements.`,
     )
   })
 
   test('abort if event handler prevents element being focused', async () => {
-    const {element} = setup(`<input value="hello"/>`)
+    const {element, user} = setup(`<input value="hello"/>`)
     element.addEventListener('focus', async () => element.blur())
 
     await expect(
-      userEvent.clear(element),
+      user.clear(element),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `The element to be cleared could not be focused.`,
     )
   })
 
   test('abort if event handler prevents content being selected', async () => {
-    const {element} = setup<HTMLInputElement>(`<input value="hello"/>`)
+    const {element, user} = setup<HTMLInputElement>(`<input value="hello"/>`)
     element.addEventListener('select', async () => {
       if (element.selectionStart === 0) {
         element.selectionStart = 1
@@ -114,7 +115,7 @@ describe('throw error when clear is impossible', () => {
     })
 
     await expect(
-      userEvent.clear(element),
+      user.clear(element),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `The element content to be cleared could not be selected.`,
     )

--- a/tests/utility/selectOptions/_setup.ts
+++ b/tests/utility/selectOptions/_setup.ts
@@ -1,11 +1,16 @@
+import userEvent from '#src'
+import {Options} from '#src/options'
 import {addListeners} from '#testHelpers'
 
-export function setupSelect({
-  disabled = false,
-  disabledOptions = false,
-  multiple = false,
-  pointerEvents = 'auto',
-} = {}) {
+export function setupSelect(
+  {
+    disabled = false,
+    disabledOptions = false,
+    multiple = false,
+    pointerEvents = 'auto',
+  } = {},
+  setupOptions: Options = {},
+) {
   const form = document.createElement('form')
   form.innerHTML = `
     <select
@@ -27,6 +32,7 @@ export function setupSelect({
     form,
     select,
     options,
+    user: userEvent.setup(setupOptions),
   }
 }
 
@@ -69,5 +75,6 @@ export function setupListbox() {
     ...addListeners(listbox),
     listbox,
     options,
+    user: userEvent.setup(),
   }
 }

--- a/tests/utility/selectOptions/deselect.ts
+++ b/tests/utility/selectOptions/deselect.ts
@@ -1,14 +1,13 @@
 import {setupSelect} from './_setup'
-import userEvent from '#src'
 import {addListeners, setup} from '#testHelpers'
 
 test('fires correct events', async () => {
-  const {form, select, options, getEventSnapshot} = setupSelect({
+  const {form, select, options, getEventSnapshot, user} = setupSelect({
     multiple: true,
   })
   options[0].selected = true
 
-  await userEvent.deselectOptions(select, '1')
+  await user.deselectOptions(select, '1')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: select[name="select"][value=[]]
@@ -34,7 +33,7 @@ test('fires correct events', async () => {
 })
 
 test('blurs previously focused element', async () => {
-  const {form, select} = setupSelect({multiple: true})
+  const {form, select, user} = setupSelect({multiple: true})
   const button = document.createElement('button')
   form.append(button)
 
@@ -42,7 +41,7 @@ test('blurs previously focused element', async () => {
   button.focus()
 
   clearEventCalls()
-  await userEvent.deselectOptions(select, '1')
+  await user.deselectOptions(select, '1')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: form
@@ -64,7 +63,7 @@ test('blurs previously focused element', async () => {
 })
 
 test('toggle options as expected', async () => {
-  const {element} = setup(`
+  const {element, user} = setup(`
     <form>
       <select name="select" multiple>
         <option value="1">One</option>
@@ -79,44 +78,44 @@ test('toggle options as expected', async () => {
   const select = element.querySelector('select') as HTMLSelectElement
 
   // select one
-  await userEvent.selectOptions(select, ['1'])
+  await user.selectOptions(select, ['1'])
 
   expect(element).toHaveFormValues({select: ['1']})
 
   // select two and three
-  await userEvent.selectOptions(select, ['2', '3'])
+  await user.selectOptions(select, ['2', '3'])
   expect(element).toHaveFormValues({select: ['1', '2', '3']})
 
   // deselect one and three
-  await userEvent.deselectOptions(select, ['1', '3'])
+  await user.deselectOptions(select, ['1', '3'])
   expect(element).toHaveFormValues({select: ['2']})
 })
 
 test('sets the selected prop on the selected option using option html elements', async () => {
-  const {select, options} = setupSelect({multiple: true})
+  const {select, options, user} = setupSelect({multiple: true})
   const [o1, o2, o3] = options
   o2.selected = true
   o3.selected = true
 
-  await userEvent.deselectOptions(select, [o3, o2])
+  await user.deselectOptions(select, [o3, o2])
   expect(o1.selected).toBe(false)
   expect(o2.selected).toBe(false)
   expect(o3.selected).toBe(false)
 })
 
 test('throws error when provided element is not a multiple select', async () => {
-  const {element} = setup(`<select />`)
-  await expect(userEvent.deselectOptions(element, [])).rejects.toThrowError(
+  const {element, user} = setup(`<select />`)
+  await expect(user.deselectOptions(element, [])).rejects.toThrowError(
     /unable to deselect/i,
   )
 })
 
 test('throws an error one selected option does not match', async () => {
-  const {element} = setup(
+  const {element, user} = setup(
     `<select multiple><option value="a">A</option><option value="b">B</option></select>`,
   )
 
   await expect(
-    userEvent.deselectOptions(element, 'Matches nothing'),
+    user.deselectOptions(element, 'Matches nothing'),
   ).rejects.toThrowError(/not found/i)
 })

--- a/tests/utility/type.ts
+++ b/tests/utility/type.ts
@@ -1,10 +1,9 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 test('type into input', async () => {
-  const {element, getEventSnapshot} = setup('<input value="foo"/>')
+  const {element, getEventSnapshot, user} = setup('<input value="foo"/>')
 
-  await userEvent.type(element, 'bar')
+  await user.type(element, 'bar')
 
   expect(element).toHaveValue('foobar')
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
@@ -43,22 +42,24 @@ test('type into input', async () => {
 })
 
 test('can skip the initial click', async () => {
-  const {element, getEvents, clearEventCalls} = setup('<input value="foo"/>')
+  const {element, getEvents, clearEventCalls, user} = setup(
+    '<input value="foo"/>',
+  )
   element.focus() // users MUST focus themselves if they wish to skip the click
   clearEventCalls()
 
-  await userEvent.type(element, 'bar', {skipClick: true})
+  await user.type(element, 'bar', {skipClick: true})
 
   expect(getEvents('click')).toHaveLength(0)
   expect(element).toHaveValue('barfoo')
 })
 
 test('type with initialSelection', async () => {
-  const {element} = setup<HTMLTextAreaElement>(
+  const {element, user} = setup<HTMLTextAreaElement>(
     '<textarea>Hello World</textarea>',
   )
 
-  await userEvent.type(element, 'Frien', {
+  await user.type(element, 'Frien', {
     initialSelectionStart: 6,
     initialSelectionEnd: 10,
   })
@@ -68,26 +69,26 @@ test('type with initialSelection', async () => {
 
 describe('automatically release pressed keys', () => {
   test('release keys', async () => {
-    const {element, getEvents} = setup('<input />')
+    const {element, getEvents, user} = setup('<input />')
 
-    await userEvent.type(element, '{meta>}{alt>}{control>}a{/alt}')
+    await user.type(element, '{meta>}{alt>}{control>}a{/alt}')
 
     expect(getEvents('keyup')).toHaveLength(4)
   })
 
   test('skipAutoClose', async () => {
-    const {element, getEvents} = setup('<input />')
+    const {element, getEvents, user} = setup('<input />')
 
-    await userEvent.type(element, '{meta>}a', {skipAutoClose: true})
+    await user.type(element, '{meta>}a', {skipAutoClose: true})
 
     expect(getEvents('keyup')).toHaveLength(1)
   })
 })
 
 test('do nothing on disabled element', async () => {
-  const {element, getEvents} = setup('<input disabled/>')
+  const {element, getEvents, user} = setup('<input disabled/>')
 
-  await userEvent.type(element, 'foo')
+  await user.type(element, 'foo')
 
   expect(getEvents()).toHaveLength(0)
 })

--- a/tests/utils/edit/calculateNewValue.ts
+++ b/tests/utils/edit/calculateNewValue.ts
@@ -1,11 +1,10 @@
-import userEvent from '#src'
 import {setup} from '#testHelpers'
 
 // TODO: focus the maxlength tests on the tested aspects
 
 test('honors maxlength', async () => {
-  const {element, getEventSnapshot} = setup('<input maxlength="2" />')
-  await userEvent.type(element, '123')
+  const {element, getEventSnapshot, user} = setup('<input maxlength="2" />')
+  await user.type(element, '123')
 
   // NOTE: no input event when typing "3"
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
@@ -42,8 +41,8 @@ test('honors maxlength', async () => {
 })
 
 test('honors maxlength="" as if there was no maxlength', async () => {
-  const {element, getEventSnapshot} = setup('<input maxlength="" />')
-  await userEvent.type(element, '123')
+  const {element, getEventSnapshot, user} = setup('<input maxlength="" />')
+  await user.type(element, '123')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: input[value="123"]
@@ -80,10 +79,10 @@ test('honors maxlength="" as if there was no maxlength', async () => {
 })
 
 test('honors maxlength with existing text', async () => {
-  const {element, getEventSnapshot} = setup(
+  const {element, getEventSnapshot, user} = setup(
     '<input value="12" maxlength="2" />',
   )
-  await userEvent.type(element, '3')
+  await user.type(element, '3')
 
   // NOTE: no input event when typing "3"
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
@@ -111,11 +110,11 @@ test('honors maxlength with existing text', async () => {
 })
 
 test('honors maxlength on textarea', async () => {
-  const {element, getEventSnapshot} = setup(
+  const {element, getEventSnapshot, user} = setup(
     '<textarea maxlength="2">12</textarea>',
   )
 
-  await userEvent.type(element, '3')
+  await user.type(element, '3')
 
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: textarea[value="12"]
@@ -143,9 +142,11 @@ test('honors maxlength on textarea', async () => {
 
 // https://github.com/testing-library/user-event/issues/418
 test('ignores maxlength on input[type=number]', async () => {
-  const {element} = setup(`<input maxlength="2" type="number" value="12" />`)
+  const {element, user} = setup(
+    `<input maxlength="2" type="number" value="12" />`,
+  )
 
-  await userEvent.type(element, '3')
+  await user.type(element, '3')
 
   expect(element).toHaveValue(123)
 })


### PR DESCRIPTION
**What**:

Rename previous `setup` helper to `render`.
Add new `setup` helper that also calls `userEvent.setup()` and returns the instance.

Rewrite tests for `userEvent.setup()` and the direct APIs.

**Why**:

Using the APIs per `userEvent.setup()` is recommended. Testing the APIs the same way is logical.
It also cleans up tests that rely on input device states.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
