### PR TITLE
fix(clipboard): await `DataTransferItem.getAsString()` callback

### DIFF
--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -192,7 +192,7 @@ export async function writeDataTransferToClipboard(
   const items = []
   for (let i = 0; i < clipboardData.items.length; i++) {
     const dtItem = clipboardData.items[i]
-    const blob = getBlobFromDataTransferItem(window, dtItem)
+    const blob = await getBlobFromDataTransferItem(window, dtItem)
     items.push(createClipboardItem(window, blob))
   }
 

--- a/src/utils/dataTransfer/DataTransfer.ts
+++ b/src/utils/dataTransfer/DataTransfer.ts
@@ -150,17 +150,14 @@ export function createDataTransfer(
   return dt
 }
 
-export function getBlobFromDataTransferItem(
+export async function getBlobFromDataTransferItem(
   window: Window & typeof globalThis,
   item: DataTransferItem,
 ) {
   if (item.kind === 'file') {
     return item.getAsFile() as File
   }
-  // TODO: await callback
-  let data: string = ''
-  item.getAsString(s => {
-    data = s
+  return new window.Blob([await new Promise(r => item.getAsString(r))], {
+    type: item.type,
   })
-  return new window.Blob([data], {type: item.type})
 }

--- a/tests/utils/dataTransfer/DataTransfer.ts
+++ b/tests/utils/dataTransfer/DataTransfer.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/dom'
+import {waitFor} from '@testing-library/dom'
 import {createDataTransfer, getBlobFromDataTransferItem} from '#src/utils'
 
 describe('create DataTransfer', () => {
@@ -45,12 +45,14 @@ describe('create DataTransfer', () => {
     const dt = createDataTransfer(window, [f0, f1])
     dt.setData('text/html', 'foo')
 
-    expect(dt.types).toEqual(expect.arrayContaining(
+    expect(dt.types).toEqual(
+      expect.arrayContaining(
         // TODO: Fix DataTransferStub
         typeof window.DataTransfer === 'undefined'
-        ? ['Files', 'text/html']
-        : ['text/html']
-    ))
+          ? ['Files', 'text/html']
+          : ['text/html'],
+      ),
+    )
     expect(dt.files.length).toBe(2)
   })
 
@@ -108,16 +110,18 @@ test('get Blob from DataTransfer', async () => {
   dt.items.add('foo', 'text/plain')
   dt.items.add(new File(['bar'], 'bar.txt', {type: 'text/plain'}))
 
-  expect(getBlobFromDataTransferItem(window, dt.items[0])).toHaveProperty(
+  expect(await getBlobFromDataTransferItem(window, dt.items[0])).toHaveProperty(
     'type',
     'text/plain',
   )
-  expect(getBlobFromDataTransferItem(window, dt.items[0])).not.toBeInstanceOf(
+  expect(
+    await getBlobFromDataTransferItem(window, dt.items[0]),
+  ).not.toBeInstanceOf(File)
+  expect(await getBlobFromDataTransferItem(window, dt.items[1])).toHaveProperty(
+    'type',
+    'text/plain',
+  )
+  expect(await getBlobFromDataTransferItem(window, dt.items[1])).toBeInstanceOf(
     File,
   )
-  expect(getBlobFromDataTransferItem(window, dt.items[1])).toHaveProperty(
-    'type',
-    'text/plain',
-  )
-  expect(getBlobFromDataTransferItem(window, dt.items[1])).toBeInstanceOf(File)
 })


### PR DESCRIPTION
**Why**:

Callback for `DataTransferItem.getAsString()` gets called on new event loop step in browser.

**Checklist**:

- [x] Tests
- [x] Ready to be merged
