### PR TITLE
fix(build): add `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "validate": "kcd-scripts typecheck"
   },
   "devDependencies": {
-    "@ph.fritsche/scripts-config": "^2.3.0",
+    "@ph.fritsche/scripts-config": "^2.3.1",
     "@testing-library/dom": "^8.11.4",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
**What**:

Add `exports` field

**Why**:

Missing `exports` field breaks native ESM import.
See https://github.com/testing-library/user-event/discussions/1021

**How**:

Updated script to always generate `exports` field when creating a dual-build.

**Checklist**:
- [x] Ready to be merged
