### PR TITLE
test: prevent false-positive with fake timers

### DIFF
--- a/tests/utils/misc/wait.ts
+++ b/tests/utils/misc/wait.ts
@@ -14,5 +14,5 @@ test('advances timers when set', async () => {
 
   expect(performance.now() - beforeFake).toBe(1000)
   jest.useRealTimers()
-  expect(performance.now() - beforeReal).toBeLessThan(10)
+  expect(performance.now() - beforeReal).toBeLessThan(1000)
 }, 10)


### PR DESCRIPTION
**What**:

Prevent false-positive test due to slow test environment.

**Why**:

Sometimes the execution is delayed just enough to make this assertion fail.

**Checklist**:
- [x] Ready to be merged
