### PR TITLE
fix: remove implicit global references

### DIFF
--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -19,7 +19,7 @@ export function createConfig(
   defaults: Required<Options> = defaultOptionsSetup,
   node?: Node,
 ): Config {
-  const document = getDocument(options, node)
+  const document = getDocument(options, node, defaults)
 
   const {
     keyboardState = createKeyboardState(),
@@ -43,7 +43,8 @@ export function setupMain(options: Options = {}) {
   const config = createConfig(options)
   prepareDocument(config.document)
 
-  const view = config.document.defaultView ?? /* istanbul ignore next */ window
+  const view =
+    config.document.defaultView ?? /* istanbul ignore next */ globalThis.window
   attachClipboardStubToView(view)
 
   return doSetup(config)
@@ -103,6 +104,12 @@ function doSetup(config: Config): UserEvent {
   }
 }
 
-function getDocument(options: Partial<Config>, node?: Node) {
-  return options.document ?? (node && getDocumentFromNode(node)) ?? document
+function getDocument(
+  options: Partial<Config>,
+  node: Node | undefined,
+  defaults: Required<Options>,
+) {
+  return (
+    options.document ?? (node && getDocumentFromNode(node)) ?? defaults.document
+  )
 }

--- a/src/utils/edit/buildTimeValue.ts
+++ b/src/utils/edit/buildTimeValue.ts
@@ -1,3 +1,5 @@
+const parseInt = globalThis.parseInt
+
 export function buildTimeValue(value: string): string {
   const onlyDigitsValue = value.replace(/\D/g, '')
   if (onlyDigitsValue.length < 2) {
@@ -26,7 +28,7 @@ function build(onlyDigitsValue: string, index: number): string {
   const minuteCharacters = onlyDigitsValue.slice(index)
   const parsedMinutes = parseInt(minuteCharacters, 10)
   const validMinutes = Math.min(parsedMinutes, 59)
-  return `${validHours
+  return `${validHours.toString().padStart(2, '0')}:${validMinutes
     .toString()
-    .padStart(2, '0')}:${validMinutes.toString().padStart(2, '0')}`
+    .padStart(2, '0')}`
 }

--- a/src/utils/misc/wait.ts
+++ b/src/utils/misc/wait.ts
@@ -6,7 +6,7 @@ export function wait(config: Config) {
     return
   }
   return Promise.all([
-    new Promise<void>(resolve => setTimeout(() => resolve(), delay)),
+    new Promise<void>(resolve => globalThis.setTimeout(() => resolve(), delay)),
     config.advanceTimers(delay),
   ])
 }


### PR DESCRIPTION
**What**:

Remove global references or make them explicit.

**Why**:

There might be problems with shadowed global variables in testing environments. See #892 
The way e.g. jest hoists code we cannot be sure that a reference to e.g. `window` in a module is a reference to `globalThis.window`. We further cannot be sure that e.g. `document.defaultView` references the same object as `window`.
Although this is probably no issue in most cases we should be explicit about where we access objects through variables the user provided per `setup()` and where we access through global variables.

#929 , #931 enforce to be explicit about access to globals. Any reference that can't be found per text search for `globalThis.` results in a linting error.

**How**:

- Remove global references from `Clipboard` util. We already pass down `window` to the `create` functions so we can use the scoped variable in the `class`.
  We still access the global `window` for our `afterEach` and `afterAll` hooks to `reset`/`detach` the `Clipboard` stub. This is probably not an issue as the environments providing a global `after*` hook are probably identical to environments merging `window` into the global scope (like jest+jsdom).
  If you happen to use an environment where you need to work around this, please leave a comment.
- Make global references in `setup()` explicit. If the user provides a `document` with `defaultView`, these won't be used.
- Make global references (`parseInt`, `setTimeout`) in utils explicit.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
