### PR TITLE
Trim accept tokens as in spec.

### DIFF
--- a/src/utility/upload.ts
+++ b/src/utility/upload.ts
@@ -61,13 +61,18 @@ function isAcceptableFile(file: File, accept: string) {
 
   const wildcards = ['audio/*', 'image/*', 'video/*']
 
-  return accept.split(',').some(acceptToken => {
-    if (acceptToken.startsWith('.')) {
-      // tokens starting with a dot represent a file extension
-      return file.name.endsWith(acceptToken)
-    } else if (wildcards.includes(acceptToken)) {
-      return file.type.startsWith(acceptToken.substr(0, acceptToken.length - 1))
-    }
-    return file.type === acceptToken
-  })
+  return accept
+    .split(',')
+    .map(acceptToken => acceptToken.trim())
+    .some(acceptToken => {
+      if (acceptToken.startsWith('.')) {
+        // tokens starting with a dot represent a file extension
+        return file.name.endsWith(acceptToken)
+      } else if (wildcards.includes(acceptToken)) {
+        return file.type.startsWith(
+          acceptToken.substr(0, acceptToken.length - 1),
+        )
+      }
+      return file.type === acceptToken
+    })
 }

--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -155,6 +155,7 @@ test.each([
   [true, '.png', 1],
   [true, 'text/csv', 1],
   [true, '', 4],
+  [true, '.png, .jpg', 3],
   [false, 'video/*', 4],
 ])(
   'filter according to accept attribute applyAccept=%s, acceptAttribute=%s',


### PR DESCRIPTION
**What**:
Trim whitespace around tokens from the `input` element `accept` attribute.

**Why**:
The spec says `accept` is a [set of comma-separated tokens](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens), and to obtain the list of tokens from the attribute, the user agent must [split the attribute value on commas](https://infra.spec.whatwg.org/#split-on-commas). The [algorithm for splitting](https://infra.spec.whatwg.org/#split-on-commas) says to "[Strip leading and trailing ASCII whitespace](https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace) from token." as step 2.

**How**:
Call `String.trim` on each token.

**Checklist**:

- [na] Documentation
- [x] Tests
- [x] Ready to be merged
