### PR TITLE
chore: add lint rule against implicit globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,4 +15,12 @@ module.exports = {
     // ES2022 will be released in June 2022
     'prefer-object-has-own': 0,
   },
+  overrides: [
+    {
+      files: ['src/**'],
+      rules: {
+        'explicit-globals': 'error',
+      },
+    },
+  ],
 }

--- a/eslint/explicit-globals.js
+++ b/eslint/explicit-globals.js
@@ -1,0 +1,38 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      implicitGlobal: 'implicit global "{{name}}"',
+    },
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const scope = context.getScope()
+
+        // `scope` is `GlobalScope` and `scope.variables` are the global variables
+        scope.variables.forEach(variable => {
+          // ignore `undefined`
+          if (variable.name === 'undefined') {
+            return
+          }
+          variable.references.forEach(ref => {
+            // Ignore types and global standard variables like `Object`
+            if (ref.resolved.constructor.name === 'ImplicitLibVariable') {
+              return
+            }
+
+            context.report({
+              node: ref.identifier,
+              messageId: 'implicitGlobal',
+              data: {
+                name: ref.identifier.name,
+              },
+            })
+          })
+        })
+      },
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "build": "node build.js",
-    "lint": "kcd-scripts lint",
+    "lint": "kcd-scripts lint --rulesdir=eslint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",
     "test:debug": "kcd-scripts --inspect-brk test --runInBand",


### PR DESCRIPTION
**What**:

Add a lint rule against implicit use of global variables.

**Why**:

This enforces to get things like `document` or `window` explicitly from `globalThis` or from local scope.

**How**:

Add a local lint rule per `--rulesdir=eslint`.

**Checklist**:
- [ ] Tests
- [x] Ready to be merged
