### PR TITLE
Fix dead link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
 <!-- prettier-ignore-start -->
-[egghead]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[egghead]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [issues]: https://github.com/testing-library/user-event/issues
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
**What**:

Updated link to KCD's PR course on Egghead.io.

**Why**:

Existing link leads to 404 page.

**Checklist**:

- [x] Ready to be merged

I'm wondering if it should be `http://kcd.im/pull-request` instead of the direct link.

Also, the same bad link appears on the `testing-library/jest-dom` contributing page, too:

https://github.com/testing-library/jest-dom/blob/main/CONTRIBUTING.md

I can submit a similar PR for that repo if necessary.