### PR TITLE
chore: add codesandbox template without framework

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "node": "14",
-  "sandboxes": ["vbcvs"]
+  "sandboxes": ["djcc7b", "vbcvs"]
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,9 @@ body:
       description: |
         Please set up an online code example at https://codesandbox.io.
 
-        You can use the following template as a starting point:
-        https://codesandbox.io/s/vbcvs?file=/src/App.js
+        You can use one of the following templates as a starting point:
+        Native DOM: https://codesandbox.io/s/djcc7b?file=/src/App.js
+        React: https://codesandbox.io/s/vbcvs?file=/src/App.js
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,9 +21,12 @@ body:
         Detail the minimal requirements to reproduce the problem.
 
         If you want to test e.g. certain features of your software, include a minimal component that implements the feature.
+
         Please set up an online code example at https://codesandbox.io.
-        You can use the following template as a starting point:
-        https://codesandbox.io/s/vbcvs?file=/src/App.js
+
+        You can use one of the following templates as a starting point:
+        Native DOM: https://codesandbox.io/s/djcc7b?file=/src/App.js
+        React: https://codesandbox.io/s/vbcvs?file=/src/App.js
 
         If the problem is specific to some environment and/or is not reproducible per Codesandbox,
         please provide the information necessary to reproduce it.


### PR DESCRIPTION
**What**:

Add a Codesandbox template for tests without a JS framework.

**Why**:

Behavior that isn't framework-specific should be reproduced on the native DOM elements and event handlers.

**Checklist**:
- [x] Ready to be merged
