### PR TITLE
refactor: adjust to TS4.7

### DIFF
--- a/src/document/selection.ts
+++ b/src/document/selection.ts
@@ -101,7 +101,7 @@ export function setUISelection(
   const anchorOffset =
     mode === 'replace' || element[UISelection] === undefined
       ? sanitizeOffset(anchorOffsetParam)
-      : (element[UISelection] as UISelection).anchorOffset
+      : element[UISelection].anchorOffset
   const focusOffset = sanitizeOffset(focusOffsetParam)
 
   const startOffset = Math.min(anchorOffset, focusOffset)

--- a/src/utils/misc/level.ts
+++ b/src/utils/misc/level.ts
@@ -17,7 +17,7 @@ declare module '../../setup' {
 
 export function setLevelRef(config: Config, level: ApiLevel) {
   config[Level] ??= {}
-  ;(config[Level] as LevelRefs)[level] = {}
+  config[Level][level] = {}
 }
 
 export function getLevelRef(config: Config, level: ApiLevel) {


### PR DESCRIPTION
**What**:

Typescript 4.7 infers some types correctly which removed the need for type assertions.
It also throws an error for uninitialized properties on a class. Now the property is assigned after constructing the object.

**Why**:

Upgraded dependencies including `typescript@4.7`

**Checklist**:
- [x] Tests
- [x] Ready to be merged
