### PR TITLE
Add brackets (`[]{}`) to defaultKeyMap for keyboard()/type()

### DIFF
--- a/src/keyboard/keyMap.ts
+++ b/src/keyboard/keyMap.ts
@@ -18,6 +18,10 @@ export const defaultKeyMap: keyboardKey[] = [
 
   // alphanumeric block - functional
   {code: 'Space', key: ' '},
+  {code: 'BracketLeft', key: '['},
+  {code: 'BracketRight', key: ']'},
+  {code: 'BracketLeft', key: '{', shiftKey: true},
+  {code: 'BracketRight', key: '}', shiftKey: true},
 
   {code: 'AltLeft', key: 'Alt', location: DOM_KEY_LOCATION.LEFT},
   {code: 'AltRight', key: 'Alt', location: DOM_KEY_LOCATION.RIGHT},

--- a/src/keyboard/keyMap.ts
+++ b/src/keyboard/keyMap.ts
@@ -4,7 +4,7 @@ import {DOM_KEY_LOCATION, keyboardKey} from '../system/keyboard'
  * Mapping for a default US-104-QWERTY keyboard
  */
 export const defaultKeyMap: keyboardKey[] = [
-  // alphanumeric keys
+  // alphanumeric block - writing system
   ...'0123456789'.split('').map(c => ({code: `Digit${c}`, key: c})),
   ...')!@#$%^&*('
     .split('')
@@ -16,12 +16,13 @@ export const defaultKeyMap: keyboardKey[] = [
     .split('')
     .map(c => ({code: `Key${c}`, key: c, shiftKey: true})),
 
+  {code: 'BracketLeft', key: '['},
+  {code: 'BracketLeft', key: '{', shiftKey: true},
+  {code: 'BracketRight', key: ']'},
+  {code: 'BracketRight', key: '}', shiftKey: true},
+
   // alphanumeric block - functional
   {code: 'Space', key: ' '},
-  {code: 'BracketLeft', key: '['},
-  {code: 'BracketRight', key: ']'},
-  {code: 'BracketLeft', key: '{', shiftKey: true},
-  {code: 'BracketRight', key: '}', shiftKey: true},
 
   {code: 'AltLeft', key: 'Alt', location: DOM_KEY_LOCATION.LEFT},
   {code: 'AltRight', key: 'Alt', location: DOM_KEY_LOCATION.RIGHT},

--- a/tests/keyboard/parseKeyDef.ts
+++ b/tests/keyboard/parseKeyDef.ts
@@ -44,18 +44,18 @@ cases(
     },
     '{ as printable': {
       text: '{{',
-      keyDef: {key: '{', code: 'Unknown'},
+      keyDef: {key: '{', code: 'BracketLeft', shiftKey: true},
     },
     '{ as printable followed by descriptor': {
       text: '{{{foo}',
       keyDef: [
-        {key: '{', code: 'Unknown'},
+        {key: '{', code: 'BracketLeft', shiftKey: true},
         {key: 'foo', code: 'Unknown'},
       ],
     },
     '{ as key with modifiers': {
       text: '{\\{>5/}',
-      keyDef: {key: '{', code: 'Unknown'},
+      keyDef: {key: '{', code: 'BracketLeft', shiftKey: true},
     },
     'modifier as key with modifiers': {
       text: '{/\\/>5/}',
@@ -63,7 +63,7 @@ cases(
     },
     '[ as printable': {
       text: '[[',
-      keyDef: {key: '[', code: 'Unknown'},
+      keyDef: {key: '[', code: 'BracketLeft'},
     },
   },
 )


### PR DESCRIPTION
**What**:

Adding support for brackets to address #1225

**Why**:

To allow easier testing of functionality that relies on both `key` and `code` being valid for keyboard events involving left/right brackets

**How**:

Updated `keyMap.ts`, ran the test suite.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm unclear whether any documentation needs updating, since I imagine this just falls under the heading of the TODO at the bottom of `keyMap.ts`, i.e. this is simply filling out the mappings.

Also I considered the updates to the existing tests enough, but it's possibly I ought to add more test cases (namely for the right bracket cases).