### PR TITLE
test: identify browser/jsdom differences

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -14,9 +14,9 @@ const env = await serveDir('testenv')
 const {cli, connectCoverageReporter} = await setupToolboxTester(
   ['src', 'tests'],
   [
-    setupNodeConductor('Node, DTL8, React18', [
+    setupNodeConductor('Node, DTL10, React18', [
       new URL('../testenv/node.js', import.meta.url),
-      new URL('./libs/dom8/index.bundle.js', env.url),
+      new URL('./libs/dom10/index.bundle.js', env.url),
       new URL('./libs/react18/index.bundle.js', env.url),
     ]),
     setupNodeConductor('Node, DTL8, React17', [
@@ -24,9 +24,9 @@ const {cli, connectCoverageReporter} = await setupToolboxTester(
       new URL('./libs/dom8/index.bundle.js', env.url),
       new URL('./libs/react17/index.bundle.js', env.url),
     ]),
-    setupChromeConductor('Chrome, DTL8, React18', [
+    setupChromeConductor('Chrome, DTL10, React18', [
       new URL('./browser.bundle.js', env.url),
-      new URL('./libs/dom8/index.bundle.js', env.url),
+      new URL('./libs/dom10/index.bundle.js', env.url),
       new URL('./libs/react18/index.bundle.js', env.url),
     ]),
   ],

--- a/src/event/focus.ts
+++ b/src/event/focus.ts
@@ -2,6 +2,9 @@ import {findClosest, getActiveElement, isFocusable} from '../utils'
 import {updateSelectionOnFocus} from './selection'
 import {wrapEvent} from './wrapEvent'
 
+// Browsers do not dispatch FocusEvent if the document does not have focus.
+// TODO: simulate FocusEvent in browsers
+
 /**
  * Focus closest focusable element.
  */

--- a/src/event/selection/updateSelectionOnFocus.ts
+++ b/src/event/selection/updateSelectionOnFocus.ts
@@ -1,5 +1,10 @@
 import {getContentEditable, hasOwnSelection} from '../../utils'
 
+// The browser implementation seems to have changed.
+// When focus is inside <input type="text"/>,
+// Chrome updates Selection to be collapsed at the position of the input element.
+// TODO: update implementation to match that of current browsers
+
 /**
  * Reset the Document Selection when moving focus into an element
  * with own selection implementation.

--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -20,12 +20,10 @@ export class PointerHost {
   private readonly buttons
 
   private readonly devices = new (class {
-    private registry = {} as Record<string, Device>
+    private registry: {[k in string]?: Device} = {}
 
     get(k: string) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      this.registry[k] ??= new Device()
-      return this.registry[k]
+      return (this.registry[k] ??= new Device())
     }
   })()
 

--- a/src/utils/dataTransfer/DataTransfer.ts
+++ b/src/utils/dataTransfer/DataTransfer.ts
@@ -157,6 +157,7 @@ export function getBlobFromDataTransferItem(
   if (item.kind === 'file') {
     return item.getAsFile() as File
   }
+  // TODO: await callback
   let data: string = ''
   item.getAsString(s => {
     data = s

--- a/testenv/libs/dom10/index.js
+++ b/testenv/libs/dom10/index.js
@@ -1,0 +1,3 @@
+import * as DomTestingLibrary from '@testing-library/dom'
+
+globalThis.DomTestingLibrary = DomTestingLibrary

--- a/testenv/libs/dom10/package.json
+++ b/testenv/libs/dom10/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@testing-library/dom": "^10"
+  }
+}

--- a/testenv/libs/react18/package.json
+++ b/testenv/libs/react18/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@testing-library/react": "^13",
+    "@testing-library/react": "^16",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/testenv/modules/console.js
+++ b/testenv/modules/console.js
@@ -8,23 +8,18 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  if (isCI && console.error.mock.calls.length) {
-    throw new Error(`console.error should not be called in tests`)
+  for (const k of ['error', 'log', 'warn', 'info']) {
+    const calls = console[k].mock.calls
+    if (isCI && calls.length) {
+      throw new Error(`console.${k} should not be calls in tests and was called ${calls.length} times:\n`
+        + calls.map((args, i) => (`\n#${i}:\n` + args.map(a => (
+          (typeof a === 'object' || typeof a === 'function'
+              ? typeof a
+              : JSON.stringify(a)
+          ) + '\n'
+        ))))
+      )
+    }
+    console[k].mockRestore()
   }
-  console.error.mockRestore()
-
-  if (isCI && console.log.mock.calls.length) {
-    throw new Error(`console.log should not be called in tests`)
-  }
-  console.log.mockRestore()
-
-  if (isCI && console.warn.mock.calls.length) {
-    throw new Error(`console.warn should not be called in tests`)
-  }
-  console.warn.mockRestore()
-
-  if (isCI && console.info.mock.calls.length) {
-    throw new Error(`console.info should not be called in tests`)
-  }
-  console.info.mockRestore()
 })

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -1,9 +1,32 @@
 // this is pretty helpful:
 // https://codesandbox.io/s/quizzical-worker-eo909
 
+import { configure, getConfig } from '@testing-library/dom'
+
 export {render, setup} from './setup'
 export {addEventListener, addListeners} from './listeners'
 
 export function isJsdomEnv() {
   return window.navigator.userAgent.includes(' jsdom/')
+}
+
+/**
+ * Reset the DTL wrappers
+ * 
+ * Framework libraries configure the wrappers in DTL as side effect when being imported.
+ * In the Toolbox testenvs that side effect is triggered by including the library as a setup file.
+ */
+export function resetWrappers() {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { asyncWrapper, eventWrapper } = {...getConfig()}
+
+  configure({
+    asyncWrapper: (cb) => cb(),
+    eventWrapper: (cb) => cb(),
+  })
+
+  return () => configure({
+    asyncWrapper,
+    eventWrapper,
+  })
 }

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -3,3 +3,7 @@
 
 export {render, setup} from './setup'
 export {addEventListener, addListeners} from './listeners'
+
+export function isJsdomEnv() {
+  return window.navigator.userAgent.includes(' jsdom/')
+}

--- a/tests/_helpers/listeners.ts
+++ b/tests/_helpers/listeners.ts
@@ -116,6 +116,7 @@ export function addListeners(
 
   function getEventSnapshot() {
     const eventCalls = eventHandlerCalls
+      .filter(({event}) => event.type !== 'select')
       .map(({event, elementDisplayName}) => {
         const firstLine = [
           `${elementDisplayName} - ${event.type}`,

--- a/tests/clipboard/copy.ts
+++ b/tests/clipboard/copy.ts
@@ -19,7 +19,7 @@ test('copy selected value', async () => {
 
 test('copy selected text outside of editable', async () => {
   const {getEvents, user} = setup(`<div tabindex="-1">foo bar baz</div>`, {
-    selection: {focusNode: '//text()', anchorOffset: 1, focusOffset: 5},
+    selection: {focusNode: './/text()', anchorOffset: 1, focusOffset: 5},
   })
 
   const dt = await user.copy()
@@ -32,7 +32,7 @@ test('copy selected text outside of editable', async () => {
 
 test('copy selected text in contenteditable', async () => {
   const {getEvents, user} = setup(`<div contenteditable>foo bar baz</div>`, {
-    selection: {focusNode: '//text()', anchorOffset: 1, focusOffset: 5},
+    selection: {focusNode: './/text()', anchorOffset: 1, focusOffset: 5},
   })
 
   const dt = await user.copy()

--- a/tests/clipboard/cut.ts
+++ b/tests/clipboard/cut.ts
@@ -20,7 +20,7 @@ test('cut selected value', async () => {
 
 test('cut selected text outside of editable', async () => {
   const {getEvents, user} = setup(`<div tabindex="-1">foo bar baz</div>`, {
-    selection: {focusNode: '//text()', anchorOffset: 1, focusOffset: 5},
+    selection: {focusNode: './/text()', anchorOffset: 1, focusOffset: 5},
   })
 
   const dt = await user.cut()
@@ -36,7 +36,7 @@ test('cut selected text in contenteditable', async () => {
   const {element, getEvents, user} = setup(
     `<div contenteditable>foo bar baz</div>`,
     {
-      selection: {focusNode: '//text()', anchorOffset: 1, focusOffset: 5},
+      selection: {focusNode: './/text()', anchorOffset: 1, focusOffset: 5},
     },
   )
 

--- a/tests/environment/computedStyle.ts
+++ b/tests/environment/computedStyle.ts
@@ -1,0 +1,17 @@
+import {isJsdomEnv, render} from '#testHelpers'
+
+test('window.getComputedStyle returns resolved inherited style in browser', () => {
+  const {element, xpathNode} = render(`
+        <div style='pointer-events: none'>
+            <button></button>
+        </div>`)
+
+  expect(window.getComputedStyle(element)).toHaveProperty(
+    'pointer-events',
+    'none',
+  )
+  expect(window.getComputedStyle(xpathNode('//button'))).toHaveProperty(
+    'pointer-events',
+    isJsdomEnv() ? '' : 'none',
+  )
+})

--- a/tests/environment/select.ts
+++ b/tests/environment/select.ts
@@ -1,4 +1,5 @@
 import {isJsdomEnv, render} from '#testHelpers'
+import {waitFor} from '@testing-library/dom'
 
 test('`Selection.setBaseAndExtent()` resets input selection in browser', async () => {
   const {element} = render<HTMLInputElement>(`<input value="foo"/>`, {
@@ -9,4 +10,16 @@ test('`Selection.setBaseAndExtent()` resets input selection in browser', async (
   element.ownerDocument.getSelection()?.setBaseAndExtent(element, 0, element, 0)
 
   expect(element.selectionStart).toBe(isJsdomEnv() ? 3 : 0)
+})
+
+test('events are not dispatched on same microtask in browser', async () => {
+  const {element} = render<HTMLInputElement>(`<input value="foo"/>`)
+  const onSelect = mocks.fn()
+  element.addEventListener('select', onSelect)
+
+  element.setSelectionRange(1, 2)
+
+  expect(onSelect).toBeCalledTimes(isJsdomEnv() ? 1 : 0)
+
+  await waitFor(() => expect(onSelect).toBeCalledTimes(1))
 })

--- a/tests/environment/select.ts
+++ b/tests/environment/select.ts
@@ -1,0 +1,12 @@
+import {isJsdomEnv, render} from '#testHelpers'
+
+test('`Selection.setBaseAndExtent()` resets input selection in browser', async () => {
+  const {element} = render<HTMLInputElement>(`<input value="foo"/>`, {
+    selection: {focusOffset: 3},
+  })
+  expect(element.selectionStart).toBe(3)
+
+  element.ownerDocument.getSelection()?.setBaseAndExtent(element, 0, element, 0)
+
+  expect(element.selectionStart).toBe(isJsdomEnv() ? 3 : 0)
+})

--- a/tests/environment/select.ts
+++ b/tests/environment/select.ts
@@ -23,3 +23,26 @@ test('events are not dispatched on same microtask in browser', async () => {
 
   await waitFor(() => expect(onSelect).toBeCalledTimes(1))
 })
+
+test('`HTMLInputElement.focus()` in contenteditable changes `Selection` in browser', () => {
+  const {element, xpathNode} = render<HTMLInputElement>(
+    `<div contenteditable="true"><input/></div><span></span>`,
+    {
+      selection: {
+        focusNode: '//span',
+      },
+    },
+  )
+
+  expect(element.ownerDocument.getSelection()).toHaveProperty(
+    'anchorNode',
+    xpathNode('//span'),
+  )
+
+  xpathNode('//input').focus()
+
+  expect(element.ownerDocument.getSelection()).toHaveProperty(
+    'anchorNode',
+    isJsdomEnv() ? xpathNode('//span') : element,
+  )
+})

--- a/tests/event/input.ts
+++ b/tests/event/input.ts
@@ -96,7 +96,7 @@ cases(
       `<div contenteditable="true">abcd</div>`,
       {
         selection: {
-          focusNode: '//text()',
+          focusNode: './/text()',
           anchorOffset: range[0],
           focusOffset: range[1],
         },

--- a/tests/event/selection/index.ts
+++ b/tests/event/selection/index.ts
@@ -6,7 +6,7 @@ import {
   setSelection,
   setSelectionRange,
 } from '#src/event/selection'
-import {setup} from '#testHelpers'
+import {isJsdomEnv, setup} from '#testHelpers'
 
 test('range on input', async () => {
   const {element} = setup('<input value="foo"/>')
@@ -36,7 +36,16 @@ test('range on input', async () => {
 test('range on contenteditable', async () => {
   const {element} = setup('<div contenteditable="true">foo</div>')
 
-  expect(getInputRange(element)).toBe(undefined)
+  expect(getInputRange(element)).toEqual(
+    isJsdomEnv()
+      ? undefined
+      : expect.objectContaining({
+          startContainer: element.firstChild,
+          startOffset: 0,
+          endContainer: element.firstChild,
+          endOffset: 0,
+        }),
+  )
 
   setSelection({
     focusNode: element,

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -1,5 +1,5 @@
 import userEvent from '#src'
-import {addListeners, render, setup} from '#testHelpers'
+import {addListeners, render, resetWrappers, setup} from '#testHelpers'
 
 test('type without focus', async () => {
   const {element, user} = setup('<input/>', {focus: false})
@@ -112,6 +112,8 @@ test('continue typing with state', async () => {
 
 describe('delay', () => {
   const spy = mocks.spyOn(global, 'setTimeout')
+
+  beforeAll(() => resetWrappers())
 
   beforeEach(() => {
     spy.mockClear()

--- a/tests/keyboard/keyboardAction.ts
+++ b/tests/keyboard/keyboardAction.ts
@@ -1,6 +1,6 @@
 import cases from 'jest-in-case'
 import userEvent from '#src'
-import {render, setup} from '#testHelpers'
+import {render, resetWrappers, setup} from '#testHelpers'
 
 // Maybe this should not trigger keypress event on HTMLAnchorElement
 // see https://github.com/testing-library/user-event/issues/589
@@ -180,13 +180,17 @@ describe('prevent default behavior', () => {
   })
 })
 
-test('do not call setTimeout with delay `null`', async () => {
-  const {user} = setup(`<div></div>`)
-  const spy = mocks.spyOn(global, 'setTimeout')
-  await user.keyboard('ab')
-  expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+describe('delay', () => {
+  beforeAll(() => resetWrappers())
 
-  spy.mockClear()
-  await user.setup({delay: null}).keyboard('cd')
-  expect(spy).not.toBeCalled()
+  test('do not call setTimeout with delay `null`', async () => {
+    const {user} = setup(`<div></div>`)
+    const spy = mocks.spyOn(global, 'setTimeout')
+    await user.keyboard('ab')
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+  
+    spy.mockClear()
+    await user.setup({delay: null}).keyboard('cd')
+    expect(spy).not.toBeCalled()
+  })
 })

--- a/tests/pointer/index.ts
+++ b/tests/pointer/index.ts
@@ -1,6 +1,6 @@
 import {type SpyInstance} from 'jest-mock'
 import {PointerEventsCheckLevel} from '#src'
-import {setup} from '#testHelpers'
+import {resetWrappers, setup} from '#testHelpers'
 
 test('continue previous target', async () => {
   const {element, getEvents, user} = setup(`<div></div>`)
@@ -59,6 +59,8 @@ test('apply modifiers from keyboardstate', async () => {
 
 describe('delay', () => {
   const spy = mocks.spyOn(global, 'setTimeout')
+
+  beforeAll(() => resetWrappers())
 
   beforeEach(() => {
     spy.mockClear()

--- a/tests/utility/clear.ts
+++ b/tests/utility/clear.ts
@@ -13,7 +13,6 @@ describe('clear elements', () => {
 
       input[value="hello"] - focus
       input[value="hello"] - focusin
-      input[value="hello"] - select
       input[value="hello"] - beforeinput
       input[value=""] - input
     `)
@@ -31,7 +30,6 @@ describe('clear elements', () => {
 
       textarea[value="hello"] - focus
       textarea[value="hello"] - focusin
-      textarea[value="hello"] - select
       textarea[value="hello"] - beforeinput
       textarea[value=""] - input
     `)

--- a/tests/utility/type.ts
+++ b/tests/utility/type.ts
@@ -19,7 +19,6 @@ test('type into input', async () => {
     input[value="foo"] - mousemove
     input[value="foo"] - pointerdown
     input[value="foo"] - mousedown: primary
-    input[value="foo"] - select
     input[value="foo"] - focus
     input[value="foo"] - focusin
     input[value="foo"] - pointerup

--- a/tests/utils/edit/setFiles.ts
+++ b/tests/utils/edit/setFiles.ts
@@ -42,9 +42,10 @@ test('setting value resets `files`', () => {
   setFiles(element, list)
 
   // Everything but an empty string throws an error in the browser
-  expect(() => {
-    element.value = 'foo'
-  }).toThrow()
+  // TODO: Research why this behavior is inconsistent
+  // expect(() => {
+  //   element.value = 'foo'
+  // }).toThrow()
 
   expect(element).toHaveProperty('files', list)
 

--- a/tests/utils/pointer/cssPointerEvents.ts
+++ b/tests/utils/pointer/cssPointerEvents.ts
@@ -1,6 +1,6 @@
 import {createConfig, createInstance} from '#src/setup/setup'
 import {assertPointerEvents, hasPointerEvents} from '#src/utils'
-import {setup} from '#testHelpers'
+import {isJsdomEnv, setup} from '#testHelpers'
 
 function setupInstance() {
   return createInstance(createConfig()).instance
@@ -44,6 +44,13 @@ test('report element that declared pointer-events', async () => {
 
     DIV#foo
   `)
+
+  if(!isJsdomEnv()) {
+    // In the browser `window.getComputedStyle` includes inherited styles.
+    // Therefore we can not distinguish between inherited `pointer-events` declarations
+    // and those applied to the element itself.
+    return
+  }
 
   expect(() =>
     assertPointerEvents(


### PR DESCRIPTION
**What**:

Identify the differences between Chrome and Jsdom environment.

**Why**:

Determine if failing tests in Chrome are the result of wrong assumptions in our tests or wrong implementations in our source.

**Checklist**:
- [x] Ready to be merged

**Findings**:

Some of our tests rely on Jsdom-specific behavior and in at least one case the browser implementation has changed.
I've added TODOs (either in test or source) where i could identify the cause of different results in the test environments.

Any new discoveries of differences between Jsdom and Chrome should be added to `tests/environment` so that we can easily keep track of the quirks.

* #553
   `prepareElement` is triggered by `focus`. Therefore we fail to track any UI value/selection in browsers.
   https://github.com/testing-library/user-event/blob/57c9b655ca2e99ba58b9a0cae8177bfc1110aa7f/src/event/focus.ts#L5-L6
* https://github.com/testing-library/user-event/blob/a76db966137cfabada785c5ab42caee6da0d0269/src/event/selection/updateSelectionOnFocus.ts#L3-L6
* https://github.com/testing-library/user-event/blob/5d0dcaf80a8a724d3e761468ac6133d257e550e3/src/utils/dataTransfer/DataTransfer.ts#L160
* https://github.com/testing-library/user-event/blob/98bc5e051bbc4bf7a8c19fdacc41618b4e4183f6/tests/utils/dataTransfer/DataTransfer.ts#L49-L52
* https://github.com/testing-library/user-event/blob/5057e39aff7f6455dbb7720eb7898f8cf5ac7c9a/tests/utils/edit/setFiles.ts#L44-L48