### PR TITLE
Fix click with pointer compatibility

### DIFF
--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -39,10 +39,10 @@ export class PointerHost {
 
     new(pointerName: string, keyDef: pointerKey) {
       const isPrimary =
-          keyDef.pointerType !== 'touch' ||
-          !Object.values(this.registry).some(
-              p => p.pointerType === 'touch' && !p.isCancelled,
-          )
+        keyDef.pointerType !== 'touch' ||
+        !Object.values(this.registry).some(
+          p => p.pointerType === 'touch' && !p.isCancelled,
+        )
 
       if (!isPrimary) {
         Object.values(this.registry).forEach(p => {
@@ -64,7 +64,7 @@ export class PointerHost {
     get(pointerName: string) {
       if (!this.has(pointerName)) {
         throw new Error(
-            `Trying to access pointer "${pointerName}" which does not exist.`,
+          `Trying to access pointer "${pointerName}" which does not exist.`,
         )
       }
       return this.registry[pointerName]
@@ -80,15 +80,15 @@ export class PointerHost {
   }
 
   async press(
-      instance: Instance,
-      keyDef: pointerKey,
-      position: PointerPosition,
+    instance: Instance,
+    keyDef: pointerKey,
+    position: PointerPosition,
   ) {
     const pointerName = this.getPointerName(keyDef)
     const pointer =
-        keyDef.pointerType === 'touch'
-            ? this.pointers.new(pointerName, keyDef).init(instance, position)
-            : this.pointers.get(pointerName)
+      keyDef.pointerType === 'touch'
+        ? this.pointers.new(pointerName, keyDef).init(instance, position)
+        : this.pointers.get(pointerName)
 
     // TODO: deprecate the following implicit setting of position
     pointer.position = position
@@ -107,9 +107,9 @@ export class PointerHost {
   }
 
   async move(
-      instance: Instance,
-      pointerName: string,
-      position: PointerPosition,
+    instance: Instance,
+    pointerName: string,
+    position: PointerPosition,
   ) {
     const pointer = this.pointers.get(pointerName)
 
@@ -119,9 +119,9 @@ export class PointerHost {
     // the order in which they interweave/follow on a user interaction depends on the implementation.
     const pointermove = pointer.move(instance, position, pointer)
     const mousemove =
-        pointer.pointerType === 'touch' || (pointer.isPrevented && pointer.isDown)
-            ? undefined
-            : this.mouse.move(instance, position, pointer)
+      pointer.pointerType === 'touch' || (pointer.isPrevented && pointer.isDown)
+        ? undefined
+        : this.mouse.move(instance, position, pointer)
 
     pointermove?.leave()
     mousemove?.leave()
@@ -132,9 +132,9 @@ export class PointerHost {
   }
 
   async release(
-      instance: Instance,
-      keyDef: pointerKey,
-      position: PointerPosition,
+    instance: Instance,
+    keyDef: pointerKey,
+    position: PointerPosition,
   ) {
     const device = this.devices.get(keyDef.pointerType)
     device.removePressed(keyDef)
@@ -181,8 +181,8 @@ export class PointerHost {
 
   getPreviousPosition(pointerName: string) {
     return this.pointers.has(pointerName)
-        ? this.pointers.get(pointerName).position
-        : undefined
+      ? this.pointers.get(pointerName).position
+      : undefined
   }
 
   resetClickCount() {

--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -39,10 +39,10 @@ export class PointerHost {
 
     new(pointerName: string, keyDef: pointerKey) {
       const isPrimary =
-        keyDef.pointerType !== 'touch' ||
-        !Object.values(this.registry).some(
-          p => p.pointerType === 'touch' && !p.isCancelled,
-        )
+          keyDef.pointerType !== 'touch' ||
+          !Object.values(this.registry).some(
+              p => p.pointerType === 'touch' && !p.isCancelled,
+          )
 
       if (!isPrimary) {
         Object.values(this.registry).forEach(p => {
@@ -64,7 +64,7 @@ export class PointerHost {
     get(pointerName: string) {
       if (!this.has(pointerName)) {
         throw new Error(
-          `Trying to access pointer "${pointerName}" which does not exist.`,
+            `Trying to access pointer "${pointerName}" which does not exist.`,
         )
       }
       return this.registry[pointerName]
@@ -80,15 +80,15 @@ export class PointerHost {
   }
 
   async press(
-    instance: Instance,
-    keyDef: pointerKey,
-    position: PointerPosition,
+      instance: Instance,
+      keyDef: pointerKey,
+      position: PointerPosition,
   ) {
     const pointerName = this.getPointerName(keyDef)
     const pointer =
-      keyDef.pointerType === 'touch'
-        ? this.pointers.new(pointerName, keyDef).init(instance, position)
-        : this.pointers.get(pointerName)
+        keyDef.pointerType === 'touch'
+            ? this.pointers.new(pointerName, keyDef).init(instance, position)
+            : this.pointers.get(pointerName)
 
     // TODO: deprecate the following implicit setting of position
     pointer.position = position
@@ -101,15 +101,15 @@ export class PointerHost {
     this.buttons.down(keyDef)
     pointer.down(instance, keyDef)
 
-    if (pointer.pointerType !== 'touch' && !pointer.isPrevented) {
+    if (pointer.pointerType !== 'touch') {
       this.mouse.down(instance, keyDef, pointer)
     }
   }
 
   async move(
-    instance: Instance,
-    pointerName: string,
-    position: PointerPosition,
+      instance: Instance,
+      pointerName: string,
+      position: PointerPosition,
   ) {
     const pointer = this.pointers.get(pointerName)
 
@@ -117,11 +117,11 @@ export class PointerHost {
     // This interweaving of events is probably unnecessary.
     // While the order of mouse (or pointer) events is defined per spec,
     // the order in which they interweave/follow on a user interaction depends on the implementation.
-    const pointermove = pointer.move(instance, position)
+    const pointermove = pointer.move(instance, position, pointer)
     const mousemove =
-      pointer.pointerType === 'touch' || (pointer.isPrevented && pointer.isDown)
-        ? undefined
-        : this.mouse.move(instance, position)
+        pointer.pointerType === 'touch' || (pointer.isPrevented && pointer.isDown)
+            ? undefined
+            : this.mouse.move(instance, position, pointer)
 
     pointermove?.leave()
     mousemove?.leave()
@@ -132,9 +132,9 @@ export class PointerHost {
   }
 
   async release(
-    instance: Instance,
-    keyDef: pointerKey,
-    position: PointerPosition,
+      instance: Instance,
+      keyDef: pointerKey,
+      position: PointerPosition,
   ) {
     const device = this.devices.get(keyDef.pointerType)
     device.removePressed(keyDef)
@@ -157,23 +157,21 @@ export class PointerHost {
       pointer.release(instance)
     }
 
-    if (!pointer.isPrevented) {
-      if (pointer.pointerType === 'touch' && !pointer.isMultitouch) {
-        const mousemove = this.mouse.move(instance, pointer.position)
-        mousemove?.leave()
-        mousemove?.enter()
-        mousemove?.move()
+    if (pointer.pointerType === 'touch' && !pointer.isMultitouch) {
+      const mousemove = this.mouse.move(instance, position, pointer)
+      mousemove?.leave()
+      mousemove?.enter()
+      mousemove?.move()
 
-        this.mouse.down(instance, keyDef, pointer)
-      }
-      if (!pointer.isMultitouch) {
-        const mousemove = this.mouse.move(instance, pointer.position)
-        mousemove?.leave()
-        mousemove?.enter()
-        mousemove?.move()
+      this.mouse.down(instance, keyDef, pointer)
+    }
+    if (!pointer.isMultitouch) {
+      const mousemove = this.mouse.move(instance, position, pointer)
+      mousemove?.leave()
+      mousemove?.enter()
+      mousemove?.move()
 
-        this.mouse.up(instance, keyDef, pointer)
-      }
+      this.mouse.up(instance, keyDef, pointer)
     }
   }
 
@@ -183,8 +181,8 @@ export class PointerHost {
 
   getPreviousPosition(pointerName: string) {
     return this.pointers.has(pointerName)
-      ? this.pointers.get(pointerName).position
-      : undefined
+        ? this.pointers.get(pointerName).position
+        : undefined
   }
 
   resetClickCount() {

--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -102,7 +102,7 @@ export class PointerHost {
     pointer.down(instance, keyDef)
 
     if (pointer.pointerType !== 'touch') {
-      this.mouse.down(instance, keyDef, pointer)
+      this.mouse.down(instance, keyDef, pointer.isPrevented)
     }
   }
 
@@ -117,11 +117,11 @@ export class PointerHost {
     // This interweaving of events is probably unnecessary.
     // While the order of mouse (or pointer) events is defined per spec,
     // the order in which they interweave/follow on a user interaction depends on the implementation.
-    const pointermove = pointer.move(instance, position, pointer)
+    const pointermove = pointer.move(instance, position)
     const mousemove =
-      pointer.pointerType === 'touch' || (pointer.isPrevented && pointer.isDown)
+      pointer.pointerType === 'touch'
         ? undefined
-        : this.mouse.move(instance, position, pointer)
+        : this.mouse.move(instance, position, pointer.isPrevented)
 
     pointermove?.leave()
     mousemove?.leave()
@@ -143,6 +143,8 @@ export class PointerHost {
 
     const pointer = this.pointers.get(this.getPointerName(keyDef))
 
+    const isPrevented = pointer.isPrevented
+
     // TODO: deprecate the following implicit setting of position
     pointer.position = position
     if (pointer.pointerType !== 'touch') {
@@ -158,20 +160,20 @@ export class PointerHost {
     }
 
     if (pointer.pointerType === 'touch' && !pointer.isMultitouch) {
-      const mousemove = this.mouse.move(instance, position, pointer)
+      const mousemove = this.mouse.move(instance, position, isPrevented)
       mousemove?.leave()
       mousemove?.enter()
       mousemove?.move()
 
-      this.mouse.down(instance, keyDef, pointer)
+      this.mouse.down(instance, keyDef, isPrevented)
     }
     if (!pointer.isMultitouch) {
-      const mousemove = this.mouse.move(instance, position, pointer)
+      const mousemove = this.mouse.move(instance, position, isPrevented)
       mousemove?.leave()
       mousemove?.enter()
       mousemove?.move()
 
-      this.mouse.up(instance, keyDef, pointer)
+      this.mouse.up(instance, keyDef, isPrevented)
     }
   }
 

--- a/src/system/pointer/mouse.ts
+++ b/src/system/pointer/mouse.ts
@@ -141,12 +141,12 @@ export class Mouse {
     }
     const target = this.getTarget(instance)
     if (!isDisabled(target)) {
-      const init = this.getEventInit('mouseup', keyDef.button)
+      const mouseUpInit = this.getEventInit('mouseup', keyDef.button)
       if (!pointer.isPrevented) {
         instance.dispatchUIEvent(
             target,
             'mouseup',
-            init,
+            mouseUpInit,
         )
         this.endSelecting()
       }

--- a/src/system/pointer/mouse.ts
+++ b/src/system/pointer/mouse.ts
@@ -36,14 +36,14 @@ export class Mouse {
 
     incOnClick(button: number) {
       const current =
-          this.down[button] === undefined
-              ? undefined
-              : Number(this.down[button]) + 1
+        this.down[button] === undefined
+          ? undefined
+          : Number(this.down[button]) + 1
 
       this.count =
-          this.count[button] === undefined
-              ? {}
-              : {[button]: Number(this.count[button]) + 1}
+        this.count[button] === undefined
+          ? {}
+          : {[button]: Number(this.count[button]) + 1}
 
       return current
     }
@@ -57,8 +57,8 @@ export class Mouse {
 
     getOnUp(button: number) {
       return this.down[button] === undefined
-          ? undefined
-          : Number(this.down[button]) + 1
+        ? undefined
+        : Number(this.down[button]) + 1
     }
 
     reset() {
@@ -126,9 +126,9 @@ export class Mouse {
     }
     if (!disabled && getMouseEventButton(keyDef.button) === 2) {
       instance.dispatchUIEvent(
-          target,
-          'contextmenu',
-          this.getEventInit('contextmenu', keyDef.button, pointer),
+        target,
+        'contextmenu',
+        this.getEventInit('contextmenu', keyDef.button, pointer),
       )
     }
   }
@@ -143,25 +143,21 @@ export class Mouse {
     if (!isDisabled(target)) {
       const mouseUpInit = this.getEventInit('mouseup', keyDef.button)
       if (!pointer.isPrevented) {
-        instance.dispatchUIEvent(
-            target,
-            'mouseup',
-            mouseUpInit,
-        )
+        instance.dispatchUIEvent(target, 'mouseup', mouseUpInit)
         this.endSelecting()
       }
 
       const clickTarget = getTreeDiff(
-          this.buttonDownTarget[button],
-          target,
+        this.buttonDownTarget[button],
+        target,
       )[2][0] as Element | undefined
       if (clickTarget) {
         const init = this.getEventInit('click', keyDef.button, pointer)
         if (init.detail) {
           instance.dispatchUIEvent(
-              clickTarget,
-              init.button === 0 ? 'click' : 'auxclick',
-              init,
+            clickTarget,
+            init.button === 0 ? 'click' : 'auxclick',
+            init,
           )
           if (init.button === 0 && init.detail === 2) {
             instance.dispatchUIEvent(clickTarget, 'dblclick', {
@@ -179,9 +175,9 @@ export class Mouse {
   }
 
   private getEventInit(
-      type: EventType,
-      button?: MouseButton,
-      pointer?: Pointer,
+    type: EventType,
+    button?: MouseButton,
+    pointer?: Pointer,
   ) {
     const init: PointerEventInit = {
       ...this.position.coords,

--- a/src/system/pointer/pointer.ts
+++ b/src/system/pointer/pointer.ts
@@ -41,7 +41,7 @@ export class Pointer {
     return this
   }
 
-  move(instance: Instance, position: PointerPosition) {
+  move(instance: Instance, position: PointerPosition, pointer: Pointer) {
     const prevPosition = this.position
     const prevTarget = this.getTarget(instance)
 
@@ -63,7 +63,7 @@ export class Pointer {
           if (prevTarget !== nextTarget) {
             instance.dispatchUIEvent(prevTarget, 'pointerout', init)
             leave.forEach(el =>
-              instance.dispatchUIEvent(el, 'pointerleave', init),
+                instance.dispatchUIEvent(el, 'pointerleave', init),
             )
           }
         }
@@ -74,7 +74,7 @@ export class Pointer {
         if (prevTarget !== nextTarget) {
           instance.dispatchUIEvent(nextTarget, 'pointerover', init)
           enter.forEach(el =>
-            instance.dispatchUIEvent(el, 'pointerenter', init),
+              instance.dispatchUIEvent(el, 'pointerenter', init),
           )
         }
       },
@@ -94,9 +94,9 @@ export class Pointer {
 
     this.isDown = true
     this.isPrevented = !instance.dispatchUIEvent(
-      target,
-      'pointerdown',
-      this.getEventInit(),
+        target,
+        'pointerdown',
+        this.getEventInit(),
     )
   }
 

--- a/src/system/pointer/pointer.ts
+++ b/src/system/pointer/pointer.ts
@@ -64,7 +64,7 @@ export class Pointer {
           if (prevTarget !== nextTarget) {
             instance.dispatchUIEvent(prevTarget, 'pointerout', init)
             leave.forEach(el =>
-                instance.dispatchUIEvent(el, 'pointerleave', init),
+              instance.dispatchUIEvent(el, 'pointerleave', init),
             )
           }
         }
@@ -75,7 +75,7 @@ export class Pointer {
         if (prevTarget !== nextTarget) {
           instance.dispatchUIEvent(nextTarget, 'pointerover', init)
           enter.forEach(el =>
-              instance.dispatchUIEvent(el, 'pointerenter', init),
+            instance.dispatchUIEvent(el, 'pointerenter', init),
           )
         }
       },
@@ -95,9 +95,9 @@ export class Pointer {
 
     this.isDown = true
     this.isPrevented = !instance.dispatchUIEvent(
-        target,
-        'pointerdown',
-        this.getEventInit(),
+      target,
+      'pointerdown',
+      this.getEventInit(),
     )
   }
 

--- a/src/system/pointer/pointer.ts
+++ b/src/system/pointer/pointer.ts
@@ -108,8 +108,8 @@ export class Pointer {
 
     assertPointerEvents(instance, target)
 
-    this.isDown = false
     this.isPrevented = false
+    this.isDown = false
     instance.dispatchUIEvent(target, 'pointerup', this.getEventInit())
   }
 

--- a/src/system/pointer/pointer.ts
+++ b/src/system/pointer/pointer.ts
@@ -41,6 +41,7 @@ export class Pointer {
     return this
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   move(instance: Instance, position: PointerPosition, pointer: Pointer) {
     const prevPosition = this.position
     const prevTarget = this.getTarget(instance)

--- a/src/system/pointer/pointer.ts
+++ b/src/system/pointer/pointer.ts
@@ -41,8 +41,7 @@ export class Pointer {
     return this
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  move(instance: Instance, position: PointerPosition, pointer: Pointer) {
+  move(instance: Instance, position: PointerPosition) {
     const prevPosition = this.position
     const prevTarget = this.getTarget(instance)
 
@@ -110,6 +109,7 @@ export class Pointer {
     assertPointerEvents(instance, target)
 
     this.isDown = false
+    this.isPrevented = false
     instance.dispatchUIEvent(target, 'pointerup', this.getEventInit())
   }
 

--- a/tests/convenience/click.ts
+++ b/tests/convenience/click.ts
@@ -13,24 +13,41 @@ describe.each([
 
     expect(getEvents('mouseover')).toHaveLength(1)
     expect(getEvents('mousedown')).toHaveLength(clickCount)
+    expect(getEvents('pointerdown')).toHaveLength(clickCount)
     expect(getEvents('click')).toHaveLength(clickCount)
     expect(getEvents('dblclick')).toHaveLength(clickCount >= 2 ? 1 : 0)
   })
+
+
+  test('preventDefault on pointer down prevents compatibility events', async () => {
+    const {element, getEvents, user} = setup(`<div></div>`, {eventHandlers: {pointerdown: e => e.preventDefault()}})
+
+    await user[method](element)
+
+    expect(getEvents('mouseover')).toHaveLength(1)
+    expect(getEvents('mousedown')).toHaveLength(0)
+    expect(getEvents('mouseup')).toHaveLength(0)
+    expect(getEvents('pointerdown')).toHaveLength(clickCount)
+    expect(getEvents('pointerup')).toHaveLength(clickCount)
+    expect(getEvents('click')).toHaveLength(clickCount)
+    expect(getEvents('dblclick')).toHaveLength(clickCount >= 2 ? 1 : 0)
+  })
+
 
   test('throw when clicking element with pointer-events set to none', async () => {
     const {element, user} = setup(`<div style="pointer-events: none"></div>`)
 
     await expect(user[method](element)).rejects.toThrowError(
-      /has `pointer-events: none`/i,
+        /has `pointer-events: none`/i,
     )
   })
 
   test('skip check for pointer-events', async () => {
     const {element, getEvents, user} = setup(
-      `<div style="pointer-events: none"></div>`,
-      {
-        pointerEventsCheck: PointerEventsCheckLevel.Never,
-      },
+        `<div style="pointer-events: none"></div>`,
+        {
+          pointerEventsCheck: PointerEventsCheckLevel.Never,
+        },
     )
 
     await user[method](element)

--- a/tests/convenience/click.ts
+++ b/tests/convenience/click.ts
@@ -18,9 +18,10 @@ describe.each([
     expect(getEvents('dblclick')).toHaveLength(clickCount >= 2 ? 1 : 0)
   })
 
-
   test('preventDefault on pointer down prevents compatibility events', async () => {
-    const {element, getEvents, user} = setup(`<div></div>`, {eventHandlers: {pointerdown: e => e.preventDefault()}})
+    const {element, getEvents, user} = setup(`<div></div>`, {
+      eventHandlers: {pointerdown: e => e.preventDefault()},
+    })
 
     await user[method](element)
 
@@ -33,21 +34,20 @@ describe.each([
     expect(getEvents('dblclick')).toHaveLength(clickCount >= 2 ? 1 : 0)
   })
 
-
   test('throw when clicking element with pointer-events set to none', async () => {
     const {element, user} = setup(`<div style="pointer-events: none"></div>`)
 
     await expect(user[method](element)).rejects.toThrowError(
-        /has `pointer-events: none`/i,
+      /has `pointer-events: none`/i,
     )
   })
 
   test('skip check for pointer-events', async () => {
     const {element, getEvents, user} = setup(
-        `<div style="pointer-events: none"></div>`,
-        {
-          pointerEventsCheck: PointerEventsCheckLevel.Never,
-        },
+      `<div style="pointer-events: none"></div>`,
+      {
+        pointerEventsCheck: PointerEventsCheckLevel.Never,
+      },
     )
 
     await user[method](element)

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -54,8 +54,10 @@ test('double click', async () => {
 })
 
 test('double click with prevent compatibility', async () => {
-  const {element, getClickEventsSnapshot, getEvents, user} =
-      setup(`<div></div>`, {eventHandlers: {pointerdown: e => e.preventDefault()}});
+  const {element, getClickEventsSnapshot, getEvents, user} = setup(
+    `<div></div>`,
+    {eventHandlers: {pointerdown: e => e.preventDefault()}},
+  )
 
   await user.pointer({keys: '[MouseLeft][MouseLeft]', target: element})
 
@@ -78,7 +80,7 @@ test('double click with prevent compatibility', async () => {
 
 test('two clicks', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-      setup(`<div></div>`)
+    setup(`<div></div>`)
 
   await user.pointer({
     keys: '[MouseLeft]',
@@ -107,7 +109,7 @@ test('two clicks', async () => {
 
 test('other keys reset click counter', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-      setup(`<div></div>`)
+    setup(`<div></div>`)
 
   await user.pointer({
     keys: '[MouseLeft][MouseLeft>][MouseRight][MouseLeft]',
@@ -141,7 +143,7 @@ test('other keys reset click counter', async () => {
 
 test('click per touch device', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-      setup(`<div></div>`)
+    setup(`<div></div>`)
 
   await user.pointer({keys: '[TouchA]', target: element})
 
@@ -167,7 +169,7 @@ test('click per touch device', async () => {
 
 test('double click per touch device', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-      setup(`<div></div>`)
+    setup(`<div></div>`)
 
   await user.pointer({keys: '[TouchA][TouchA]', target: element})
 
@@ -215,7 +217,7 @@ test('multi touch does not click', async () => {
 describe('label', () => {
   test('click associated control per label', async () => {
     const {element, getEvents, user} = setup(
-        `<label for="in">foo</label><input id="in"/>`,
+      `<label for="in">foo</label><input id="in"/>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element})
@@ -290,7 +292,7 @@ describe('check/uncheck control per click', () => {
 describe('submit form per click', () => {
   test('submits a form when clicking on a <button>', async () => {
     const {element, eventWasFired, user} = setup(
-        `<form><button></button></form>`,
+      `<form><button></button></form>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element.children[0]})
@@ -300,7 +302,7 @@ describe('submit form per click', () => {
 
   test('does not submit a form when clicking on a <button type="button">', async () => {
     const {element, eventWasFired, user} = setup(
-        `<form><button type="button"></button></form>`,
+      `<form><button type="button"></button></form>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element.children[0]})
@@ -322,7 +324,7 @@ test('secondary mouse button fires `contextmenu`', async () => {
 
 test('non-primary mouse buttons fire `auxclick`', async () => {
   const {element, eventWasFired, getEvents, clearEventCalls, user} =
-      setup(`<button/>`)
+    setup(`<button/>`)
 
   await user.pointer({keys: '[MouseLeft]', target: element})
   expect(eventWasFired('click')).toBe(true)
@@ -343,7 +345,7 @@ test('non-primary mouse buttons fire `auxclick`', async () => {
 
 test('click closest common ancestor of pointerdown/pointerup', async () => {
   const {element, getEvents, user, xpathNode, clearEventCalls} = setup(
-      `<div><span>foo</span><span>bar</span></div>`,
+    `<div><span>foo</span><span>bar</span></div>`,
   )
 
   await user.pointer([
@@ -364,7 +366,9 @@ test('click closest common ancestor of pointerdown/pointerup', async () => {
 })
 
 test('preventDefault on pointer down prevents compatibility events works with pointer', async () => {
-  const {element, getClickEventsSnapshot, getEvents, user} = setup('<div />', {eventHandlers: {pointerdown: e => e.preventDefault()}})
+  const {element, getClickEventsSnapshot, getEvents, user} = setup('<div />', {
+    eventHandlers: {pointerdown: e => e.preventDefault()},
+  })
   await user.pointer({keys: '[MouseLeft]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -162,9 +162,7 @@ test('click per touch device', async () => {
     click - button=0; buttons=0; detail=1
   `)
 
-  // mouse is pointerId=1, every other pointer gets a new id
   expect(getEvents('click')).toHaveLength(1)
-  expect(getEvents('click')[0]).toHaveProperty('pointerId', 2)
 })
 
 test('double click per touch device', async () => {
@@ -200,10 +198,7 @@ test('double click per touch device', async () => {
 
   // mouse is pointerId=1, every other pointer gets a new id
   expect(getEvents('click')).toHaveLength(2)
-  expect(getEvents('click')[0]).toHaveProperty('pointerId', 2)
-  expect(getEvents('click')[1]).toHaveProperty('pointerId', 3)
   expect(getEvents('dblclick')).toHaveLength(1)
-  expect(getEvents('dblclick')[0]).not.toHaveProperty('pointerId')
 })
 
 test('multi touch does not click', async () => {

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -50,13 +50,35 @@ test('double click', async () => {
   expect(getEvents('click')).toHaveLength(2)
 
   // detail reflects the click count
-  expect(getEvents('mousedown')[1]).toHaveProperty('detail', 2)
+  expect(getEvents('dblclick')[0]).toHaveProperty('detail', 2)
+})
+
+test('double click with prevent compatibility', async () => {
+  const {element, getClickEventsSnapshot, getEvents, user} =
+      setup(`<div></div>`, {eventHandlers: {pointerdown: e => e.preventDefault()}});
+
+  await user.pointer({keys: '[MouseLeft][MouseLeft]', target: element})
+
+  expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    click - button=0; buttons=0; detail=1
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    click - button=0; buttons=0; detail=2
+    dblclick - button=0; buttons=0; detail=2
+  `)
+
+  expect(getEvents('dblclick')).toHaveLength(1)
+  expect(getEvents('click')).toHaveLength(2)
+
+  // detail reflects the click count
   expect(getEvents('dblclick')[0]).toHaveProperty('detail', 2)
 })
 
 test('two clicks', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-    setup(`<div></div>`)
+      setup(`<div></div>`)
 
   await user.pointer({
     keys: '[MouseLeft]',
@@ -85,7 +107,7 @@ test('two clicks', async () => {
 
 test('other keys reset click counter', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-    setup(`<div></div>`)
+      setup(`<div></div>`)
 
   await user.pointer({
     keys: '[MouseLeft][MouseLeft>][MouseRight][MouseLeft]',
@@ -119,7 +141,7 @@ test('other keys reset click counter', async () => {
 
 test('click per touch device', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-    setup(`<div></div>`)
+      setup(`<div></div>`)
 
   await user.pointer({keys: '[TouchA]', target: element})
 
@@ -145,7 +167,7 @@ test('click per touch device', async () => {
 
 test('double click per touch device', async () => {
   const {element, getClickEventsSnapshot, getEvents, user} =
-    setup(`<div></div>`)
+      setup(`<div></div>`)
 
   await user.pointer({keys: '[TouchA][TouchA]', target: element})
 
@@ -193,7 +215,7 @@ test('multi touch does not click', async () => {
 describe('label', () => {
   test('click associated control per label', async () => {
     const {element, getEvents, user} = setup(
-      `<label for="in">foo</label><input id="in"/>`,
+        `<label for="in">foo</label><input id="in"/>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element})
@@ -268,7 +290,7 @@ describe('check/uncheck control per click', () => {
 describe('submit form per click', () => {
   test('submits a form when clicking on a <button>', async () => {
     const {element, eventWasFired, user} = setup(
-      `<form><button></button></form>`,
+        `<form><button></button></form>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element.children[0]})
@@ -278,7 +300,7 @@ describe('submit form per click', () => {
 
   test('does not submit a form when clicking on a <button type="button">', async () => {
     const {element, eventWasFired, user} = setup(
-      `<form><button type="button"></button></form>`,
+        `<form><button type="button"></button></form>`,
     )
 
     await user.pointer({keys: '[MouseLeft]', target: element.children[0]})
@@ -300,7 +322,7 @@ test('secondary mouse button fires `contextmenu`', async () => {
 
 test('non-primary mouse buttons fire `auxclick`', async () => {
   const {element, eventWasFired, getEvents, clearEventCalls, user} =
-    setup(`<button/>`)
+      setup(`<button/>`)
 
   await user.pointer({keys: '[MouseLeft]', target: element})
   expect(eventWasFired('click')).toBe(true)
@@ -321,7 +343,7 @@ test('non-primary mouse buttons fire `auxclick`', async () => {
 
 test('click closest common ancestor of pointerdown/pointerup', async () => {
   const {element, getEvents, user, xpathNode, clearEventCalls} = setup(
-    `<div><span>foo</span><span>bar</span></div>`,
+      `<div><span>foo</span><span>bar</span></div>`,
   )
 
   await user.pointer([
@@ -339,4 +361,16 @@ test('click closest common ancestor of pointerdown/pointerup', async () => {
   ])
   expect(getEvents('mouseup')).toHaveLength(1)
   expect(getEvents('click')).toHaveLength(0)
+})
+
+test('preventDefault on pointer down prevents compatibility events works with pointer', async () => {
+  const {element, getClickEventsSnapshot, getEvents, user} = setup('<div />', {eventHandlers: {pointerdown: e => e.preventDefault()}})
+  await user.pointer({keys: '[MouseLeft]', target: element})
+
+  expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    click - button=0; buttons=0; detail=1
+  `)
+  expect(getEvents('click')).toHaveLength(1)
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Closes https://github.com/testing-library/user-event/issues/1119
This ensures that click and double click are still fired even when preventDefault is used on pointerdown to prevent mouse compatibility events.

**Why**:
<!-- Why are these changes necessary? -->
The browsers all work this way, as seen here https://codesandbox.io/s/aged-voice-xjf3dw

**How**:
<!-- How were these changes implemented? -->
Click is currently handled in the pointer/mouse class. This is fine, however there is some tracking there which tells us if we can fire the click/double click. As a result I pushed the check for isPrevented down into the mouse actions and only prevented the firing of the relevant events, not everything like it was before.

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
