### PR TITLE
fix(document): do not track `value` on `HTMLSelectElement`

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -1,5 +1,6 @@
 import {dispatchUIEvent} from '../event'
 import {Config} from '../setup'
+import {isElementType} from '../utils'
 import {prepareSelectionInterceptor} from './selection'
 import {prepareRangeTextInterceptor} from './setRangeText'
 import {
@@ -24,7 +25,7 @@ export function prepareDocument(document: Document) {
   document.addEventListener(
     'focus',
     e => {
-      const el = e.target as Node
+      const el = e.target as Element
 
       prepareElement(el)
     },
@@ -62,12 +63,12 @@ export function prepareDocument(document: Document) {
   document[isPrepared] = isPrepared
 }
 
-function prepareElement(el: Node | HTMLInputElement) {
+function prepareElement(el: Element) {
   if (el[isPrepared]) {
     return
   }
 
-  if ('value' in el) {
+  if (isElementType(el, ['input', 'textarea'])) {
     prepareValueInterceptor(el)
     prepareSelectionInterceptor(el)
     prepareRangeTextInterceptor(el)

--- a/src/document/value.ts
+++ b/src/document/value.ts
@@ -57,7 +57,9 @@ function sanitizeValue(
   return String(v)
 }
 
-export function prepareValueInterceptor(element: HTMLInputElement) {
+export function prepareValueInterceptor(
+  element: HTMLInputElement | HTMLTextAreaElement,
+) {
   prepareInterceptor(element, 'value', valueInterceptor)
 }
 


### PR DESCRIPTION
**What**:

Limit tracking of setters/methods to `HTMLInputElement` and `HTMLTextareaElement`.

**Why**:

Closes #961 

**How**:

Only apply interceptors to those elements leaving other elements with `value` property untouched.
We only use the `setUI` abstraction on `HTMLInputElement` and `HTMLTextareaElement` so we don't need the interceptors here.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
