### PR TITLE
fix(document): reduce impact of React@17 workaround

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -80,8 +80,7 @@ function prepareElement(el: Element) {
 export {
   getUIValue,
   setUIValue,
-  startTrackValue,
-  endTrackValue,
+  commitValueAfterInput,
   clearInitialValue,
 } from './value'
 export {getUISelection, setUISelection} from './selection'

--- a/src/document/selection.ts
+++ b/src/document/selection.ts
@@ -145,6 +145,12 @@ export function getUISelection(
   }
 }
 
+export function hasUISelection(
+  element: HTMLInputElement | HTMLTextAreaElement,
+) {
+  return !!element[UISelection]
+}
+
 /** Flag the IDL selection as clean. This does not change the selection. */
 export function setUISelectionClean(
   element: HTMLInputElement | HTMLTextAreaElement,

--- a/src/document/value.ts
+++ b/src/document/value.ts
@@ -151,19 +151,22 @@ export function commitValueAfterInput(
 
   element[TrackChanges] = undefined
 
+  if (!changes?.tracked?.length) {
+    return
+  }
+
   const isJustReactStateUpdate =
-    changes?.tracked?.length === 2 &&
+    changes.tracked.length === 2 &&
     changes.tracked[0] === changes.previousValue &&
     changes.tracked[1] === element.value
 
-  if (isJustReactStateUpdate) {
-    if (hasUISelection(element)) {
-      setUISelection(element, {focusOffset: cursorOffset})
-    }
-  } else if (changes?.tracked?.length) {
+  if (!isJustReactStateUpdate) {
     setUIValueClean(element)
-    if (hasUISelection(element)) {
-      setUISelection(element, {focusOffset: element.value.length})
-    }
+  }
+
+  if (hasUISelection(element)) {
+    setUISelection(element, {
+      focusOffset: isJustReactStateUpdate ? cursorOffset : element.value.length,
+    })
   }
 }

--- a/src/utils/edit/input.ts
+++ b/src/utils/edit/input.ts
@@ -1,9 +1,8 @@
 import {
   clearInitialValue,
-  endTrackValue,
+  commitValueAfterInput,
   getUIValue,
   setUIValue,
-  startTrackValue,
   UISelectionRange,
 } from '../../document'
 import {dispatchUIEvent} from '../../event'
@@ -233,24 +232,9 @@ function commitInput(
   newOffset: number,
   inputInit: InputEventInit,
 ) {
-  // When the input event happens in the browser, React executes all event handlers
-  // and if they change state of a controlled value, nothing happens.
-  // But when we trigger the event handlers in test environment,
-  // the changes are rolled back by React before the state update is applied.
-  // Then the updated state is applied which results in a reset cursor.
-  // There is probably a better way to work around  if we figure out
-  // why the batched update is executed differently in our test environment.
-  startTrackValue(element)
-
   dispatchUIEvent(config, element, 'input', inputInit)
 
-  if (endTrackValue(element as HTMLInputElement)) {
-    setSelection({
-      focusNode: element,
-      anchorOffset: newOffset,
-      focusOffset: newOffset,
-    })
-  }
+  commitValueAfterInput(element, newOffset)
 }
 
 function isValidNumberInput(value: string) {


### PR DESCRIPTION
**What**:

Apply workaround only if the element is controlled by React17.
Do not reapply cursor position if selection has been changed by user code.

**Why**:

Closes #971 

The rollback to previous value before applying a state update in test environment is specific to React@17.

**How**:

Check if `window.REACT_VERSION === 17` and if the `__react` properties exist on the element, before applying the workaround.

**Checklist**:
- [x] Tests
- [x] Ready to be merged
