### PR TITLE
chore: do not build in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: validate
+name: CI
 on:
   push:
     branches:
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches-ignore: ['all-contributors/**']
 jobs:
-  main:
+  validate:
     strategy:
       matrix:
         node: [12, 14, 16]
@@ -47,7 +47,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   release:
-    needs: main
+    needs: validate
     runs-on: ubuntu-latest
     if:
       ${{ github.repository == 'testing-library/user-event' &&

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,8 +36,12 @@ jobs:
         env:
           HUSKY_SKIP_INSTALL: true
 
-      - name: ▶️ Run validate script
-        run: npm run validate
+      - name: ✍ Lint
+        run: npm run lint
+      - name: 🧪 Test
+        run: npm run test
+      - name: 🏗 Build
+        run: npm run build
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
       - name: ✍ Lint
         run: npm run lint
       - name: 🧪 Test
-        run: npm run test
+        run: npm run test -- --coverage
       - name: 🏗 Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "test": "kcd-scripts test",
     "test:debug": "kcd-scripts --inspect-brk test --runInBand",
     "test:update": "npm test -- --updateSnapshot --coverage",
-    "validate": "kcd-scripts validate",
-    "typecheck": "kcd-scripts typecheck"
+    "validate": "kcd-scripts typecheck"
   },
   "devDependencies": {
     "@ph.fritsche/scripts-config": "^2.2.4",


### PR DESCRIPTION
**What**:

Run `typecheck` during pre-commit.

Run `lint` `test` and `build` in CI.

**Why**:

`build` writes to the file system including `package.json` which might result in uncommitted changes.
The properties set on `package.json` by the build script should not be included in the repository as this might give the false impression that changes there might have an effect on the distributed package.

**How**:

During `pre-commit` hook the `validate` script skips `lint` and `test` and only runs `build` and `typecheck`.
We only need `typecheck` here.

In CI the `validate` script runs `lint`, `test`, `build` and `typecheck`.
The build already includes the typecheck.

=> The `validate` script invoked by the `pre-commit` script directly calls `kcd-scripts typecheck`.
=> The CI explicitly lists `lint`, `test` and `build` as separate steps.

**Checklist**:
- [x] Ready to be merged
