### PR TITLE
fix(pointer): compare `x` against `x` not `y` in `isDifferentPointerPosition()`

### DIFF
--- a/src/system/pointer/shared.ts
+++ b/src/system/pointer/shared.ts
@@ -27,7 +27,7 @@ export function isDifferentPointerPosition(
 ) {
   return (
     positionA.target !== positionB.target ||
-    positionA.coords?.x !== positionB.coords?.y ||
+    positionA.coords?.x !== positionB.coords?.x ||
     positionA.coords?.y !== positionB.coords?.y ||
     positionA.caret?.node !== positionB.caret?.node ||
     positionA.caret?.offset !== positionB.caret?.offset

--- a/tests/pointer/drag.ts
+++ b/tests/pointer/drag.ts
@@ -20,6 +20,27 @@ test('drag sequence', async () => {
   `)
 })
 
+test('drag sequence w/ differing x coordinates', async () => {
+  const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
+
+  await user.pointer([
+    {keys: '[MouseLeft>]', target: element, coords: {x: 0, y: 0}},
+    {target: element, coords: {x: 0, y: 0}}, // doesn't actually move, won't show up in snapshot below
+    {target: element, coords: {x: 10, y: 0}}, // will show up in snapshot below
+    '[/MouseLeft]',
+  ])
+
+  expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    mousedown - button=0; buttons=1; detail=1
+    pointermove - pointerId=1; pointerType=mouse; isPrimary=true
+    mousemove - button=0; buttons=1; detail=0
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    mouseup - button=0; buttons=0; detail=1
+    click - button=0; buttons=0; detail=1
+  `)
+})
+
 test('drag touch', async () => {
   const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixing logic in `isDifferentPointerPosition()` where we compare `y` against `y` but we compare `x` also against `y`.

**Why**:

I can only imagine this is a bug.

**How**:

Just change `x` to `y`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- N/A Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
