### PR TITLE
chore: fix snapshot testing

### DIFF
--- a/testenv/modules/inlineSnapshot.js
+++ b/testenv/modules/inlineSnapshot.js
@@ -7,7 +7,7 @@ export function toMatchInlineSnapshot(
     actual,
     expected,
 ) {
-    const normalizedActual = stripAddedLinebreaks(stripAddedIndentation(actual.snapshot ?? actual))
+    const normalizedActual = stripAddedLinebreaks(stripAddedIndentation(String(actual?.snapshot ?? actual)))
     const normalizedExpected = stripAddedLinebreaks(stripAddedIndentation(expected))
 
     return {

--- a/testenv/modules/inlineSnapshot.js
+++ b/testenv/modules/inlineSnapshot.js
@@ -13,16 +13,12 @@ export function toMatchInlineSnapshot(
     return {
         pass: normalizedActual === normalizedExpected,
         message: () => [
-            this.utils.matcherHint(
-                `${this.isNot ? '.not' : ''}.toMatchInlineSnapshot`,
-                'element',
-                '',
-            ),
+            this.utils.matcherHint('toMatchInlineSnapshot', undefined, undefined, {
+                isNot: this.isNot,
+                promise: this.promise,
+            }),
             '',
-            `Expected: ${this.isNot ? 'not ' : ''}${this.promise}`,
-            `  ${this.utils.printExpected(normalizedExpected)}`,
-            'Received:',
-            `  ${this.utils.printReceived(normalizedActual)}`,
+            this.utils.diff(normalizedExpected, normalizedActual, {expand: this.expand}),
         ].join('\n'),
     }
 }
@@ -45,16 +41,14 @@ export function toThrowErrorMatchingInlineSnapshot(
     return {
         pass: this.isNot === !didThrow && normalizedActual === normalizedExpected,
         message: () => [
-            this.utils.matcherHint(
-                `${this.isNot ? '.not' : ''}.toThrowErrorMatchingInlineSnapshot`,
-                'callback',
-                '',
-            ),
+            this.utils.matcherHint('toMatchInlineSnapshot', undefined, undefined, {
+                isNot: this.isNot,
+                promise: this.promise,
+            }),
             '',
-            `Expected: ${this.isNot ? 'not ' : ''}${this.promise}`,
-            `  ${this.utils.printExpected(normalizedExpected)}`,
-            'Received:',
-            `  ${didThrow ? this.utils.printReceived(normalizedActual) : '[Did not throw]'}`,
+            didThrow
+                ? this.utils.diff(normalizedExpected, normalizedActual, { expand: this.expand })
+                : '[Did not throw]',
         ].join('\n'),
     }
 }

--- a/testenv/node.js
+++ b/testenv/node.js
@@ -2,23 +2,11 @@ import './modules/expect.js'
 import './modules/mocks.js'
 import './modules/timers.js'
 import './modules/testinglibrary.js'
+import './modules/inlineSnapshot.js'
 import './modules/console.js'
 
 import 'css.escape'
-import jestSnapshot from 'jest-snapshot'
 import {JSDOM} from 'jsdom'
-
-expect.setState({
-    snapshotState: new jestSnapshot.SnapshotState('tests/__snapshot__/', {
-        updateSnapshot: 'none',
-    })
-})
-expect.extend({
-    toMatchInlineSnapshot: jestSnapshot.toMatchInlineSnapshot,
-    toMatchSnapshot: jestSnapshot.toMatchSnapshot,
-    toThrowErrorMatchingInlineSnapshot: jestSnapshot.toThrowErrorMatchingInlineSnapshot,
-    toThrowErrorMatchingSnapshot: jestSnapshot.toThrowErrorMatchingSnapshot,
-})
 
 const jsdom = new JSDOM()
 globalThis.navigator = jsdom.window.navigator

--- a/tests/clipboard/copy.ts
+++ b/tests/clipboard/copy.ts
@@ -84,8 +84,8 @@ describe('without Clipboard API', () => {
 
     await expect(
       userEvent.copy({writeToClipboard: true}),
-    ).rejects.toMatchInlineSnapshot(
-      `[Error: The Clipboard API is unavailable.]`,
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `The Clipboard API is unavailable.`,
     )
   })
 

--- a/tests/clipboard/cut.ts
+++ b/tests/clipboard/cut.ts
@@ -92,8 +92,8 @@ describe('without Clipboard API', () => {
 
     await expect(
       userEvent.cut({writeToClipboard: true}),
-    ).rejects.toMatchInlineSnapshot(
-      `[Error: The Clipboard API is unavailable.]`,
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `The Clipboard API is unavailable.`,
     )
   })
 

--- a/tests/clipboard/paste.ts
+++ b/tests/clipboard/paste.ts
@@ -143,8 +143,8 @@ describe('without Clipboard API', () => {
   test('reject if trying to use missing API', async () => {
     const {getEvents} = render(`<input/>`)
 
-    await expect(userEvent.paste()).rejects.toMatchInlineSnapshot(
-      `[Error: \`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.]`,
+    await expect(userEvent.paste()).rejects.toThrowErrorMatchingInlineSnapshot(
+      `\`userEvent.paste()\` without \`clipboardData\` requires the \`ClipboardAPI\` to be available.`,
     )
     expect(getEvents()).toHaveLength(0)
   })


### PR DESCRIPTION
**What**:

1. Print diff of failing inline snapshots.
2. Use own snapshot matchers in `node` environment.

**Why**:

1. Easier to read than full print of `expected` vs `received`.
2. `jest-snapshot` calls `context.dontThrow()` so that tests pass with failing snapshots. I couldn't find documentation how this is supposed to be configured correctly. So for now we don't use `jest-snapshot` in the toolbox tests.

**Checklist**:
- [x] Ready to be merged
