### PR TITLE
fix(event): be robust against incomplete event implementations

### DIFF
--- a/src/event/dom-events.d.ts
+++ b/src/event/dom-events.d.ts
@@ -2,8 +2,25 @@ declare module '@testing-library/dom/dist/event-map.js' {
   import {EventType} from '@testing-library/dom'
   export const eventMap: {
     [k in EventType]: {
-      EventType: string
+      EventType: EventInterface
       defaultInit: EventInit
     }
   }
 }
+
+type EventInterface =
+  | 'AnimationEvent'
+  | 'ClipboardEvent'
+  | 'CompositionEvent'
+  | 'DragEvent'
+  | 'Event'
+  | 'FocusEvent'
+  | 'InputEvent'
+  | 'KeyboardEvent'
+  | 'MouseEvent'
+  | 'PointerEvent'
+  | 'PopStateEvent'
+  | 'ProgressEvent'
+  | 'TouchEvent'
+  | 'TransitionEvent'
+  | 'UIEvent'

--- a/src/event/eventMap.ts
+++ b/src/event/eventMap.ts
@@ -4,17 +4,23 @@ import {EventType} from './types'
 export const eventMap = {
   ...baseEventMap,
 
+  click: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
   auxclick: {
-    // like other events this should be PointerEvent, but this is missing in Jsdom
-    // see https://github.com/jsdom/jsdom/issues/2527
-    EventType: 'MouseEvent',
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  contextmenu: {
+    EventType: 'PointerEvent',
     defaultInit: {bubbles: true, cancelable: true, composed: true},
   },
   beforeInput: {
     EventType: 'InputEvent',
     defaultInit: {bubbles: true, cancelable: true, composed: true},
   },
-}
+} as const
 
 export const eventMapKeys: {
   [k in keyof DocumentEventMap]?: keyof typeof eventMap

--- a/src/event/index.ts
+++ b/src/event/index.ts
@@ -1,8 +1,8 @@
 import {Config} from '../setup'
-import {createEvent, EventTypeInit} from './createEvent'
+import {createEvent} from './createEvent'
 import {dispatchEvent} from './dispatchEvent'
 import {isKeyboardEvent, isMouseEvent} from './eventMap'
-import {EventType, PointerCoords} from './types'
+import {EventType, EventTypeInit, PointerCoords} from './types'
 
 export type {EventType, PointerCoords}
 

--- a/src/event/types.ts
+++ b/src/event/types.ts
@@ -1,5 +1,27 @@
 export type EventType = keyof DocumentEventMap
 
+export type EventTypeInit<K extends EventType> = SpecificEventInit<
+  FixedDocumentEventMap[K]
+>
+
+export interface FixedDocumentEventMap extends DocumentEventMap {
+  input: InputEvent
+}
+
+type SpecificEventInit<E extends Event> = E extends InputEvent
+  ? InputEventInit
+  : E extends ClipboardEvent
+  ? ClipboardEventInit
+  : E extends KeyboardEvent
+  ? KeyboardEventInit
+  : E extends PointerEvent
+  ? PointerEventInit
+  : E extends MouseEvent
+  ? MouseEventInit
+  : E extends UIEvent
+  ? UIEventInit
+  : EventInit
+
 export interface PointerCoords {
   x?: number
   y?: number

--- a/tests/_helpers/listeners.ts
+++ b/tests/_helpers/listeners.ts
@@ -164,6 +164,8 @@ function isMouseEvent(event: Event): event is MouseEvent {
   return (
     event.constructor.name === 'MouseEvent' ||
     event.type === 'click' ||
+    event.type === 'auxclick' ||
+    event.type === 'contextmenu' ||
     event.type.startsWith('mouse')
   )
 }

--- a/tests/keyboard/modifiers.ts
+++ b/tests/keyboard/modifiers.ts
@@ -12,8 +12,7 @@ test.each([
   const modifierDown = getEvents('keydown')[0]
   expect(modifierDown).toHaveProperty('key', key)
   expect(modifierDown).toHaveProperty(modifier, true)
-  // This should be true, but this is a bug in JSDOM
-  // expect(modifierDown.getModifierState(key)).toBe(true)
+  expect(modifierDown.getModifierState(key)).toBe(true)
 
   await user.keyboard('a')
   expect(getEvents('keydown')[1]).toHaveProperty(modifier, true)


### PR DESCRIPTION
**What**:

Assign the specific event properties and methods on the events instead of relying on the event constructors.

**Why**:

Some DOM implementations are incomplete. E.g. Jsdom lacks support for `PointerEvent` and it won't be implemented any time soon.
While initializing the events should be out of scope, events lacking the properties we correctly provide for `init` makes for a bad user experience and simply assigning the properties seems sufficient.

Closes #926 

Return correct modifier state for `Alt`, `Control`, `Meta` and `Shift` per `getModifierState`.

**How**:

Replace the `createEvent` imported from `@testing-library/dom` with own implementation.

**Checklist**:
- [x] Tests
- [x] Ready to be merged