### PR TITLE
New option: `autoFocusDocumentBeforeTyping` to reduce real browser testing flakiness 

### DIFF
--- a/src/keyboard/index.ts
+++ b/src/keyboard/index.ts
@@ -1,6 +1,7 @@
+import {fireEvent} from '@testing-library/dom'
 import type {Instance} from '../setup'
 import type {keyboardKey} from '../system/keyboard'
-import {wait} from '../utils'
+import {getActiveElementOrBody, wait} from '../utils'
 import {parseKeyDef} from './parseKeyDef'
 
 interface KeyboardAction {
@@ -11,6 +12,9 @@ interface KeyboardAction {
 }
 
 export async function keyboard(this: Instance, text: string): Promise<void> {
+  if (this.config.autoFocusDocumentBeforeTyping) {
+    fireEvent.focus(getActiveElementOrBody(this.config.document))
+  }
   const actions: KeyboardAction[] = parseKeyDef(this.config.keyboardMap, text)
 
   for (let i = 0; i < actions.length; i++) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,10 +36,10 @@ export interface Options {
   autoModify?: boolean
 
   /**
-   * Automatically focus the active document before interacting with the keyboard
+   * Automatically focus the active document before interacting with the keyboard.
    *
-   * Recommended to enable whenever the test is running against a real web-browser
-   * and a real user interaction may interfere the test.
+   * Recommended to enable it whenever the test is running against a real web browser and
+   * a real user interaction may interfere with the test.
    *
    * @default false
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -36,6 +36,16 @@ export interface Options {
   autoModify?: boolean
 
   /**
+   * Automatically focus the active document before interacting with the keyboard
+   *
+   * Recommended to enable whenever the test is running against a real web-browser
+   * and a real user interaction may interfere the test.
+   *
+   * @default false
+   */
+  autoFocusDocumentBeforeTyping?: boolean
+
+  /**
    * Between some subsequent inputs like typing a series of characters
    * the code execution is delayed per `setTimeout` for (at least) `delay` seconds.
    * This moves the next changes at least to next macro task

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -21,6 +21,7 @@ import {DirectOptions} from './directApi'
 const defaultOptionsDirect: Required<Options> = {
   applyAccept: true,
   autoModify: true,
+  autoFocusDocumentBeforeTyping: false,
   delay: 0,
   document: globalThis.document,
   keyboardMap: defaultKeyboardMap,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Adding a new optional option, `autoFocusDocumentBeforeTyping`, to fix tests running against a real browser (e.g: [jasmine-browser-runner](https://github.com/jasmine/jasmine-browser-runner)) that may be interfered with a real user interacting with their system.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

My company's front-end integration tests can be run against a headless or a real browser context.

We noticed that during a real browser test, users can interfere negatively with the test result, simply by focusing the Chrome dev tools or on another software while and before the test is running. When the `.keyboard` interaction is being called, the element won't receive the key events.

<!-- Why are these changes necessary? -->

**How**:
Send an event to refocus the currently active element or `config.document` before sending `keyboard` events.

<!-- How were these changes implemented? -->

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Documentation
- [ ] Tests: I didn't find a testing strategy that could replicate the issue
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

** Additional comments **

A similar issue was experienced by https://github.com/testing-library/user-event/issues/553, but I couldn't replicate locally the issue against `.focus()`

## Example 

The test is using `.type` against an input.

1. Run with the page being focused
2. Click on the Chrome Devtools
3. F5, to re-run the test, the test is now failing

![Kapture 2023-01-05 at 13 07 46](https://user-images.githubusercontent.com/1910927/210850460-70c7ed74-c3ca-4a4f-95d3-b38392062d80.gif)

<!-- feel free to add additional comments -->
