### PR TITLE
allow keyboard events on shadow root hosts

### DIFF
--- a/src/utils/focus/getActiveElement.ts
+++ b/src/utils/focus/getActiveElement.ts
@@ -6,18 +6,20 @@ export function getActiveElement(
   const activeElement = document.activeElement
 
   if (activeElement?.shadowRoot) {
-    return getActiveElement(activeElement.shadowRoot)
-  } else {
-    // Browser does not yield disabled elements as document.activeElement - jsdom does
-    if (isDisabled(activeElement)) {
-      return document.ownerDocument
-        // TODO: verify behavior in ShadowRoot
-        ? /* istanbul ignore next */ document.ownerDocument.body
-        : document.body
+    const activeShadowRootElement = getActiveElement(activeElement.shadowRoot)
+    if (activeShadowRootElement) {
+      return activeShadowRootElement
     }
-
-    return activeElement
   }
+  // Browser does not yield disabled elements as document.activeElement - jsdom does
+  if (isDisabled(activeElement)) {
+    return document.ownerDocument
+      ? // TODO: verify behavior in ShadowRoot
+        /* istanbul ignore next */ document.ownerDocument.body
+      : document.body
+  }
+
+  return activeElement
 }
 
 export function getActiveElementOrBody(document: Document): Element {

--- a/src/utils/focus/getActiveElement.ts
+++ b/src/utils/focus/getActiveElement.ts
@@ -14,8 +14,8 @@ export function getActiveElement(
   // Browser does not yield disabled elements as document.activeElement - jsdom does
   if (isDisabled(activeElement)) {
     return document.ownerDocument
-      ? // TODO: verify behavior in ShadowRoot
-        /* istanbul ignore next */ document.ownerDocument.body
+      // TODO: verify behavior in ShadowRoot
+      ? /* istanbul ignore next */ document.ownerDocument.body
       : document.body
   }
 

--- a/src/utils/focus/getActiveElement.ts
+++ b/src/utils/focus/getActiveElement.ts
@@ -6,9 +6,9 @@ export function getActiveElement(
   const activeElement = document.activeElement
 
   if (activeElement?.shadowRoot) {
-    const activeShadowRootElement = getActiveElement(activeElement.shadowRoot)
-    if (activeShadowRootElement) {
-      return activeShadowRootElement
+    const activeElementInShadowTree = getActiveElement(activeElement.shadowRoot)
+    if (activeElementInShadowTree) {
+      return activeElementInShadowTree
     }
   }
   // Browser does not yield disabled elements as document.activeElement - jsdom does

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -165,3 +165,30 @@ test('disabling activeElement moves action to HTMLBodyElement', async () => {
     body - keyup: c
   `)
 })
+
+test('typing on focused element with shadow root', async () => {
+  const keypressHandler = mocks.fn()
+  class CustomElement extends HTMLElement {
+    constructor() {
+      super()
+
+      this.attachShadow({mode: 'open'})
+      this.addEventListener('keypress', keypressHandler)
+    }
+  }
+
+  customElements.define('custom-element', CustomElement)
+
+  const {element, user} = setup(
+    '<custom-element tabindex="0"></custom-element>',
+  )
+
+  // Tab to body
+  await user.tab()
+  // Tab to custom element
+  await user.tab()
+  expect(element).toHaveFocus()
+
+  await user.keyboard('[Space]')
+  expect(keypressHandler).toHaveBeenCalled()
+})

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -167,28 +167,26 @@ test('disabling activeElement moves action to HTMLBodyElement', async () => {
 })
 
 test('typing on focused element with shadow root', async () => {
-  const keypressHandler = mocks.fn()
-  class CustomElement extends HTMLElement {
-    constructor() {
-      super()
-
-      this.attachShadow({mode: 'open'})
-      this.addEventListener('keypress', keypressHandler)
-    }
-  }
-
-  customElements.define('custom-element', CustomElement)
-
-  const {element, user} = setup(
-    '<custom-element tabindex="0"></custom-element>',
+  const {user, eventWasFired} = setup(
+    '<focusable-custom-element></focusable-custom-element>',
   )
 
-  // Tab to body
-  await user.tab()
-  // Tab to custom element
-  await user.tab()
-  expect(element).toHaveFocus()
-
   await user.keyboard('[Space]')
-  expect(keypressHandler).toHaveBeenCalled()
+  expect(eventWasFired('keypress')).toBe(true)
 })
+
+customElements.define(
+  'focusable-custom-element',
+  class FocusableCustomElement extends HTMLElement {
+    constructor() {
+      super()
+      this.attachShadow({mode: 'open'})
+    }
+
+    connectedCallback() {
+      if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '0')
+      }
+    }
+  },
+)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
Resolves #1153 
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
The current code only allows keyboard entry on elements with a ShadowRoot if the ShadowRoot has a focusable element
<!-- Why are these changes necessary? -->

**How**:
The `getActiveElement` function previously checked for the existence of a `shadowRoot` on the currently active element, since active elements in a shadow DOM make the host element the active element in the light DOM, but this logic ignored the fact that host elements can also be active elements on their own.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
