### PR TITLE
Remove label-click-implies-input-click as this behavior is handled by DOM libs

### DIFF
--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -1,8 +1,8 @@
-import {cloneEvent, getWindow, isElementType, isFocusable} from '../../utils'
+import {getWindow, isElementType, isFocusable} from '../../utils'
 import {blurElement, focusElement} from '../focus'
 import {behavior} from './registry'
 
-behavior.click = (event, target, instance) => {
+behavior.click = (event, target) => {
   const context = target.closest('button,input,label,select,textarea')
   const control = context && isElementType(context, 'label') && context.control
   if (control) {
@@ -10,7 +10,6 @@ behavior.click = (event, target, instance) => {
       if (isFocusable(control)) {
         focusElement(control)
       }
-      instance.dispatchEvent(control, cloneEvent(event))
     }
   } else if (isElementType(target, 'input', {type: 'file'})) {
     return () => {

--- a/src/event/dispatchEvent.ts
+++ b/src/event/dispatchEvent.ts
@@ -40,24 +40,13 @@ export function dispatchEvent(
       )
 
   if (behaviorImplementation) {
-    event.preventDefault()
-    let defaultPrevented = false
-    Object.defineProperty(event, 'defaultPrevented', {
-      get: () => defaultPrevented,
-    })
-    Object.defineProperty(event, 'preventDefault', {
-      value: () => {
-        defaultPrevented = event.cancelable
-      },
-    })
-
     wrapEvent(() => target.dispatchEvent(event), target)
 
-    if (!defaultPrevented as boolean) {
+    if (!event.defaultPrevented) {
       behaviorImplementation()
     }
 
-    return !defaultPrevented
+    return !event.defaultPrevented
   }
 
   return wrapEvent(() => target.dispatchEvent(event), target)

--- a/src/utility/upload.ts
+++ b/src/utility/upload.ts
@@ -49,7 +49,7 @@ export async function upload(
 
   input.addEventListener('fileDialog', fileDialog)
 
-  await this.click(element)
+  await this.click(input)
 
   input.removeEventListener('fileDialog', fileDialog)
 }

--- a/tests/event/dispatchEvent.ts
+++ b/tests/event/dispatchEvent.ts
@@ -23,19 +23,6 @@ test('keep default behavior', () => {
   expect(element).toBeChecked()
 })
 
-test('replace default behavior', () => {
-  const {element} = render(`<input type="checkbox"/>`)
-
-  const mockBehavior = mocks.fn(() => void 0)
-  mockPlugin.mockImplementationOnce(() => mockBehavior)
-
-  setupInstance().dispatchUIEvent(element, 'click')
-
-  expect(mockPlugin).toBeCalledTimes(1)
-  expect(element).not.toBeChecked()
-  expect(mockBehavior).toBeCalled()
-})
-
 test('prevent replaced default behavior', () => {
   const {element} = render(`<input type="checkbox"/>`)
   element.addEventListener('click', e => {

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -192,13 +192,13 @@ test('multi touch does not click', async () => {
 
 describe('label', () => {
   test('click associated control per label', async () => {
-    const {element, getEvents, user} = setup(
-      `<label for="in">foo</label><input id="in"/>`,
-    )
+    const onClick = mocks.fn()
+    const {element, user} = setup(`<label for="in">foo</label><input id="in"/>`)
+    element.nextSibling?.addEventListener('click', onClick)
 
     await user.pointer({keys: '[MouseLeft]', target: element})
 
-    expect(getEvents('click')).toHaveLength(2)
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 
   test('click nested control per label', async () => {

--- a/tests/utility/upload.ts
+++ b/tests/utility/upload.ts
@@ -58,18 +58,17 @@ test('relay click/upload on label to file input', async () => {
   expect(getEventSnapshot()).toMatchInlineSnapshot(`
     Events fired on: div
 
-    label[for="element"] - pointerover
+    input#element[value=""] - pointerover
     div - pointerenter
-    label[for="element"] - mouseover
+    input#element[value=""] - mouseover
     div - mouseenter
-    label[for="element"] - pointermove
-    label[for="element"] - mousemove
-    label[for="element"] - pointerdown
-    label[for="element"] - mousedown: primary
-    label[for="element"] - pointerup
-    label[for="element"] - mouseup: primary
-    label[for="element"] - click: primary
+    input#element[value=""] - pointermove
+    input#element[value=""] - mousemove
+    input#element[value=""] - pointerdown
+    input#element[value=""] - mousedown: primary
     input#element[value=""] - focusin
+    input#element[value=""] - pointerup
+    input#element[value=""] - mouseup: primary
     input#element[value=""] - click: primary
     input#element[value=""] - focusout
     input#element[value="C:\\\\fakepath\\\\hello.png"] - input


### PR DESCRIPTION
There's this common UA behavior where clicking on a label which controls an input behaves the same way as a click on the input. As far as I can tell this isn't part of any standard, but it's pretty much universal among browsers in practice. There is some code here in user-event to simulate this behavior, however [jsdom](https://github.com/jsdom/jsdom/blob/main/lib/jsdom/living/nodes/HTMLLabelElement-impl.js#L87) and [happy-dom](https://github.com/capricorn86/happy-dom/blob/c29f36c5644eacd0546b5c302ecd6bd7feacf50f/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElement.ts) both implement this.

In the case of happy-dom this causes a bug producing double-clicks on elements when their controlling label is clicked: https://github.com/capricorn86/happy-dom/issues/1410 . This doesn't affect jsdom because the way it handles `preventDefault` is different, but that's purely an implementation detail that we shouldn't be relying on here.

This MR removes the logic to attempt to click controlled inputs when their controlling labels are clicked and leaves it to the DOM lib. In so doing, to prevent interfering with the dom lib's handling of this behavior, this PR also removes the logic to half-way preventing default when user-event has some additional behavior to apply on top of dispatching an event (e.g. in the case of click or clipboard events). It seems to have only really been needed for the label-click scenario. If we find this is necessary, we can let the individual behavior handlers make their own determination about preventing default or not.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
