### PR TITLE
Verify window exists before resetting clipboard stub

### DIFF
--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -216,10 +216,18 @@ const g = globalThis as {
 }
 /* istanbul ignore else */
 if (typeof g.afterEach === 'function') {
-  g.afterEach(() => resetClipboardStubOnView(globalThis.window))
+  g.afterEach(() => {
+    if (typeof globalThis.window !== 'undefined') {
+      resetClipboardStubOnView(globalThis.window)
+    }
+  })
 }
 
 /* istanbul ignore else */
 if (typeof g.afterAll === 'function') {
-  g.afterAll(() => detachClipboardStubFromView(globalThis.window))
+  g.afterAll(() => {
+    if (typeof globalThis.window !== 'undefined') {
+      resetClipboardStubOnView(globalThis.window)
+    }
+  })
 }

--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -227,7 +227,7 @@ if (typeof g.afterEach === 'function') {
 if (typeof g.afterAll === 'function') {
   g.afterAll(() => {
     if (typeof globalThis.window !== 'undefined') {
-      resetClipboardStubOnView(globalThis.window)
+      detachClipboardStubFromView(globalThis.window)
     }
   })
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Ensure that `globalThis.window` exists before resetting/detaching the clipboard stub in the `afterEach`/`afterAll` hooks.

**Why**:

<!-- Why are these changes necessary? -->

Using this library in a test suite does not imply that every test in the suite will run in a browser-like environment. I have a test suite that initializes `jsdom` to test client-side code, but then tears it down after the tests. I wanted to use this library, but I couldn't because as soon as a test ran that didn't initialize `jsdom`, this `afterEach` hook would run and throw an error because `globalThis.window` was undefined.

**How**:

<!-- How were these changes implemented? -->

Verify that `globalThis.window` exists inside of the hook. I didn't want to put the check inside of `resetClipboardStubOnView` because this file is meant to be run in a browser-like environment, so it seemed most appropriate to put the check inside the hook.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

There were no existing tests related to the `afterEach`/`afterAll` hooks, and I wasn't sure how to go about writing a test for those, so this code does not have any unit tests around it.