### PR TITLE
feat: export callbacks for hooks

### DIFF
--- a/src/document/patchFocus.ts
+++ b/src/document/patchFocus.ts
@@ -5,7 +5,7 @@ const patched = Symbol('patched focus/blur methods')
 
 declare global {
   interface HTMLElement {
-    readonly [patched]?: Pick<HTMLElement, 'focus' | 'blur'>
+    [patched]?: Pick<HTMLElement, 'focus' | 'blur'>
   }
 }
 
@@ -93,11 +93,17 @@ export function restoreFocus(HTMLElement: typeof globalThis['HTMLElement']) {
     Object.defineProperties(HTMLElement.prototype, {
       focus: {
         configurable: true,
-        get: () => focus,
+        value: focus,
+        writable: true,
       },
       blur: {
         configurable: true,
-        get: () => blur,
+        value: blur,
+        writable: true,
+      },
+      [patched]: {
+        configurable: true,
+        get: () => undefined,
       },
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,32 @@
 // the default export is kept for backward compatibility only...
 export {userEvent as default} from './setup'
 
-export {userEvent} from './setup'
+export {userEvent, prepare, reset, detach} from './setup'
 export type {UserEvent} from './setup/setup'
 export type {keyboardKey} from './system/keyboard'
 export type {pointerKey} from './system/pointer'
 export {PointerEventsCheckLevel, type Options} from './options'
+
+import {reset, detach} from './setup'
+
+const g = globalThis as {
+  afterEach?: (cb?: () => void) => void
+  afterAll?: (cb?: () => void) => void
+  window?: Window & typeof globalThis
+}
+
+if (typeof g.afterEach === 'function') {
+  g.afterEach(() => {
+    if (g.window) {
+      reset(g.window)
+    }
+  })
+}
+
+if (typeof g.afterAll === 'function') {
+  g.afterAll(() => {
+    if (g.window) {
+      detach(g.window)
+    }
+  })
+}

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -7,3 +7,9 @@ export const userEvent = {
   ...directApi,
   setup: setupMain,
 } as const
+
+export {
+  prepare,
+  reset,
+  detach,
+} from './setup'

--- a/src/utils/dataTransfer/Clipboard.ts
+++ b/src/utils/dataTransfer/Clipboard.ts
@@ -209,17 +209,3 @@ export async function writeDataTransferToClipboard(
     throw new Error('The Clipboard API is unavailable.')
   }
 }
-
-const g = globalThis as {
-  afterEach?: (cb?: () => void) => void
-  afterAll?: (cb?: () => void) => void
-}
-/* istanbul ignore else */
-if (typeof g.afterEach === 'function') {
-  g.afterEach(() => resetClipboardStubOnView(globalThis.window))
-}
-
-/* istanbul ignore else */
-if (typeof g.afterAll === 'function') {
-  g.afterAll(() => detachClipboardStubFromView(globalThis.window))
-}


### PR DESCRIPTION
### What

Export `@experimental` functions `prepare`, `reset` and `detach` to improve support for different test environments.

```js
import userEvent, {prepare, reset, detach } from '@testing-library/user-event'
import { beforeAll, afterEach, afterAll, test } from 'some-test-runner'
import { DomImplementation } from 'some-dom-implementation'

const window = new DomImplementation()

beforeAll(() => prepare(window))
afterEach(() => reset(window))
afterAll(() => detach(window))

test('something', async () => {
  const user = userEvent.setup({document: window.document})
  // ...
```

### Why

UserEvent should work in various environments. Exposing these functions allows our users to integrate UserEvent in environments that don't use global hooks or global document.

### How

Includes a fix to `restoreFocus`.

Includes a check if `globalThis.window` exists.

### Checklist
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
