### PR TITLE
Fix radio events

### DIFF
--- a/src/event/behavior/keydown.ts
+++ b/src/event/behavior/keydown.ts
@@ -28,7 +28,7 @@ const keydownBehavior: {
   ArrowDown: (event, target, instance) => {
     /* istanbul ignore else */
     if (isElementType(target, 'input', {type: 'radio'} as const)) {
-      return () => walkRadio(instance, target, -1)
+      return () => walkRadio(instance, target, 1)
     }
   },
   ArrowLeft: (event, target, instance) => {
@@ -46,7 +46,7 @@ const keydownBehavior: {
   ArrowUp: (event, target, instance) => {
     /* istanbul ignore else */
     if (isElementType(target, 'input', {type: 'radio'} as const)) {
-      return () => walkRadio(instance, target, 1)
+      return () => walkRadio(instance, target, -1)
     }
   },
   Backspace: (event, target, instance) => {

--- a/src/event/radio.ts
+++ b/src/event/radio.ts
@@ -28,5 +28,6 @@ export function walkRadio(
 
     focusElement(group[i])
     instance.dispatchUIEvent(group[i], 'click')
+    return
   }
 }

--- a/tests/event/behavior/keydown.ts
+++ b/tests/event/behavior/keydown.ts
@@ -317,7 +317,9 @@ cases(
       <input type="radio" name="" value="nameless2"/>
       <input type="radio" name="group" value="c" disabled/>
       <input type="radio" name="group" value="d"/>
-      <input type="radio" name="foo"/>
+      <input type="radio" name="group" value="f" aria-disabled />
+      <input type="radio" name="group" value="e" />
+        <input type="radio" name="foo"/>
       <input type="text" name="group"/>
     `,
       {focus},
@@ -360,14 +362,14 @@ cases(
       expectedTarget: '//input[@value="a"]',
     },
     'forward around the corner': {
-      focus: '//input[@value="d"]',
+      focus: '//input[@value="e"]',
       key: 'ArrowRight',
       expectedTarget: '//input[@value="a"]',
     },
     'backward around the corner': {
       focus: '//input[@value="a"]',
       key: 'ArrowUp',
-      expectedTarget: '//input[@value="d"]',
+      expectedTarget: '//input[@value="e"]',
     },
     'do nothing on single radio': {
       focus: '//input[@name="solo"]',
@@ -378,5 +380,10 @@ cases(
       key: 'ArrowRight',
       expectedTarget: '//input[@value="nameless2"]',
     },
+    'on radios with aria-disabled': {
+        focus: '//input[@value="d"]',
+        key: 'ArrowDown',
+        expectedTarget: '//input[@value="f"]',
+      },
   },
 )


### PR DESCRIPTION
**What**:
There is currently an issue with the behavior of radio inputs and the user-event library. Because the `walkRadio` method does not break out of the loop when iterating through options, it can sometimes skip over the correct option.

There's also an issue where the direction that the arrow up and arrow down keys were swapped. Arrow down should increment and arrow up should decrement.

Fixes issue: https://github.com/testing-library/user-event/issues/1198

**Why**:

There was an issue with the robustness of the tests where going through the radio options, only A and D were possible. So the tests were just flipping between the only two available radio options. Adding an additional radio input breaks the tests. 

**How**:

I've updated the tests to include an additional radio input to ensure that behavior is correct. I've also added an additional tests to ensure that radio inputs behave correctly for aria-disabled as they should still be focusable. This matches the browser behavior.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation 
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
