### PR TITLE
respect elements that are hidden by <details>

### DIFF
--- a/src/utils/misc/isVisible.ts
+++ b/src/utils/misc/isVisible.ts
@@ -1,18 +1,37 @@
 import {getWindow} from './getWindow'
 
+function isAttributeVisible(element: Element, previousElement: Element | null) {
+  let detailsVisibility
+
+  if (previousElement) {
+    detailsVisibility =
+      element.nodeName === 'DETAILS' && previousElement.nodeName !== 'SUMMARY'
+        ? element.hasAttribute('open')
+        : true
+  } else {
+    detailsVisibility =
+      element.nodeName === 'DETAILS' ? element.hasAttribute('open') : true
+  }
+
+  return detailsVisibility
+}
+
 export function isVisible(element: Element): boolean {
   const window = getWindow(element)
 
   for (
-    let el: Element | null = element;
+    let el: Element | null = element, prev: Element | null = null;
     el?.ownerDocument;
-    el = el.parentElement
+    prev = el, el = el.parentElement
   ) {
     const {display, visibility} = window.getComputedStyle(el)
     if (display === 'none') {
       return false
     }
-    if (visibility === 'hidden') {
+    if (visibility === 'hidden' || visibility === 'collapse') {
+      return false
+    }
+    if (!isAttributeVisible(el, prev)) {
       return false
     }
   }

--- a/tests/utils/focus/getTabDestination.ts
+++ b/tests/utils/focus/getTabDestination.ts
@@ -76,6 +76,9 @@ test('exclude hidden elements', () => {
         <input hidden />
         <input style="visibility: hidden"/>
         <input style="display: none"/>
+        <details>
+          <button></button>
+        </details>
     `)
 
   assertTabOrder([elA])

--- a/tests/utils/misc/isVisible.ts
+++ b/tests/utils/misc/isVisible.ts
@@ -12,6 +12,15 @@ test('check if element is visible', async () => {
     <input data-testid="styledDisplayedInput" hidden style="display: block"/>
     <div style="display: none"><input data-testid="childInput" /></div>
     <input data-testid="styledVisibiliyHiddenInput" style="visibility: hidden">
+    <details>
+      <input data-testid="collapsedInput">
+    </details>
+    <details open>
+      <input data-testid="expandedInput">
+    </details>
+    <details>
+      <summary data-testid="summary"></summary>
+    </details>
   `)
 
   expect(isVisible(screen.getByTestId('visibleInput'))).toBe(true)
@@ -22,4 +31,7 @@ test('check if element is visible', async () => {
   expect(isVisible(screen.getByTestId('styledVisibiliyHiddenInput'))).toBe(
     false,
   )
+  expect(isVisible(screen.getByTestId('collapsedInput'))).toBe(false)
+  expect(isVisible(screen.getByTestId('expandedInput'))).toBe(true)
+  expect(isVisible(screen.getByTestId('summary'))).toBe(true)
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

stop considering elements hidden by a collapsed `<details>` element to be _visible_ or focusable, via `getTabDestination()`.

for example, `user.tab()` should not focus elements _hidden_ by a collapsed `details` ancestor.

**Why**:

<!-- Why are these changes necessary? -->

same reasons for [how `.toBeVisible` works in jest-dom](https://github.com/testing-library/jest-dom#tobevisible)

> An element is visible if all the following conditions are met:
> - […]
> - if `<details />` it has the `open` attribute

given the following code:

```html
<details>
  <button id="hidden"></button>
</details>
<details open>
  <button id="visible"></button>
</details>
```

`button#hidden` should not be considered _visible_, nor should it be focusable, but `button#visible` should.

> **Note**
> the single exception for this is a `summary` element that is a direct descendant of a `details` element. the `summary` element acts as an [always visible] trigger for controlling the expanded state of the `details` element.

**How**:

<!-- How were these changes implemented? -->

at least for conveniences sake, i copied [the same logic from jest-dom for determining if an element should be considered _visible_ when walking the element tree](https://github.com/testing-library/jest-dom/blob/af1845383ee2cba007f43460104f73409e7618ac/src/to-be-visible.js#L16-L30) (with one exception: looking for the `hidden` attribute — this caused an issue that i think might be a bug in that library)

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
