### PR TITLE
fix: add missing html tag `details` in FOCUSABLE_SELECTOR

### DIFF
--- a/src/utils/focus/selector.ts
+++ b/src/utils/focus/selector.ts
@@ -7,4 +7,5 @@ export const FOCUSABLE_SELECTOR = [
   '[contenteditable="true"]',
   'a[href]',
   '[tabindex]:not([disabled])',
+  'details',
 ].join(', ')


### PR DESCRIPTION

**What**:
The `<details >` can be focused by default, but couldn't pass the test using `user-event`.

**Why**:

Due to it is missing from the helper `FOCUSABLE_SELECTOR` variable in `user-event`.

**How**:

Total focusable(accessibility) native elements see list in [Accessibility concerns docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns)

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
