### PR TITLE
fix/feat: dispatch clipboard events without active selection

### DIFF
--- a/src/clipboard/copy.ts
+++ b/src/clipboard/copy.ts
@@ -1,23 +1,27 @@
 import {copySelection} from '../document'
 import {type Instance} from '../setup'
-import {writeDataTransferToClipboard} from '../utils'
+import {
+  createDataTransfer,
+  getWindow,
+  writeDataTransferToClipboard,
+} from '../utils'
 
 export async function copy(this: Instance) {
   const doc = this.config.document
   const target = doc.activeElement ?? /* istanbul ignore next */ doc.body
 
-  const clipboardData = copySelection(target)
-
-  if (clipboardData.items.length === 0) {
-    return
+  const clipboardData = createDataTransfer(getWindow(target))
+  const shouldDoDefault = this.dispatchUIEvent(target, 'copy', {
+    clipboardData,
+  })
+  if (shouldDoDefault) {
+    const defaultClipboardData = copySelection(target)
+    defaultClipboardData.types.forEach(type => {
+      clipboardData.setData(type, defaultClipboardData.getData(type))
+    })
   }
 
-  if (
-    this.dispatchUIEvent(target, 'copy', {
-      clipboardData,
-    }) &&
-    this.config.writeToClipboard
-  ) {
+  if (clipboardData.items.length > 0 && this.config.writeToClipboard) {
     await writeDataTransferToClipboard(doc, clipboardData)
   }
 


### PR DESCRIPTION
**What**:

Make the `copy()`and `cut()` functions more compatible with actual browser behaviour by always dispatching the respective events with an empty `clipboardData` event member and only adding the default behaviour *iff* the event was not `preventDefault()`ed.

**Why**:

At $WORK we are implementing custom copy and paste handlers on elements that are neither editable in the classic sense (e.g. not an `<input>` element) nor require classic selection (marking *text* with the cursor).
These handlers convert a rich datastructure to different MIME types and add the data to the event's `clipboardData`. When pasting in our web application, we can read a custom MIME type and restore the rich data structure. When pasting externally to an application that only understands text, a reduced text version is pasted.
This works perfectly in browsers!

Without this PR, `user.copy()` does not dispatch a copy event, because it only dispatches the event if there is text selected. This is not in conformance with browser behavior and also not in conformance with the [Clipboard API and events spec](https://w3c.github.io/clipboard-apis/#copy-action).

**How**:

This pull request changes the implementation of `copy()` and `paste()` functions according to the Clipboard API and events spec.
Specifically, the following changes were made:
* **always** dispatch a `copy`/`cut` event, regardless of selection state. 
* the event's initial `clipboardData` property is **empty** and can be filled by event listeners
* the default behaviour (of adding the current selection text) is only executed **after** bubbling has finished and the default behavior was not prevents by any listeners
* the clipboard data is written to the clipboard regardless of whether the default behavior was prevented or not (event handlers can add their own content to the event, then call `e.preventDefault()` and only their content is written to the clipboard).

**Checklist**:

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged



**Additional Notes**:
Unfortunately, this breaks existing behaviour :-/
I doubt users rely on this, because it does not match the browser's behavior and relying that the event is not dispatched if nothing is selected or that it has the current selection content already set would break the event handlers in a real environment. Still I want to mention that this is not really backwards compatible.
