### PR TITLE
fix: x/y typo in isDifferentPointerPosition

### DIFF
--- a/src/system/pointer/shared.ts
+++ b/src/system/pointer/shared.ts
@@ -27,7 +27,7 @@ export function isDifferentPointerPosition(
 ) {
   return (
     positionA.target !== positionB.target ||
-    positionA.coords?.x !== positionB.coords?.y ||
+    positionA.coords?.x !== positionB.coords?.x ||
     positionA.coords?.y !== positionB.coords?.y ||
     positionA.caret?.node !== positionB.caret?.node ||
     positionA.caret?.offset !== positionB.caret?.offset


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

When determining whether a pointer position has changed, the x and y coordinates are now compared correctly.

**Why**:

Due to a common typo, x used to be compared with y.

**How**:

Fixed typo to reflect the original intent.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests. The change is trivially correct.
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
