### PR TITLE
Clipboard - Check for window existence in `afterAll` functions

### DIFF
--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -148,7 +148,7 @@ export function attachClipboardStubToView(window: Window & typeof globalThis) {
 }
 
 export function resetClipboardStubOnView(window: Window & typeof globalThis) {
-  if (isClipboardStub(window.navigator.clipboard)) {
+  if (isClipboardStub(window?.navigator.clipboard)) {
     window.navigator.clipboard[ClipboardStubControl].resetClipboardStub()
   }
 }
@@ -156,7 +156,7 @@ export function resetClipboardStubOnView(window: Window & typeof globalThis) {
 export function detachClipboardStubFromView(
   window: Window & typeof globalThis,
 ) {
-  if (isClipboardStub(window.navigator.clipboard)) {
+  if (isClipboardStub(window?.navigator.clipboard)) {
     window.navigator.clipboard[ClipboardStubControl].detachClipboardStub()
   }
 }


### PR DESCRIPTION
**What**:
Added a verification that window exists in functions `resetClipboardStubOnView` and `detachClipboardStubFromView` which are called on `afterAll`.

**Why**:
When testing in SSR environment, window does (and should) not exist, therefore my tests fail.

**How**:
Just added a conditional chaining.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I believe these functions should not be called in `afterAll` at all unless the user is actively using clipboard functionality.
Thanks 💛 