### PR TITLE
fix(paste): skip input according to `defaultPrevented`

### DIFF
--- a/src/clipboard/paste.ts
+++ b/src/clipboard/paste.ts
@@ -1,10 +1,5 @@
 import {Config, Instance} from '../setup'
-import {
-  createDataTransfer,
-  isEditable,
-  readDataTransferFromClipboard,
-  input,
-} from '../utils'
+import {createDataTransfer, readDataTransferFromClipboard} from '../utils'
 
 export async function paste(
   this: Instance,
@@ -26,10 +21,6 @@ export async function paste(
   this.dispatchUIEvent(target, 'paste', {
     clipboardData: dataTransfer,
   })
-
-  if (isEditable(target)) {
-    input(this[Config], target, dataTransfer.getData('text'), 'insertFromPaste')
-  }
 }
 
 function getClipboardDataFromString(text: string) {

--- a/src/event/behavior/index.ts
+++ b/src/event/behavior/index.ts
@@ -2,6 +2,7 @@ import './click'
 import './keydown'
 import './keypress'
 import './keyup'
+import './paste'
 
 export {behavior} from './registry'
 export type {BehaviorPlugin} from './registry'

--- a/src/event/behavior/paste.ts
+++ b/src/event/behavior/paste.ts
@@ -1,0 +1,17 @@
+import {input, isEditable} from '../../utils'
+import {behavior} from './registry'
+
+behavior.paste = (event, target, config) => {
+  if (isEditable(target)) {
+    return () => {
+      if (event.clipboardData) {
+        input(
+          config,
+          target,
+          event.clipboardData.getData('text'),
+          'insertFromPaste',
+        )
+      }
+    }
+  }
+}

--- a/src/event/behavior/paste.ts
+++ b/src/event/behavior/paste.ts
@@ -4,13 +4,9 @@ import {behavior} from './registry'
 behavior.paste = (event, target, config) => {
   if (isEditable(target)) {
     return () => {
-      if (event.clipboardData) {
-        input(
-          config,
-          target,
-          event.clipboardData.getData('text'),
-          'insertFromPaste',
-        )
+      const insertData = event.clipboardData?.getData('text')
+      if (insertData) {
+        input(config, target, insertData, 'insertFromPaste')
       }
     }
   }

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -12,7 +12,7 @@ test('paste with empty clipboard', async () => {
   expect(getEvents('input')).toHaveLength(0)
 })
 
-test('paste with file data', async () => {
+test('do not trigger input for paste with file data', async () => {
   const {getEvents, user} = setup(`<input/>`)
 
   const f0 = new File(['bar'], 'bar0.txt', {type: 'text/plain'})

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -78,15 +78,12 @@ test('does not paste when disabled', async () => {
 })
 
 test('prevent input per paste event handler', async () => {
-  const {element, getEventSnapshot, user} = setup(`<input />`)
+  const {element, eventWasFired, user} = setup(`<input />`)
   element.addEventListener('paste', e => e.preventDefault())
 
   await user.paste('hi')
-  expect(getEventSnapshot()).toMatchInlineSnapshot(`
-    Events fired on: input[value=""]
-
-    input[value=""] - paste
-  `)
+  expect(eventWasFired('paste')).toBe(true)
+  expect(eventWasFired('input')).toBe(false)
 })
 
 test.each(['input', 'textarea'])(

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -65,6 +65,18 @@ test('does not paste when disabled', async () => {
   )
 })
 
+test('does not paste when preventDefault is called', async () => {
+  const {element, getEventSnapshot, user} = setup(`<input />`)
+  element.addEventListener('paste', e => e.preventDefault())
+
+  await user.paste('hi')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: input[value=""]
+
+    input[value=""] - paste
+  `)
+})
+
 test.each(['input', 'textarea'])(
   'should paste text in <%s> up to maxLength if provided',
   async type => {

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -77,7 +77,7 @@ test('does not paste when disabled', async () => {
   )
 })
 
-test('does not paste when preventDefault is called', async () => {
+test('prevent input per paste event handler', async () => {
   const {element, getEventSnapshot, user} = setup(`<input />`)
   element.addEventListener('paste', e => e.preventDefault())
 

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -1,11 +1,23 @@
 import userEvent from '#src'
 import {render, setup} from '#testHelpers'
+import {createDataTransfer} from '#src/utils'
 
 test('paste with empty clipboard', async () => {
   const {element, getEvents, user} = setup(`<input/>`)
   await element.ownerDocument.defaultView?.navigator.clipboard.write([])
 
   await user.paste()
+
+  expect(getEvents('paste')).toHaveLength(1)
+  expect(getEvents('input')).toHaveLength(0)
+})
+
+test('paste with file data', async () => {
+  const {getEvents, user} = setup(`<input/>`)
+
+  const f0 = new File(['bar'], 'bar0.txt', {type: 'text/plain'})
+  const dt = createDataTransfer([f0])
+  await user.paste(dt)
 
   expect(getEvents('paste')).toHaveLength(1)
   expect(getEvents('input')).toHaveLength(0)


### PR DESCRIPTION
**What**:
The paste event now uses the central event dispatching system introduced in #847 to implement the effects of the `paste` event, which ensures the effects are skipped if `event.preventDefault` is called.

**Why**:
This ensures that the effect of the `paste` event is ignored if `event.preventDefault()` is called on the paste event. This matches the behavior of the paste event in the browser, and is necessary to test sites that rely on this behavior. This fixes #861.

**How**:
The behavior of the `paste` event (which is to insert the clipboard content into the current context if it is editable) has been moved from the `paste` module to a separate module in the `behavior` directory. This effect of pasting is now called by the event dispatching system, which also ensures this effect is suppressed if `event.preventDefault` is called.

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
