### PR TITLE
fix: PointerEvent button and buttons set to incorrect values; fixes #1083

### DIFF
--- a/src/system/pointer/index.ts
+++ b/src/system/pointer/index.ts
@@ -89,7 +89,7 @@ export class PointerHost {
     const pointerName = this.getPointerName(keyDef)
     const pointer =
       keyDef.pointerType === 'touch'
-        ? this.pointers.new(pointerName, keyDef).init(instance, position)
+        ? this.pointers.new(pointerName, keyDef).init(instance, position, keyDef)
         : this.pointers.get(pointerName)
 
     // TODO: deprecate the following implicit setting of position

--- a/tests/_helpers/listeners.ts
+++ b/tests/_helpers/listeners.ts
@@ -100,7 +100,7 @@ export function addListeners(
       isMouseEvent(e)
         ? `${e.type} - button=${e.button}; buttons=${e.buttons}; detail=${e.detail}`
         : isPointerEvent(e)
-        ? `${e.type} - pointerId=${e.pointerId}; pointerType=${e.pointerType}; isPrimary=${e.isPrimary}`
+        ? `${e.type} - pointerId=${e.pointerId}; pointerType=${e.pointerType}; isPrimary=${e.isPrimary}; button=${e.button}; buttons=${e.buttons}`
         : e.type,
     )
     return {snapshot: lines.join('\n')}

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -5,9 +5,9 @@ test('click element', async () => {
   await user.pointer({keys: '[MouseLeft]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
   `)
@@ -19,7 +19,7 @@ test('secondary button triggers contextmenu', async () => {
   await user.pointer({keys: '[MouseRight>]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=2; buttons=2
     mousedown - button=2; buttons=2; detail=1
     contextmenu - button=2; buttons=2; detail=0
   `)
@@ -33,14 +33,14 @@ test('double click', async () => {
   await user.pointer({keys: '[MouseLeft][MouseLeft]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=2
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=2
     click - button=0; buttons=0; detail=2
     dblclick - button=0; buttons=0; detail=2
@@ -65,14 +65,14 @@ test('two clicks', async () => {
   await user.pointer({keys: '[MouseLeft]'})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
   `)
@@ -93,22 +93,22 @@ test('other keys reset click counter', async () => {
   })
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=2
     mousedown - button=2; buttons=3; detail=1
     contextmenu - button=2; buttons=3; detail=0
     mouseup - button=2; buttons=1; detail=1
     auxclick - button=2; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=0
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
   `)
@@ -124,12 +124,12 @@ test('click per touch device', async () => {
   await user.pointer({keys: '[TouchA]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerover - pointerId=2; pointerType=touch; isPrimary=true
-    pointerenter - pointerId=2; pointerType=touch; isPrimary=true
-    pointerdown - pointerId=2; pointerType=touch; isPrimary=true
-    pointerup - pointerId=2; pointerType=touch; isPrimary=true
-    pointerout - pointerId=2; pointerType=touch; isPrimary=true
-    pointerleave - pointerId=2; pointerType=touch; isPrimary=true
+    pointerover - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerenter - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerdown - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerup - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerout - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerleave - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
     mouseover - button=0; buttons=0; detail=0
     mouseenter - button=0; buttons=0; detail=0
     mousemove - button=0; buttons=0; detail=0
@@ -150,24 +150,24 @@ test('double click per touch device', async () => {
   await user.pointer({keys: '[TouchA][TouchA]', target: element})
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerover - pointerId=2; pointerType=touch; isPrimary=true
-    pointerenter - pointerId=2; pointerType=touch; isPrimary=true
-    pointerdown - pointerId=2; pointerType=touch; isPrimary=true
-    pointerup - pointerId=2; pointerType=touch; isPrimary=true
-    pointerout - pointerId=2; pointerType=touch; isPrimary=true
-    pointerleave - pointerId=2; pointerType=touch; isPrimary=true
+    pointerover - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerenter - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerdown - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerup - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerout - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerleave - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
     mouseover - button=0; buttons=0; detail=0
     mouseenter - button=0; buttons=0; detail=0
     mousemove - button=0; buttons=0; detail=0
     mousedown - button=0; buttons=1; detail=1
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
-    pointerover - pointerId=3; pointerType=touch; isPrimary=true
-    pointerenter - pointerId=3; pointerType=touch; isPrimary=true
-    pointerdown - pointerId=3; pointerType=touch; isPrimary=true
-    pointerup - pointerId=3; pointerType=touch; isPrimary=true
-    pointerout - pointerId=3; pointerType=touch; isPrimary=true
-    pointerleave - pointerId=3; pointerType=touch; isPrimary=true
+    pointerover - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerenter - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerdown - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerup - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerout - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerleave - pointerId=3; pointerType=touch; isPrimary=true; button=0; buttons=0
     mousedown - button=0; buttons=1; detail=2
     mouseup - button=0; buttons=0; detail=2
     click - button=0; buttons=0; detail=2

--- a/tests/pointer/drag.ts
+++ b/tests/pointer/drag.ts
@@ -10,11 +10,11 @@ test('drag sequence', async () => {
   ])
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=1
     mousedown - button=0; buttons=1; detail=1
-    pointermove - pointerId=1; pointerType=mouse; isPrimary=true
+    pointermove - pointerId=1; pointerType=mouse; isPrimary=true; button=-1; buttons=1
     mousemove - button=0; buttons=1; detail=0
-    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true; button=0; buttons=0
     mouseup - button=0; buttons=0; detail=1
     click - button=0; buttons=0; detail=1
   `)
@@ -30,13 +30,13 @@ test('drag touch', async () => {
   ])
 
   expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
-    pointerover - pointerId=2; pointerType=touch; isPrimary=true
-    pointerenter - pointerId=2; pointerType=touch; isPrimary=true
-    pointerdown - pointerId=2; pointerType=touch; isPrimary=true
-    pointermove - pointerId=2; pointerType=touch; isPrimary=true
-    pointerup - pointerId=2; pointerType=touch; isPrimary=true
-    pointerout - pointerId=2; pointerType=touch; isPrimary=true
-    pointerleave - pointerId=2; pointerType=touch; isPrimary=true
+    pointerover - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerenter - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointerdown - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=1
+    pointermove - pointerId=2; pointerType=touch; isPrimary=true; button=-1; buttons=1
+    pointerup - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerout - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
+    pointerleave - pointerId=2; pointerType=touch; isPrimary=true; button=0; buttons=0
     mouseover - button=0; buttons=0; detail=0
     mouseenter - button=0; buttons=0; detail=0
     mousemove - button=0; buttons=0; detail=0


### PR DESCRIPTION
**What**:

Set `button` and `buttons` values appropriately for `PointerEvent` (https://github.com/testing-library/user-event/issues/1083)

**Why**:

Allows `PointerEvent` handlers that rely on `button` and/or `buttons` values to be properly tested

**How**:

Keep track of the `buttons` state in Pointer in a way that mimics browser behavior

**Checklist**:

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
