### PR TITLE
test: correct false-negative for advancing timers

### DIFF
--- a/tests/utils/misc/wait.ts
+++ b/tests/utils/misc/wait.ts
@@ -1,9 +1,18 @@
+import {createConfig} from '#src/setup/setup'
 import {wait} from '#src/utils/misc/wait'
 
 test('advances timers when set', async () => {
+  const beforeReal = performance.now()
   jest.useFakeTimers()
-  jest.setTimeout(50)
-  // If this wasn't advancing fake timers, we'd timeout and fail the test
-  await wait(10000, jest.advanceTimersByTime)
+  const beforeFake = performance.now()
+
+  const config = createConfig({
+    delay: 1000,
+    advanceTimers: jest.advanceTimersByTime,
+  })
+  await wait(config)
+
+  expect(performance.now() - beforeFake).toBe(1000)
   jest.useRealTimers()
-})
+  expect(performance.now() - beforeReal).toBeLessThan(10)
+}, 10)


### PR DESCRIPTION
**What**:

Rewrite test.

**Why**:

Previous test would not fail if `advanceTimers` wasn't applied.

https://github.com/testing-library/user-event/blob/ee062e762f9ac185d982dbf990387e97e05b3c9d/tests/utils/misc/wait.ts#L3-L9

`validate` script doesn't typecheck tests :disappointed: 
We need to fix that.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
