### PR TITLE
Add failing test when reading uploaded file with FormData

### DIFF
--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -1,4 +1,5 @@
-import {setup} from '#testHelpers'
+import {render, setup} from '#testHelpers'
+import userEvent from '#src'
 
 test('change file input', async () => {
   const file = new File(['hello'], 'hello.png', {type: 'image/png'})
@@ -224,4 +225,26 @@ test('throw error if trying to use upload on an invalid element', async () => {
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `The associated INPUT element does not accept file uploads`,
   )
+})
+
+test('uploaded file can be read with FormData', async () => {
+  const file = new File(['hello'], 'hello.png', {type: 'image/png'})
+  const {element: form} = render<HTMLFormElement>(
+    '<form><input name="file" type="file" /></form>',
+  )
+
+  const input = form.querySelector('input') as HTMLInputElement
+
+  await userEvent.upload(input, file)
+
+  const data = new FormData(form)
+
+  const formFile = data.get('file')
+  if (!(formFile instanceof File)) {
+    throw new Error('formFile is not a File')
+  }
+
+  expect(formFile).toBeInstanceOf(File)
+  expect(formFile.name).toBe('hello.png')
+  expect(formFile).toBe(input.files?.[0])
 })


### PR DESCRIPTION


**What**:
Just adding a failing test for a bug I found. It seems to be impossible to read a file added to a form with `userEvent.upload()` using `FormData`. See the test.

I was trying the test React Zorm file capabilities with this but got stuck due to this bug

See https://github.com/esamattis/react-zorm/pull/37

**Why**:

I think this should work.

**How**:

It's not.


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
