### PR TITLE
fix: prevent click event on non-focusable control

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
 <!-- prettier-ignore-start -->
-[egghead]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[egghead]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [issues]: https://github.com/testing-library/user-event/issues
 <!-- prettier-ignore-end -->

--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -9,8 +9,8 @@ behavior.click = (event, target, instance) => {
     return () => {
       if (isFocusable(control)) {
         focusElement(control)
+        instance.dispatchEvent(control, cloneEvent(event))
       }
-      instance.dispatchEvent(control, cloneEvent(event))
     }
   } else if (isElementType(target, 'input', {type: 'file'})) {
     return () => {

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -216,6 +216,24 @@ describe('label', () => {
 
     expect(getEvents('click')).toHaveLength(2)
   })
+
+  test('do not click associated non-focusable control per label', async () => {
+    const {element, getEvents, user} = setup(
+      `<label for="in">foo</label><input disabled id="in"/>`,
+    )
+
+    await user.pointer({keys: '[MouseLeft]', target: element})
+
+    expect(getEvents('click')).toHaveLength(1)
+  })
+
+  test('do not click nested non-focusable control per label', async () => {
+    const {element, getEvents, user} = setup(`<label><input disabled/></label>`)
+
+    await user.pointer({keys: '[MouseLeft]', target: element})
+
+    expect(getEvents('click')).toHaveLength(1)
+  })
 })
 
 describe('check/uncheck control per click', () => {
@@ -258,6 +276,19 @@ describe('check/uncheck control per click', () => {
     await user.pointer({keys: '[MouseLeft]', target: label})
 
     expect(input).toBeChecked()
+
+    await user.pointer({keys: '[MouseLeft]', target: label})
+
+    expect(input).not.toBeChecked()
+  })
+
+  test('clicking label does not change non-focusable checkable input', async () => {
+    const {
+      elements: [input, label],
+      user,
+    } = setup(`<input type="checkbox" disabled id="a"/><label for="a"></label>`)
+
+    expect(input).not.toBeChecked()
 
     await user.pointer({keys: '[MouseLeft]', target: label})
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Resolves #1057. This change stops click events from being forwarded to non-focusable inputs from labels.

**Why**:
<!-- Why are these changes necessary? -->
Currently, click events are being forwarded to inputs from labels. This is expected behavior unless the input is disabled or hidden or otherwise not focusable. This behavior break tests that rely on clicking labels of disabled inputs.

**How**:
<!-- How were these changes implemented? -->
The function call forwarding the click was moved inside the conditional checking if the control was focusable.

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Also, updating the "How to Contribute" egghead tutorial link in CONTRIBUTING.md.

Based on @nknapp's [suggestion](https://github.com/testing-library/user-event/issues/1057#issuecomment-1505985844).