### PR TITLE
Use .js extension for build outputs

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,9 +1,9 @@
 ;(async () => {
   const child = require('child_process')
-  const {build} = require('esbuild')
+  const { build } = require('esbuild')
 
   await build({
-    outfile: 'dist/index.mjs',
+    outfile: 'dist/esm/index.js',
     format: 'esm',
     target: 'es6',
     bundle: true,
@@ -12,7 +12,7 @@
   })
 
   await build({
-    outfile: 'dist/index.cjs',
+    outfile: 'dist/index.js',
     format: 'cjs',
     target: 'node12',
     bundle: true,

--- a/build.js
+++ b/build.js
@@ -1,7 +1,9 @@
 ;(async () => {
   const child = require('child_process')
-  const { build } = require('esbuild')
+  const {build} = require('esbuild')
+  const fs = require('fs')
 
+  // put the ESM output in a separate directory to avoid using the .mjs extension
   await build({
     outfile: 'dist/esm/index.js',
     format: 'esm',
@@ -10,6 +12,10 @@
     external: ['@testing-library/dom'],
     entryPoints: ['src/index.ts'],
   })
+
+  // Node will interpret the JS output as CommonJS without a specific type declaration
+  // see https://nodejs.org/dist/latest/docs/api/packages.html#packagejson-and-file-extensions
+  fs.writeFileSync('dist/esm/package.json', '{ "type": "module" }')
 
   await build({
     outfile: 'dist/index.js',

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.mjs"
+      "require": "./dist/index.js",
+      "default": "./dist/esm/index.js"
     }
   },
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
**What**:
Fixes https://github.com/testing-library/user-event/issues/839 by separating the ESM build and CommonJS builds into different directories, instead of using `.cjs` and `.mjs` extensions.

**Why**:
Some build tools don't work well with the `.cjs` / `.mjs` extensions, so using a `.js` extension is more compatible. Users with existing tooling setup for `.js` don't need to update their configurations to work with the new extensions.

**How**:
The entry points in `package.json` were changed to use `index.js` with the ESM build using an `esm/` directory. The `build.js` script now tells `esbuild` to put the files in the appropriate space with the `.js` extension.

**Checklist**:

- [ ] Documentation - N/A
- [x] Tests
- [x] Ready to be merged