### PR TITLE
remove remaining implicit global

### DIFF
--- a/eslint-local-rules/explicit-globals.js
+++ b/eslint-local-rules/explicit-globals.js
@@ -1,3 +1,53 @@
+// ignore standard built-in objects
+const whitelist = [
+  'Infinity',
+  'NaN',
+  'undefined',
+  'Object',
+  'Function',
+  'Boolean',
+  'Symbol',
+  'Error',
+  'EvalError',
+  'InternalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'Number',
+  'Math',
+  'Date',
+  'String',
+  'RegExp',
+  'Array',
+  'Int8Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'ArrayBuffer',
+  'DataView',
+  'JSON',
+  'Promise',
+  'Generator',
+  'GeneratorFunction',
+  'Reflect',
+  'Proxy',
+  'Intl',
+  'Intl.Collator',
+  'Intl.DateTimeFormat',
+  'Intl.NumberFormat',
+]
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -13,13 +63,12 @@ module.exports = {
 
         // `scope` is `GlobalScope` and `scope.variables` are the global variables
         scope.variables.forEach(variable => {
-          // ignore `undefined`
-          if (variable.name === 'undefined') {
+          if (whitelist.includes(variable.name)) {
             return
           }
+
           variable.references.forEach(ref => {
-            // Ignore types and global standard variables like `Object`
-            if (ref.resolved.constructor.name === 'ImplicitLibVariable') {
+            if (ref.identifier.parent.type.startsWith('TS')) {
               return
             }
 

--- a/src/utility/upload.ts
+++ b/src/utility/upload.ts
@@ -1,4 +1,10 @@
-import {createFileList, isDisabled, isElementType, setFiles} from '../utils'
+import {
+  createFileList,
+  getWindow,
+  isDisabled,
+  isElementType,
+  setFiles,
+} from '../utils'
 import {Config, Instance} from '../setup'
 
 export interface uploadInit {
@@ -36,7 +42,7 @@ export async function upload(
       return
     }
 
-    setFiles(input, createFileList(files))
+    setFiles(input, createFileList(getWindow(element), files))
     this.dispatchUIEvent(input, 'input')
     this.dispatchUIEvent(input, 'change')
   }

--- a/src/utils/dataTransfer/FileList.ts
+++ b/src/utils/dataTransfer/FileList.ts
@@ -1,6 +1,9 @@
 // FileList can not be created per constructor.
 
-export function createFileList(files: File[]): FileList {
+export function createFileList(
+  window: Window & typeof globalThis,
+  files: File[],
+): FileList {
   const list: FileList & Iterable<File> = {
     ...files,
     length: files.length,
@@ -11,8 +14,8 @@ export function createFileList(files: File[]): FileList {
       }
     },
   }
-  list.constructor = FileList
-  Object.setPrototypeOf(list, FileList.prototype)
+  list.constructor = window.FileList
+  Object.setPrototypeOf(list, window.FileList.prototype)
   Object.freeze(list)
 
   return list

--- a/tests/utils/dataTransfer/FileList.ts
+++ b/tests/utils/dataTransfer/FileList.ts
@@ -2,7 +2,7 @@ import {createFileList} from '#src/utils'
 
 test('implement FileList', () => {
   const file = new File(['hello'], 'hello.png', {type: 'image/png'})
-  const list = createFileList([file])
+  const list = createFileList(window, [file])
 
   expect(list).toBeInstanceOf(FileList)
   expect(list).toHaveLength(1)

--- a/tests/utils/edit/setFiles.ts
+++ b/tests/utils/edit/setFiles.ts
@@ -6,7 +6,7 @@ test('set files', () => {
     `<input type="file"/>`,
   )
 
-  const list = createFileList([new File(['foo'], 'foo.txt')])
+  const list = createFileList(window, [new File(['foo'], 'foo.txt')])
   setFiles(element, list)
 
   expect(element).toHaveProperty('files', list)
@@ -20,7 +20,7 @@ test('switching type resets value', () => {
 
   expect(element).toHaveValue('')
 
-  const list = createFileList([new File(['foo'], 'foo.txt')])
+  const list = createFileList(window, [new File(['foo'], 'foo.txt')])
   setFiles(element as HTMLInputElement & {type: 'file'}, list)
 
   element.type = 'file'
@@ -38,7 +38,7 @@ test('setting value resets `files`', () => {
     `<input type="file"/>`,
   )
 
-  const list = createFileList([new File(['foo'], 'foo.txt')])
+  const list = createFileList(window, [new File(['foo'], 'foo.txt')])
   setFiles(element, list)
 
   // Everything but an empty string throws an error in the browser
@@ -58,7 +58,7 @@ test('is save to call multiple times', () => {
     `<input type="file"/>`,
   )
 
-  const list = createFileList([new File(['foo'], 'foo.txt')])
+  const list = createFileList(window, [new File(['foo'], 'foo.txt')])
   setFiles(element, list)
   setFiles(element, list)
 


### PR DESCRIPTION
**What**:

Flag more implicit globals when linting.
Replace implicit global `FileList` with `window.FileList`.

**Why**:

See #932

**How**:

Don't allow `ImplicitLibVariable`.
Whitelist standard built-in objects.
Ignore types.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
