### PR TITLE
fix: wait after each method before leaving `asyncWrapper`

### DIFF
--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -8,6 +8,7 @@ import {
   attachClipboardStubToView,
   getDocumentFromNode,
   setLevelRef,
+  wait,
 } from '../utils'
 import type {Instance, UserEvent, UserEventApi} from './index'
 import {Config} from './config'
@@ -80,7 +81,12 @@ function wrapAndBindImpl<
   function method(...args: Args) {
     setLevelRef(instance[Config], ApiLevel.Call)
 
-    return wrapAsync(() => impl.apply(instance, args))
+    return wrapAsync(() =>
+      impl.apply(instance, args).then(async ret => {
+        await wait(instance[Config])
+        return ret
+      }),
+    )
   }
   Object.defineProperty(method, 'name', {get: () => impl.name})
 

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -123,9 +123,7 @@ describe('delay', () => {
     const time0 = performance.now()
     await user.keyboard('foo')
 
-    // we don't call delay after the last action
-    // TODO: Should we call it?
-    expect(spy).toBeCalledTimes(2)
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2)
     expect(time0).toBeLessThan(performance.now() - 20)
   })
 

--- a/tests/keyboard/keyboardAction.ts
+++ b/tests/keyboard/keyboardAction.ts
@@ -184,7 +184,9 @@ test('do not call setTimeout with delay `null`', async () => {
   const {user} = setup(`<div></div>`)
   const spy = jest.spyOn(global, 'setTimeout')
   await user.keyboard('ab')
-  expect(spy).toBeCalledTimes(1)
+  expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+
+  spy.mockClear()
   await user.setup({delay: null}).keyboard('cd')
-  expect(spy).toBeCalledTimes(1)
+  expect(spy).not.toBeCalled()
 })

--- a/tests/pointer/index.ts
+++ b/tests/pointer/index.ts
@@ -73,9 +73,7 @@ describe('delay', () => {
       '[/MouseLeft]',
     ])
 
-    // we don't call delay after the last action
-    // TODO: Should we call it?
-    expect(spy).toBeCalledTimes(2)
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2)
     expect(time0).toBeLessThan(performance.now() - 20)
   })
 


### PR DESCRIPTION
**What**:

Wait for asynchronous state updates before leaving the `asyncWrapper`

**Why**:
Closes #938 

**How**:

Add a `wait` call after the respective method when wrapping in `asyncWrapper`.
That should prevent `act` warnings on the `await` right before an API call as it returns on a fresh macrotask.

**Checklist**:
- [x] Tests
- [x] Ready to be merged

** Additional information **
Codesandbox example:
https://codesandbox.io/s/billowing-hooks-h5oj5w?file=/src/App.test.js
