### PR TITLE
Update PointerEvent to have default width / height set to 1

### DIFF
--- a/src/event/createEvent.ts
+++ b/src/event/createEvent.ts
@@ -262,8 +262,8 @@ function initPointerEvent(
 ) {
   assignProps(event, {
     pointerId: sanitizeNumber(pointerId),
-    width: sanitizeNumber(width),
-    height: sanitizeNumber(height),
+    width: width ?? 1,
+    height: height ?? 1,
     pressure: sanitizeNumber(pressure),
     tangentialPressure: sanitizeNumber(tangentialPressure),
     tiltX: sanitizeNumber(tiltX),

--- a/src/event/createEvent.ts
+++ b/src/event/createEvent.ts
@@ -262,8 +262,8 @@ function initPointerEvent(
 ) {
   assignProps(event, {
     pointerId: sanitizeNumber(pointerId),
-    width: width ?? 1,
-    height: height ?? 1,
+    width: sanitizeNumber(width ?? 1),
+    height: sanitizeNumber(height ?? 1),
     pressure: sanitizeNumber(pressure),
     tangentialPressure: sanitizeNumber(tangentialPressure),
     tiltX: sanitizeNumber(tiltX),

--- a/src/event/createEvent.ts
+++ b/src/event/createEvent.ts
@@ -28,14 +28,14 @@ const eventInitializer: {
   Event: [],
   FocusEvent: [initUIEvent, initFocusEvent],
   InputEvent: [initUIEvent, initInputEvent],
-  MouseEvent: [initUIEvent, initUIEventModififiers, initMouseEvent],
+  MouseEvent: [initUIEvent, initUIEventModifiers, initMouseEvent],
   PointerEvent: [
     initUIEvent,
-    initUIEventModififiers,
+    initUIEventModifiers,
     initMouseEvent,
     initPointerEvent,
   ],
-  KeyboardEvent: [initUIEvent, initUIEventModififiers, initKeyboardEvent],
+  KeyboardEvent: [initUIEvent, initUIEventModifiers, initKeyboardEvent],
 }
 
 export function createEvent<K extends EventType>(
@@ -143,7 +143,7 @@ function initUIEvent(event: UIEvent, {view, detail}: UIEventInit) {
   })
 }
 
-function initUIEventModififiers(
+function initUIEventModifiers(
   event: KeyboardEvent | MouseEvent,
   {
     altKey,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

This PR updates `PointerEvent` to have default width / height set to `1` as per the spec.

* https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/width
* https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/height

**Why**:

<!-- Why are these changes necessary? -->

`new PointerEvent('xxx')` on most browser implementations should set them `1` by default.

Also some libraries check if a pointer event is _virtual_ or not by looking at the geometry values, while we expect this library to work exactly as the actual interactions.

* ex: [Floating UI](https://github.com/floating-ui/floating-ui/blob/3656e71dbd59078debc393696a50b4b5aee57f65/packages/react/src/utils.ts#L90)

**How**:

<!-- How were these changes implemented? -->

Just use `1` as default values on them.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Documentation
  - Not needed?
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
