### PR TITLE
fix: track calls to `HTMLInputElement.select()`

### DIFF
--- a/src/document/selection.ts
+++ b/src/document/selection.ts
@@ -69,6 +69,19 @@ export function prepareSelectionInterceptor(
       return {realArgs: v}
     },
   )
+
+  prepareInterceptor(
+    element,
+    'select',
+    function interceptorImpl(this: HTMLInputElement | HTMLTextAreaElement) {
+      this[UISelection] = {
+        anchorOffset: 0,
+        focusOffset: getUIValue(element).length,
+      }
+
+      return {realArgs: [] as []}
+    },
+  )
 }
 
 export function setUISelection(

--- a/tests/document/index.ts
+++ b/tests/document/index.ts
@@ -140,4 +140,23 @@ test('clear UI selection if selection is programmatically set', async () => {
   element.selectionStart = 2
   expect(getUISelection(element)).toHaveProperty('startOffset', 2)
   expect(getUISelection(element)).toHaveProperty('endOffset', 2)
+
+  setUISelection(element, {anchorOffset: 1, focusOffset: 2})
+  element.select()
+  expect(getUISelection(element)).toHaveProperty('startOffset', 0)
+  expect(getUISelection(element)).toHaveProperty('endOffset', 3)
+})
+
+test('select input without selectionRange support', () => {
+  const {element} = render<HTMLInputElement>(
+    `<input type="number" value="123"/>`,
+  )
+
+  prepare(element)
+
+  setUISelection(element, {focusOffset: 1})
+  element.select()
+
+  expect(getUISelection(element)).toHaveProperty('startOffset', 0)
+  expect(getUISelection(element)).toHaveProperty('endOffset', 3)
 })


### PR DESCRIPTION
**What**:

Support setting the UI selection per `HTMLInputElement.select()`.

**Why**:

Closes #897 

**How**:

Add an interceptor on the method and change `UISelection` accordingly.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
