### PR TITLE
fix(click): skip explicit re-dispatch for face

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,8 @@ Thanks for your interest in the project. Bugs filed and PRs submitted are apprec
 
 Please make sure that you are familiar with and follow the Code of Conduct for
 this project (found in the CODE_OF_CONDUCT.md file).
-
 Also, please make sure you're familiar with and follow the instructions in the
 contributing guidelines (found in the CONTRIBUTING.md file).
-
 If you're new to contributing to open source projects, you might find this free
 video course helpful: http://kcd.im/pull-request
 
@@ -14,28 +12,22 @@ Please fill out the information below to expedite the review and (hopefully)
 merge of your pull request!
 -->
 
-**What**:
-
+### What
 <!-- What changes are being made? (What feature/bug is being fixed here?) -->
 
-**Why**:
-
+### Why
 <!-- Why are these changes necessary? -->
 
-**How**:
-
+### How
 <!-- How were these changes implemented? -->
 
-**Checklist**:
-
+### Checklist
 <!-- Have you done all of these things?  -->
-
 <!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
-<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->
+<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->
 
 - [ ] Documentation
 - [ ] Tests
-- [ ] Ready to be merged
-      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 
 <!-- feel free to add additional comments -->

--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -4,7 +4,7 @@ import {behavior} from './registry'
 
 behavior.click = (event, target, instance) => {
   const context = target.closest('button,input,label,select,textarea')
-  const control = context && isElementType(context, 'label') && context.control
+  const control = context && isElementType(context, 'label') && !(target.constructor as { formAssociated?: boolean }).formAssociated && context.control
   if (control) {
     return () => {
       if (isFocusable(control)) {

--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -4,8 +4,11 @@ import {behavior} from './registry'
 
 behavior.click = (event, target, instance) => {
   const context = target.closest('button,input,label,select,textarea')
-  const control = context && isElementType(context, 'label') && !(target.constructor as { formAssociated?: boolean }).formAssociated && context.control
-  if (control) {
+  const control = context && isElementType(context, 'label') && context.control
+  if (
+    control &&
+    !(control.constructor as {formAssociated?: boolean}).formAssociated
+  ) {
     return () => {
       if (isFocusable(control)) {
         focusElement(control)

--- a/src/event/behavior/click.ts
+++ b/src/event/behavior/click.ts
@@ -5,10 +5,7 @@ import {behavior} from './registry'
 behavior.click = (event, target, instance) => {
   const context = target.closest('button,input,label,select,textarea')
   const control = context && isElementType(context, 'label') && context.control
-  if (
-    control &&
-    !(control.constructor as {formAssociated?: boolean}).formAssociated
-  ) {
+  if (control && control !== target) {
     return () => {
       if (isFocusable(control)) {
         focusElement(control)

--- a/tests/pointer/click.ts
+++ b/tests/pointer/click.ts
@@ -216,6 +216,28 @@ describe('label', () => {
 
     expect(getEvents('click')).toHaveLength(2)
   })
+
+  // TODO: enable as soon as jsdom properly supports CEs
+  test.skip('click nested FACE per label', async () => {
+    const {elements, getEvents, user} = setup(`
+      <script>
+        class FaCe extends HTMLElement {
+          static formAssociated = true;
+        }
+        customElements.define("fa-ce", FaCe);
+      </script>
+      <label>
+        <fa-ce></fa-ce>
+      </label>
+    `)
+
+    await user.pointer({
+      keys: '[MouseLeft]',
+      target: Array.from(elements).at(-1),
+    })
+
+    expect(getEvents('click')).toHaveLength(2)
+  })
 })
 
 describe('check/uncheck control per click', () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
closes #1237 

**Why**:

<!-- Why are these changes necessary? -->
Re-dispatching a click event on the control of a label is already skipped for labeled controls that are builtin. This change also skips form associated custom elements (FACEs) since they are always classified as labelable elements and are thus handled by the user agent already.

**How**:

<!-- How were these changes implemented? -->
Check whether the `formAssociated` static property exists by reading it from the targets constructor.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
