### PR TITLE
Avoid usage of logical nullish assignment for node 14 compatibility

### DIFF
--- a/src/system/keyboard.ts
+++ b/src/system/keyboard.ts
@@ -98,7 +98,7 @@ export class KeyboardHost {
     const target = getActiveElementOrBody(config.document)
     this.setKeydownTarget(target)
 
-    this.pressed[code] ??= {
+    this.pressed[code] = this.pressed[code] ?? {
       keyDef,
       unpreventedDefault: false,
     }

--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -41,7 +41,7 @@ export class PointerHost {
     private registry = {} as Record<string, Device>
 
     get(k: string) {
-      this.registry[k] ??= new Device()
+      this.registry[k] = this.registry[k] ?? new Device()
       return this.registry[k]
     }
   })()

--- a/src/utils/misc/level.ts
+++ b/src/utils/misc/level.ts
@@ -16,7 +16,7 @@ declare module '../../setup' {
 }
 
 export function setLevelRef(config: Config, level: ApiLevel) {
-  config[Level] ??= {}
+  config[Level] = config[Level] ?? {}
   config[Level][level] = {}
 }
 


### PR DESCRIPTION

**What**:

Replace logical nullish assignement `test ??= other` with `test = test ?? other`.

**Why**:

For better compatibility.

See https://github.com/testing-library/user-event/issues/1014

**How**:

Adopting the source files.


**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
