### PR TITLE
fix: error trying to do in on a null value in is ui function call

### DIFF
--- a/src/document/UI.ts
+++ b/src/document/UI.ts
@@ -19,9 +19,9 @@ export type UIValueString = String & {[UIValue]: true}
 export type UISelectionStart = Number & {[UISelection]: true}
 
 export function isUIValue(
-  value: string | UIValueString,
+  value: string | UIValueString | null,
 ): value is UIValueString {
-  return typeof value === 'object' && UIValue in value
+  return typeof value === 'object' && value !== null && UIValue in value
 }
 
 export function isUISelectionStart(


### PR DESCRIPTION
I am having a hard time narrowing down exactly when this is occurring, but overall the error is easy to address so haven't come up with exact reproduction. If required I can spend more time doing so.

Overall issue seems to be that sometimes the value of an input is set to null which is causing the isUIValue check to be called from the interceptorImpl function. With null being passed in an error is thrown which causes vitest to exit non zero.

My stack is vitest/quasar/happy-dom so maybe an issue somewhere else if it is felt that this function should not take in null as a type.