### PR TITLE
fix(pointer): do not throw for `pointer-events: none` on previous target

### DIFF
--- a/src/convenience/hover.ts
+++ b/src/convenience/hover.ts
@@ -1,9 +1,14 @@
-import {Instance} from '../setup'
+import {Config, Instance} from '../setup'
+import {assertPointerEvents} from '../utils'
 
 export async function hover(this: Instance, element: Element) {
   return this.pointer({target: element})
 }
 
 export async function unhover(this: Instance, element: Element) {
+  assertPointerEvents(
+    this[Config],
+    this[Config].pointerState.position.mouse.target as Element,
+  )
   return this.pointer({target: element.ownerDocument.body})
 }

--- a/src/pointer/pointerMove.ts
+++ b/src/pointer/pointerMove.ts
@@ -7,6 +7,7 @@ import {
   assertPointerEvents,
   setLevelRef,
   ApiLevel,
+  hasPointerEvents,
 } from '../utils'
 import {firePointerEvent} from './firePointerEvents'
 import {resolveSelectionTarget} from './resolveSelectionTarget'
@@ -37,13 +38,13 @@ export async function pointerMove(
 
   if (prevTarget && prevTarget !== target) {
     setLevelRef(config, ApiLevel.Trigger)
-    assertPointerEvents(config, prevTarget)
+    if (hasPointerEvents(config, prevTarget)) {
+      // Here we could probably calculate a few coords to a fake boundary(?)
+      fireMove(prevTarget, prevCoords)
 
-    // Here we could probably calculate a few coords to a fake boundary(?)
-    fireMove(prevTarget, prevCoords)
-
-    if (!isDescendantOrSelf(target, prevTarget)) {
-      fireLeave(prevTarget, prevCoords)
+      if (!isDescendantOrSelf(target, prevTarget)) {
+        fireLeave(prevTarget, prevCoords)
+      }
     }
   }
 

--- a/src/utility/selectOptions.ts
+++ b/src/utility/selectOptions.ts
@@ -80,7 +80,7 @@ async function selectOptionsBase(
         const withPointerEvents =
           this[Config].pointerEventsCheck === 0
             ? true
-            : hasPointerEvents(option)
+            : hasPointerEvents(this[Config], option)
 
         // events fired for multiple select are weird. Can't use hover...
         if (withPointerEvents) {
@@ -111,7 +111,9 @@ async function selectOptionsBase(
       }
     } else if (selectedOptions.length === 1) {
       const withPointerEvents =
-        this[Config].pointerEventsCheck === 0 ? true : hasPointerEvents(select)
+        this[Config].pointerEventsCheck === 0
+          ? true
+          : hasPointerEvents(this[Config], select)
       // the click to open the select options
       if (withPointerEvents) {
         await this.click(select)

--- a/tests/utils/pointer/cssPointerEvents.ts
+++ b/tests/utils/pointer/cssPointerEvents.ts
@@ -11,10 +11,10 @@ test('get pointer-events from element or ancestor', async () => {
         </div>
     `)
 
-  expect(hasPointerEvents(element)).toBe(false)
-  expect(hasPointerEvents(element.children[0])).toBe(true)
-  expect(hasPointerEvents(element.children[1])).toBe(false)
-  expect(hasPointerEvents(element.children[2])).toBe(false)
+  expect(hasPointerEvents(createConfig(), element)).toBe(false)
+  expect(hasPointerEvents(createConfig(), element.children[0])).toBe(true)
+  expect(hasPointerEvents(createConfig(), element.children[1])).toBe(false)
+  expect(hasPointerEvents(createConfig(), element.children[2])).toBe(false)
 })
 
 test('report element that declared pointer-events', async () => {


### PR DESCRIPTION
**What**:

Silently discard pointer events for a previous pointer target that has or inherits `pointer-events: none` instead of throwing an error.

**Why**:

Closes #922 

**How**:

Just skip the calls if the element should not receive pointer events.
Add `assertPointerEvents` in `unhover` so that it still throws for `.unhover(elementWithoutPointerEvents)`.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
