### PR TITLE
Add named export for userEvent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {userEvent as default} from './setup'
+export {userEvent} from './setup'
 export type {keyboardKey} from './system/keyboard'
 export type {pointerKey} from './system/pointer'
 export {PointerEventsCheckLevel} from './options'


### PR DESCRIPTION
**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adding a new named export for `userEvent`

**Why**:
<!-- Why are these changes necessary? -->
Allows users who use TypeScript 4.7+ with `moduleResolution` set to `Node16` to avoid configuring `esModuleInterop` to import the default CJS export.

**How**:
<!-- How were these changes implemented? -->
By importing the named export instead of the default one

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
