### PR TITLE
Expose `UserEvent` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {userEvent as default} from './setup'
+export {userEvent as default, UserEvent} from './setup'
 export type {keyboardKey} from './keyboard'
 export type {pointerKey} from './pointer'
 export {PointerEventsCheckLevel} from './options'


### PR DESCRIPTION
**What**:
I exposed `UserEvent` type from `types/setup.ts` to be available in `index.d.ts`

**Why**:
We have been using `user-event` a lot with `eslint-import-resolver-typescript`, but after upgrade of the resolver package, we've got the following error:

> Resolve error: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath `./dist/types/setup` is not defined by "exports" in `/path/to/project/node_modules/@testing-library/user-event/package.json`

So we should either add `types/setup` to exports or just expose this type in `index.d.ts`.

**How**:
-

**Checklist**:
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

I think it's ready to be merged.