### PR TITLE
add 'summary' element to list of focusable selectors

### DIFF
--- a/src/utils/focus/selector.ts
+++ b/src/utils/focus/selector.ts
@@ -7,4 +7,5 @@ export const FOCUSABLE_SELECTOR = [
   '[contenteditable="true"]',
   'a[href]',
   '[tabindex]:not([disabled])',
+  'summary',
 ].join(', ')

--- a/src/utils/focus/selector.ts
+++ b/src/utils/focus/selector.ts
@@ -7,5 +7,5 @@ export const FOCUSABLE_SELECTOR = [
   '[contenteditable="true"]',
   'a[href]',
   '[tabindex]:not([disabled])',
-  'summary',
+  'details > summary',
 ].join(', ')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

add `summary` element to list of _focusable_ selectors

**Why**:

<!-- Why are these changes necessary? -->

in all major browsers, the [`summary`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) element is focusable via keyboard (when it's a direct descendent of a `details` element)

making this change will allow `user.tab()` (via [`getTabDestination()`](https://github.com/testing-library/user-event/blob/main/src/utils/focus/getTabDestination.ts)) to focus `summary` elements; which matches the behavior found in all major browsers.

- in chrome, firefox, and safari: `document.activeElement` results in the `<summary>` element
- in devtools, the summary element is consistently labeled as focusable
  - in chrome, the element is given a more abstract role called "DisclosureTriangle", but is always marked as focusable ("Details" is not)
    <img width="197" alt="screenshot of chrome devtools — Details, DisclosureTriangle, focusable: true, expanded: false" src="https://github.com/testing-library/user-event/assets/2516349/275ded97-1ce5-4cd3-afac-f4735fdf2d99">
    <img width="226" alt="screenshot of chrome devtools — role: DisclosureTriangle, focusable: true, expanded: false" src="https://github.com/testing-library/user-event/assets/2516349/10db8114-5add-4577-af8d-66fe975e67f1">
  - in firefox, the same is true
    <img width="350" alt="screenshot of firefox devtools — role: summary, DOMNode: summary, states: [collpased, focusable, selectable text, …]" src="https://github.com/testing-library/user-event/assets/2516349/00b11281-2079-48b6-b41f-15a9be2b0a08">
  - unfortunately, safari doesn't provide a way to inspect its accessibility tree, but it matches the behavior of other vendors via `document.activeElement`

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

#### what about https://github.com/testing-library/user-event/pull/947 and what about `details` being marked as "interactive content" per the spec, but summary technically is _not_?

i understand there's some nuance to `<details>` without a `<summary>` and that `details` is the one that marked as "interactive content", but what reflects reality is that...

- all major browsers treat the `summary` element as _interactive_ (see above); and _never_ the `details` element itself
- MDN reports an implicit role of "button" for `<summary>`, where as `<details>` has an implicit role of "group" (this more or less matches what's seen in devtools)
- even if there's more nuance _in addition_ to a focusable `summary` element (such as `details` without a descendent `summary`), this doesn't change the most common case where `details > summary` _is_ focusable
