### PR TITLE
keyMap: add ContextMenu key

### DIFF
--- a/src/keyboard/keyMap.ts
+++ b/src/keyboard/keyMap.ts
@@ -50,6 +50,7 @@ export const defaultKeyMap: keyboardKey[] = [
 
   {code: 'OSLeft', key: 'OS', location: DOM_KEY_LOCATION.LEFT},
   {code: 'OSRight', key: 'OS', location: DOM_KEY_LOCATION.RIGHT},
+  {code: 'ContextMenu', key: 'ContextMenu'},
 
   {code: 'Tab', key: 'Tab'},
   {code: 'CapsLock', key: 'CapsLock'},


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

add ContextMenu key to default keyboard layout 

**Why**:
The menu key is part of the standard 104 key layout.


**How**:
Researched to ensure the key was standard. Looked up key code on MDN.


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
