### PR TITLE
fix: allow reassignment of `focus` and `blur` methods on `HTMLElement…

### DIFF
--- a/src/document/patchFocus.ts
+++ b/src/document/patchFocus.ts
@@ -17,14 +17,23 @@ export function patchFocus(HTMLElement: typeof globalThis['HTMLElement']) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const {focus, blur} = HTMLElement.prototype
 
+  let focusOverride: null | typeof patchedFocus = null
+  let blurOverride: null | typeof patchedBlur = null
+
   Object.defineProperties(HTMLElement.prototype, {
     focus: {
       configurable: true,
-      get: () => patchedFocus,
+      get: () => focusOverride ?? patchedFocus,
+      set: (f: typeof patchedFocus) => {
+        focusOverride = f
+      },
     },
     blur: {
       configurable: true,
-      get: () => patchedBlur,
+      get: () => blurOverride ?? patchedBlur,
+      set: (b: typeof patchedBlur) => {
+        blurOverride = b
+      },
     },
     [patched]: {
       configurable: true,

--- a/src/document/patchFocus.ts
+++ b/src/document/patchFocus.ts
@@ -17,23 +17,16 @@ export function patchFocus(HTMLElement: typeof globalThis['HTMLElement']) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const {focus, blur} = HTMLElement.prototype
 
-  let focusOverride: null | typeof patchedFocus = null
-  let blurOverride: null | typeof patchedBlur = null
-
   Object.defineProperties(HTMLElement.prototype, {
     focus: {
       configurable: true,
-      get: () => focusOverride ?? patchedFocus,
-      set: (f: typeof patchedFocus) => {
-        focusOverride = f
-      },
+      value: patchedFocus,
+      writable: true,
     },
     blur: {
       configurable: true,
-      get: () => blurOverride ?? patchedBlur,
-      set: (b: typeof patchedBlur) => {
-        blurOverride = b
-      },
+      value: patchedBlur,
+      writable: true,
     },
     [patched]: {
       configurable: true,

--- a/tests/document/patchFocus.ts
+++ b/tests/document/patchFocus.ts
@@ -31,6 +31,44 @@ test('dispatch focus events', () => {
   `)
 })
 
+describe('reassign focus and blur', () => {
+  let currentFocus: HTMLElement['focus'],
+   currentBlur: HTMLElement['blur']
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    currentFocus = HTMLElement.prototype.focus
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    currentBlur = HTMLElement.prototype.blur
+  })
+
+  afterEach(() => {
+    HTMLElement.prototype.focus = currentFocus
+    HTMLElement.prototype.blur = currentBlur
+  })
+
+  test('set custom focus and blur', () => {
+    const {
+      elements: [a],
+      getEventSnapshot,
+    } = render(`<input id="a"/>`, {focus: false})
+
+    const mockFocus = mocks.fn()
+    HTMLElement.prototype.focus = mockFocus
+    const mockBlur = mocks.fn()
+    HTMLElement.prototype.blur = mockBlur
+
+    a.focus()
+    a.blur()
+
+    expect(getEventSnapshot()).toMatchInlineSnapshot(
+      `No events were fired on: input#a[value=""]`,
+    )
+    expect(mockFocus).toHaveBeenCalledTimes(1)
+    expect(mockBlur).toHaveBeenCalledTimes(1)
+  })
+})
+
 test('`focus` handler can prevent subsequent `focusin`', () => {
   const {element, getEventSnapshot} = render(`<input/>`, {focus: false})
 

--- a/tests/document/patchFocus.ts
+++ b/tests/document/patchFocus.ts
@@ -31,44 +31,6 @@ test('dispatch focus events', () => {
   `)
 })
 
-describe('reassign focus and blur', () => {
-  let currentFocus: HTMLElement['focus'],
-   currentBlur: HTMLElement['blur']
-
-  beforeAll(() => {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    currentFocus = HTMLElement.prototype.focus
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    currentBlur = HTMLElement.prototype.blur
-  })
-
-  afterEach(() => {
-    HTMLElement.prototype.focus = currentFocus
-    HTMLElement.prototype.blur = currentBlur
-  })
-
-  test('set custom focus and blur', () => {
-    const {
-      elements: [a],
-      getEventSnapshot,
-    } = render(`<input id="a"/>`, {focus: false})
-
-    const mockFocus = mocks.fn()
-    HTMLElement.prototype.focus = mockFocus
-    const mockBlur = mocks.fn()
-    HTMLElement.prototype.blur = mockBlur
-
-    a.focus()
-    a.blur()
-
-    expect(getEventSnapshot()).toMatchInlineSnapshot(
-      `No events were fired on: input#a[value=""]`,
-    )
-    expect(mockFocus).toHaveBeenCalledTimes(1)
-    expect(mockBlur).toHaveBeenCalledTimes(1)
-  })
-})
-
 test('`focus` handler can prevent subsequent `focusin`', () => {
   const {element, getEventSnapshot} = render(`<input/>`, {focus: false})
 


### PR DESCRIPTION
### What

Reinstates the ability to reassign `HTMLElement.prototype.focus` and `HTMLElement.prototype.blur` that was removed in #1252.

### Why

Some UI libraries (Chakra UI, for example) override the `focus` and/or `blur` methods on the `HTMLElement` prototype. #1252 introduced a patched `focus` implementation that only included a getter, which means these libraries error when run with `@testing-library/user-event` because there is no setter.

### How

This adds a setter to the patched `focus` and `blur` methods.

### Checklist

- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I'm not super confident that this is the correct or preferred way to resolve the issue, but it works for my use cases.

This line from `@zag-js/radio-group` (a dependency of `@chakra-ui/react`) was the operative code in my case: https://github.com/chakra-ui/zag/blob/c1ffbfe1eb09028c837b305942f34bb77b9ac4fc/packages/utilities/focus-visible/src/index.ts#L143