### PR TITLE
Correct coord property "x" to "y" in isDifferentPointerPosition

### DIFF
--- a/src/system/pointer/shared.ts
+++ b/src/system/pointer/shared.ts
@@ -27,7 +27,7 @@ export function isDifferentPointerPosition(
 ) {
   return (
     positionA.target !== positionB.target ||
-    positionA.coords?.x !== positionB.coords?.y ||
+    positionA.coords?.x !== positionB.coords?.x ||
     positionA.coords?.y !== positionB.coords?.y ||
     positionA.caret?.node !== positionB.caret?.node ||
     positionA.caret?.offset !== positionB.caret?.offset

--- a/tests/pointer/move.ts
+++ b/tests/pointer/move.ts
@@ -129,3 +129,24 @@ test('declare pointer coordinates', async () => {
     expect(getEvents('mouseover')[0]).toHaveProperty(prop, value)
   })
 })
+
+test('move pointer by x/y coords', async () => {
+  const {elements, getEventSnapshot, user} = setup('<div></div>')
+
+  await user.pointer([
+    {keys: '[MouseLeft>]', target: elements[0], coords: {x: 20, y: 20}},
+    {coords: {x: 40, y: 20}},
+    {coords: {x: 40, y: 40}},
+  ])
+
+  expect(getEventSnapshot()).toMatchInlineSnapshot(`
+    Events fired on: div
+
+    div - pointerdown
+    div - mousedown: primary
+    div - pointermove
+    div - mousemove
+    div - pointermove
+    div - mousemove
+  `)
+})


### PR DESCRIPTION
Fixes #1047

**What**:

Correct coord property "x" to "y" in isDifferentPointerPosition.

**Why**:

It had a typo.

**How**:

N/A

**Checklist**:

- N/A Documentation
- [x] Tests
- [x] Ready to be merged


<!-- feel free to add additional comments -->
