### PR TITLE
fix(build): add `types` field in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "validate": "kcd-scripts typecheck"
   },
   "devDependencies": {
-    "@ph.fritsche/scripts-config": "^2.3.1",
+    "@ph.fritsche/scripts-config": "^2.4.0",
     "@testing-library/dom": "^8.11.4",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
**What**:

`exports[path].types` is added to `package.json` by the build script in the latest version.
The change to the package.json isn't necessary, but let's add it to the changelog this way.

**Why**:
Closes #1024 
See https://github.com/testing-library/user-event/discussions/978

**Checklist**:
- [x] Ready to be merged
