### PR TITLE
fix: use globalThis instead of global for browser support

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -55,7 +55,7 @@ export interface Options {
    * This defaults to the owner document of an element if an API is called directly with an element and without setup.
    * Otherwise it falls back to the global document.
    *
-   * @default element.ownerDocument??global.document
+   * @default element.ownerDocument??globalThis.document
    */
   document?: Document
 
@@ -136,7 +136,7 @@ export const defaultOptionsDirect: Required<Options> = {
   applyAccept: true,
   autoModify: true,
   delay: 0,
-  document: global.document,
+  document: globalThis.document,
   keyboardMap: defaultKeyboardMap,
   pointerMap: defaultPointerMap,
   pointerEventsCheck: PointerEventsCheckLevel.EachApiCall,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
This PR fixes a regression introduced [here](https://github.com/testing-library/user-event/pull/790/files#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8R116)

**Why**:
<!-- Why are these changes necessary? -->
At Storybook we have a package [@storybook/testing-library](https://github.com/storybookjs/testing-library) which we use user-event and we'd love to upgrade to v14, but until browser support is sorted we have to hold off.

**How**:
<!-- How were these changes implemented? -->
This PR changes a reference from `global` to `globalThis` to enable browser support. 

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests (tested this fix in a project + ran tests in this repo)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
