### PR TITLE
configure defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 ## Project setup
 
 1. Fork and clone the repo
-2. Run `npm run setup -s` to install dependencies and run validation
+2. Run `npm run setup` to install dependencies and run validation
 3. Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
 > Tip: Keep your `main` branch pointing at the original repository and make pull
@@ -20,7 +20,7 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 > git branch --set-upstream-to=upstream/main main
 > ```
 >
-> This will add the original repository as a "remote" called "upstream," Then
+> This will add the original repository as a "remote" called "upstream", Then
 > fetch the git information from that remote, then set your local `main` branch
 > to use the upstream main branch whenever you run `git pull`. Then you can make
 > all of your pull request branches based on this `main` branch. Whenever you

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "node build.js",
     "lint": "kcd-scripts lint",
-    "setup": "npm install && npm run validate -s",
+    "setup": "npm install --legacy-peer-deps && npm run validate -s",
     "test": "kcd-scripts test",
     "test:debug": "kcd-scripts --inspect-brk test --runInBand",
     "test:update": "npm test -- --updateSnapshot --coverage",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export {userEvent as default} from './setup'
 export type {keyboardKey} from './keyboard'
 export type {pointerKey} from './pointer'
-export {PointerEventsCheckLevel} from './options'
+export {PointerEventsCheckLevel, configureDefaults} from './options'

--- a/src/options.ts
+++ b/src/options.ts
@@ -125,7 +125,7 @@ export interface Options {
 /**
  * Default options applied when API is called per `userEvent.anyApi()`
  */
-export const defaultOptionsDirect: Required<Options> = {
+let defaultOptionsDirect: Required<Options> = {
   applyAccept: true,
   autoModify: true,
   delay: 0,
@@ -142,7 +142,27 @@ export const defaultOptionsDirect: Required<Options> = {
 /**
  * Default options applied when API is called per `userEvent().anyApi()`
  */
-export const defaultOptionsSetup: Required<Options> = {
+let defaultOptionsSetup: Required<Options> = {
   ...defaultOptionsDirect,
   writeToClipboard: true,
+}
+
+export function getDefaultOptions(type: 'direct' | 'setup') {
+  if (type === 'direct') {
+    return defaultOptionsDirect
+  }
+  return defaultOptionsSetup
+}
+
+export function configureDefaults(options: Partial<Options>) {
+  defaultOptionsDirect = {
+    ...defaultOptionsDirect,
+    ...options,
+  }
+
+  defaultOptionsSetup = {
+    ...defaultOptionsSetup,
+    ...options,
+    writeToClipboard: true,
+  }
 }

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -2,7 +2,7 @@ import {prepareDocument} from '../document'
 import {bindDispatchUIEvent} from '../event'
 import {createKeyboardState} from '../keyboard'
 import {createPointerState} from '../pointer'
-import {defaultOptionsDirect, defaultOptionsSetup, Options} from '../options'
+import {getDefaultOptions, Options} from '../options'
 import {
   ApiLevel,
   attachClipboardStubToView,
@@ -16,7 +16,7 @@ import {wrapAsync} from './wrapAsync'
 
 export function createConfig(
   options: Partial<Config> = {},
-  defaults: Required<Options> = defaultOptionsSetup,
+  defaults: Required<Options> = getDefaultOptions('setup'),
   node?: Node,
 ): Config {
   const document = getDocument(options, node)
@@ -53,7 +53,7 @@ export function setupMain(options: Options = {}) {
  * Setup in direct call per `userEvent.anyApi()`
  */
 export function setupDirect(options: Partial<Config> = {}, node?: Node) {
-  const config = createConfig(options, defaultOptionsDirect, node)
+  const config = createConfig(options, getDefaultOptions('direct'), node)
   prepareDocument(config.document)
 
   return {

--- a/tests/setup/options.ts
+++ b/tests/setup/options.ts
@@ -1,0 +1,21 @@
+import {configureDefaults, getDefaultOptions, Options} from '#src/options'
+
+test('configureDefaults overrides global default values', () => {
+  configureDefaults({
+    usingFakeTimers: true,
+    delay: null,
+    writeToClipboard: false,
+  })
+  expect(getDefaultOptions('direct')).toMatchObject<Options>({
+    usingFakeTimers: true,
+    delay: null,
+    writeToClipboard: false,
+    skipHover: false,
+  })
+  expect(getDefaultOptions('setup')).toMatchObject<Options>({
+    usingFakeTimers: true,
+    delay: null,
+    writeToClipboard: true,
+    skipHover: false,
+  })
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

#904 - addresses pain points with the 14.x API changes regarding configurations and fake timers.

**Why**:
<!-- Why are these changes necessary? -->

Not necessary as there are workarounds, but this will provide a better developer experience and dramatically reduce the amount of code that needs to be changed when upgrading to 14.x since default configs can be set globally.

**How**:
<!-- How were these changes implemented? -->

Took a similar pattern to [dom-testing-library's configure method](https://github.com/testing-library/dom-testing-library/blob/main/src/config.ts).

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Misc**

There were a few small pain points or inconsistencies I noticed when getting setup to contribute which I fixed while I was here:

* `npm run setup` already includes the `-s` flag internally so removed it from the instructions
* The quotes around the repository names included a comma which in this case could be confusing
* `npm install` with npm v7+ was giving errors without the `--legacy-peer-deps` flag (which should be backwards compatible)