### PR TITLE
fix(event): assign pointer coords to MouseEvent

### DIFF
--- a/src/event/createEvent.ts
+++ b/src/event/createEvent.ts
@@ -211,7 +211,14 @@ function initMouseEvent(
     button,
     buttons,
     relatedTarget,
-  }: MouseEventInit & {x?: number; y?: number},
+    offsetX,
+    offsetY,
+    pageX,
+    pageY,
+  }: MouseEventInit &
+    Partial<
+      Pick<MouseEvent, 'x' | 'y' | 'offsetX' | 'offsetY' | 'pageX' | 'pageY'>
+    >,
 ) {
   assignProps(event, {
     screenX: sanitizeNumber(screenX),
@@ -223,6 +230,10 @@ function initMouseEvent(
     button: sanitizeNumber(button),
     buttons: sanitizeNumber(buttons),
     relatedTarget,
+    offsetX: sanitizeNumber(offsetX),
+    offsetY: sanitizeNumber(offsetY),
+    pageX: sanitizeNumber(pageX),
+    pageY: sanitizeNumber(pageY),
   })
 }
 

--- a/tests/pointer/move.ts
+++ b/tests/pointer/move.ts
@@ -103,3 +103,25 @@ test('move touch over elements', async () => {
     div - click: primary
   `)
 })
+
+test('declare pointer coordinates', async () => {
+  const {element, getEvents, user} = setup(`<div></div>`)
+
+  const coords: Partial<MouseEvent> = {
+    x: 1,
+    y: 2,
+    offsetX: 3,
+    offsetY: 4,
+    pageX: 5,
+    pageY: 6,
+    screenX: 7,
+    screenY: 8,
+  }
+
+  await user.pointer({target: element, coords})
+
+  // .toEqual(expect.objectContaining) yields a misleading diff
+  Object.entries(coords).forEach(([prop, value]) => {
+    expect(getEvents('mouseover')[0]).toHaveProperty(prop, value)
+  })
+})


### PR DESCRIPTION
**What**:

Assign missing pointer coords.

**Why**:

Closes #1037 

**Checklist**:
- [x] Tests
- [x] Ready to be merged
