### PR TITLE
fix(document): use setters/methods on element as default

### DIFF
--- a/src/document/interceptor.ts
+++ b/src/document/interceptor.ts
@@ -51,7 +51,7 @@ export function prepareInterceptor<
     ...args: Params<ElementType[PropName]>
   ) {
     const {
-      applyNative = true,
+      applyNative = false,
       realArgs,
       then,
     } = interceptorImpl.call(this, ...args)

--- a/src/document/selection.ts
+++ b/src/document/selection.ts
@@ -32,8 +32,7 @@ export function prepareSelectionInterceptor(
     function interceptorImpl(
       this: HTMLInputElement | HTMLTextAreaElement,
       start: number | Value | null,
-      end: number | null,
-      direction: 'forward' | 'backward' | 'none' = 'none',
+      ...others
     ) {
       const isUI = start && typeof start === 'object' && start[UISelection]
 
@@ -42,10 +41,11 @@ export function prepareSelectionInterceptor(
       }
 
       return {
-        realArgs: [Number(start), end, direction] as [
+        applyNative: !!isUI,
+        realArgs: [Number(start), ...others] as [
           number,
           number,
-          typeof direction,
+          'forward' | 'backward' | 'none' | undefined,
         ],
       }
     },


### PR DESCRIPTION
**What**:

We circumvent the setters/methods on element objects when we change "UI" selection/value.
Do not directly apply prototype setters/methods for programmatic calls.

**Why**:

Closes #986

**How**:

Set default for `applyNative` to `false`.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
