### PR TITLE
fix(pointer): make sure to check all fields of `coords` in `isDifferentPointerPosition()`

### DIFF
--- a/src/system/pointer/shared.ts
+++ b/src/system/pointer/shared.ts
@@ -29,6 +29,14 @@ export function isDifferentPointerPosition(
     positionA.target !== positionB.target ||
     positionA.coords?.x !== positionB.coords?.y ||
     positionA.coords?.y !== positionB.coords?.y ||
+    positionA.coords?.clientX !== positionB.coords?.clientX ||
+    positionA.coords?.clientY !== positionB.coords?.clientY ||
+    positionA.coords?.offsetX !== positionB.coords?.offsetX ||
+    positionA.coords?.offsetY !== positionB.coords?.offsetY ||
+    positionA.coords?.pageX !== positionB.coords?.pageX ||
+    positionA.coords?.pageY !== positionB.coords?.pageY ||
+    positionA.coords?.screenX !== positionB.coords?.screenX ||
+    positionA.coords?.screenY !== positionB.coords?.screenY ||
     positionA.caret?.node !== positionB.caret?.node ||
     positionA.caret?.offset !== positionB.caret?.offset
   )

--- a/tests/pointer/drag.ts
+++ b/tests/pointer/drag.ts
@@ -20,6 +20,27 @@ test('drag sequence', async () => {
   `)
 })
 
+test('drag sequence w/ differing client coordinates', async () => {
+  const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
+
+  await user.pointer([
+    {keys: '[MouseLeft>]', target: element, coords: {clientX: 0, clientY: 0}},
+    {target: element, coords: {clientX: 0, clientY: 0}}, // doesn't actually move, won't show up in snapshot below
+    {target: element, coords: {clientX: 10, clientY: 0}}, // will show up in snapshot below
+    '[/MouseLeft]',
+  ])
+
+  expect(getClickEventsSnapshot()).toMatchInlineSnapshot(`
+    pointerdown - pointerId=1; pointerType=mouse; isPrimary=true
+    mousedown - button=0; buttons=1; detail=1
+    pointermove - pointerId=1; pointerType=mouse; isPrimary=true
+    mousemove - button=0; buttons=1; detail=0
+    pointerup - pointerId=1; pointerType=mouse; isPrimary=true
+    mouseup - button=0; buttons=0; detail=1
+    click - button=0; buttons=0; detail=1
+  `)
+})
+
 test('drag touch', async () => {
   const {element, getClickEventsSnapshot, user} = setup(`<div></div>`)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixing a bug I observed where I tried to simulate click-and-drag, and the second event didn't fire because the logic thought the two positions were equal.

**Why**:

Fixes #1139.

**How**:

Checked https://github.com/bawjensen/user-event/blob/d0362796a33c2d39713998f82ae309020c37b385/src/event/types.ts#L27-L38, and used all those fields in comparison rather than simply `x` and `y`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- N/A Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
