### PR TITLE
fix: log correct docs link for invalid key descriptors

### DIFF
--- a/src/keyboard/parseKeyDef.ts
+++ b/src/keyboard/parseKeyDef.ts
@@ -27,7 +27,7 @@ export function parseKeyDef(keyboardMap: keyboardKey[], text: string) {
       releasePrevious,
       releaseSelf = true,
       repeat,
-    } = readNextDescriptor(text)
+    } = readNextDescriptor(text, 'keyboard')
 
     const keyDef = keyboardMap.find(def => {
       if (type === '[') {

--- a/src/pointer/parseKeyDef.ts
+++ b/src/pointer/parseKeyDef.ts
@@ -14,7 +14,7 @@ export function parseKeyDef(pointerMap: pointerKey[], keys: string) {
       consumedLength,
       releasePrevious,
       releaseSelf = true,
-    } = readNextDescriptor(keys)
+    } = readNextDescriptor(keys, 'pointer')
     const keyDef = pointerMap.find(p => p.name === descriptor)
 
     if (keyDef) {

--- a/src/utils/keyDef/readNextDescriptor.ts
+++ b/src/utils/keyDef/readNextDescriptor.ts
@@ -81,18 +81,17 @@ function readTag(
   const endBracket = text[pos] === expectedEndBracket ? expectedEndBracket : ''
 
   if (!endBracket) {
-    throw new Error(
-      getErrorMessage(
-        [
-          !repeatModifier && 'repeat modifier',
-          !releaseSelfModifier && 'release modifier',
-          `"${expectedEndBracket}"`,
-        ]
-          .filter(Boolean)
-          .join(' or '),
-        text[pos],
-        text,
-      ),
+    throw applyErrorMessage(
+      new Error(),
+      [
+        !repeatModifier && 'repeat modifier',
+        !releaseSelfModifier && 'release modifier',
+        `"${expectedEndBracket}"`,
+      ]
+        .filter(Boolean)
+        .join(' or '),
+      text[pos],
+      text,
     )
   }
 
@@ -113,7 +112,7 @@ function assertDescriptor(
   pos: number,
 ): asserts descriptor is string {
   if (!descriptor) {
-    throw new Error(getErrorMessage('key descriptor', text[pos], text))
+    throw applyErrorMessage(new Error(), 'key descriptor', text[pos], text)
   }
 }
 
@@ -127,12 +126,19 @@ function hasReleaseSelf(releaseSelfModifier: string, repeatModifier: string) {
   }
 }
 
-function getErrorMessage(
+function applyErrorMessage(
+  error: Error,
   expected: string,
   found: string | undefined,
   text: string,
 ) {
-  return `Expected ${expected} but found "${found ?? ''}" in "${text}"
-    See https://github.com/testing-library/user-event/blob/main/README.md#keyboardtext-options
+  error.message = `Expected ${expected} but found "${found ?? ''}" in "${text}"
+    See ${
+      error.stack?.match(/pointer|keyboard/)?.[0] === 'pointer'
+        ? `https://testing-library.com/docs/user-event/pointer#pressing-a-button-or-touching-the-screen`
+        : `https://testing-library.com/docs/user-event/keyboard`
+    }
     for more information about how userEvent parses your input.`
+
+  return error
 }

--- a/tests/keyboard/parseKeyDef.ts
+++ b/tests/keyboard/parseKeyDef.ts
@@ -110,32 +110,3 @@ cases(
     },
   },
 )
-
-cases(
-  'errors',
-  ({text, expectedError}) => {
-    expect(() => parseKeyDef(defaultKeyMap, `${text}`)).toThrow(expectedError)
-  },
-  {
-    'missing descriptor': {
-      text: '',
-      expectedError: 'but found "" in ""',
-    },
-    'missing closing bracket': {
-      text: '{a)',
-      expectedError: 'but found ")" in "{a)"',
-    },
-    'invalid repeat modifier': {
-      text: '{a>e}',
-      expectedError: 'but found "e" in "{a>e}"',
-    },
-    'missing bracket after repeat modifier': {
-      text: '{a>3)',
-      expectedError: 'but found ")" in "{a>3)"',
-    },
-    'unescaped modifier': {
-      text: '{/>5}',
-      expectedError: 'but found ">" in "{/>5}"',
-    },
-  },
-)

--- a/tests/utils/keyDef/readNextDescriptor.ts
+++ b/tests/utils/keyDef/readNextDescriptor.ts
@@ -5,7 +5,9 @@ import userEvent from '#src'
 cases(
   'errors',
   ({text, expectedError}) => {
-    expect(() => readNextDescriptor(`${text}`)).toThrow(expectedError)
+    expect(() => readNextDescriptor(`${text}`, 'keyboard')).toThrow(
+      expectedError,
+    )
   },
   {
     'missing descriptor': {

--- a/tests/utils/keyDef/readNextDescriptor.ts
+++ b/tests/utils/keyDef/readNextDescriptor.ts
@@ -1,0 +1,41 @@
+import cases from 'jest-in-case'
+import {readNextDescriptor} from '#src/utils'
+import userEvent from '#src'
+
+cases(
+  'errors',
+  ({text, expectedError}) => {
+    expect(() => readNextDescriptor(`${text}`)).toThrow(expectedError)
+  },
+  {
+    'missing descriptor': {
+      text: '',
+      expectedError: 'but found "" in ""',
+    },
+    'missing closing bracket': {
+      text: '{a)',
+      expectedError: 'but found ")" in "{a)"',
+    },
+    'invalid repeat modifier': {
+      text: '{a>e}',
+      expectedError: 'but found "e" in "{a>e}"',
+    },
+    'missing bracket after repeat modifier': {
+      text: '{a>3)',
+      expectedError: 'but found ")" in "{a>3)"',
+    },
+    'unescaped modifier': {
+      text: '{/>5}',
+      expectedError: 'but found ">" in "{/>5}"',
+    },
+  },
+)
+
+test('include appropriate docs link in error message', async () => {
+  await expect(() => userEvent.keyboard('{')).rejects.toThrow(
+    'docs/user-event/keyboard',
+  )
+  await expect(() => userEvent.pointer('{')).rejects.toThrow(
+    'docs/user-event/pointer',
+  )
+})


### PR DESCRIPTION
**What**:

Log correct docs link for invalid key descriptors.

**Why**:

Closes #876 

**How**:

Pass down the context in which the `readNextDescriptor` utility is called.
Link to the updated docs.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
