### PR TITLE
Convert "export {userEvent as default}" to "export default"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export {userEvent as default} from './setup'
+import {userEvent} from './setup'
+export default userEvent
 export type {keyboardKey} from './system/keyboard'
 export type {pointerKey} from './system/pointer'
 export {PointerEventsCheckLevel} from './options'


### PR DESCRIPTION
**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Replacing `export {userEvent as default} from './setup'` with syntax compatible with TypeScript 4.7+ and `moduleResolution` set to `Node16`

**Why**:
<!-- Why are these changes necessary? -->
TypeScript 4.7+ with `moduleResolution` set to `Node16` doesn't work with `export {x as default} from './y'` syntax

**How**:
<!-- How were these changes implemented? -->
Named import followed by default export

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
