### PR TITLE
change value of number input when pressing arrow up or down

### DIFF
--- a/src/event/behavior/keydown.ts
+++ b/src/event/behavior/keydown.ts
@@ -28,6 +28,10 @@ const keydownBehavior: {
     if (isElementType(target, 'input', {type: 'radio'} as const)) {
       return () => walkRadio(instance, target, 1)
     }
+
+    if (isElementType(target, 'input', {type: 'number'} as const)) {
+      return () => input(instance, target, 'ArrowDown', 'changeNumberInput')
+    }
   },
   ArrowLeft: (event, target, instance) => {
     if (isElementType(target, 'input', {type: 'radio'} as const)) {
@@ -45,6 +49,10 @@ const keydownBehavior: {
     /* istanbul ignore else */
     if (isElementType(target, 'input', {type: 'radio'} as const)) {
       return () => walkRadio(instance, target, -1)
+    }
+
+    if (isElementType(target, 'input', {type: 'number'} as const)) {
+      return () => input(instance, target, 'ArrowUp', 'changeNumberInput')
     }
   },
   Backspace: (event, target, instance) => {

--- a/src/event/input.ts
+++ b/src/event/input.ts
@@ -11,6 +11,8 @@ import {
   EditableInputOrTextarea,
   getMaxLength,
   getNextCursorPosition,
+  isDisabled,
+  isEditable,
   isElementType,
   isValidDateOrTimeValue,
   supportsMaxLength,
@@ -217,6 +219,35 @@ function calculateNewValue(
     if (builtValue !== '' && isValidDateOrTimeValue(node, builtValue)) {
       newValue = builtValue
       newOffset = builtValue.length
+    }
+  }
+
+  if (
+    isElementType(node, 'input', {type: 'number'} as const) &&
+    inputType === 'changeNumberInput' &&
+    !isDisabled(node) &&
+    !node.readOnly
+  ) {
+    const step = node.step ? Number(node.step) : 1
+
+    const reachedMax = value === node.max
+    if (inputData === 'ArrowUp' && !reachedMax) {
+      const exceedsMax = Number(value) + step > Number(node.max)
+      if (exceedsMax && !!node.max) {
+        newValue = node.max
+      } else {
+        newValue = (Number(value) + step).toString()
+      }
+    }
+
+    const reachedMin = value === node.min
+    if (inputData === 'ArrowDown' && !reachedMin) {
+      const exceedsMin = Number(value) - step < Number(node.min)
+      if (exceedsMin && !!node.min) {
+        newValue = node.min
+      } else {
+        newValue = (Number(value) - step).toString()
+      }
     }
   }
 

--- a/tests/event/behavior/keydown.ts
+++ b/tests/event/behavior/keydown.ts
@@ -387,3 +387,153 @@ cases(
     },
   },
 )
+
+test("increment number input's value when pressing the arrow up key", () => {
+  const {element} = render<HTMLInputElement>(`<input value="1" type="number"/>`)
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(2)
+})
+
+test("do not increment number input's value when pressing the arrow up key and it would go above the max value", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" max="1"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(1)
+})
+
+test("decrement number input's value when pressing the arrow down key", () => {
+  const {element} = render<HTMLInputElement>(`<input value="1" type="number"/>`)
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(0)
+})
+
+test("do not decrement number input's value when pressing the arrow down key and it would go below the min value", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" min="1"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(1)
+})
+
+test("increments number input's value by the defined steps when pressing the arrow up key", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="10" type="number" step="10"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(20)
+})
+
+test("decrements number input's value by the defined steps when pressing the arrow down key", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="10" type="number" step="10"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(0)
+})
+
+test('decrements only to the min value when pressing the arrow down key and steps are too large', async () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="5" type="number" min="0" step="10"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(0)
+})
+
+test('increments only to the max value when pressing the arrow up key and steps are too large', async () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="5" type="number" max="10" step="10"/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(10)
+})
+
+test("does not increment number input's value when pressing the arrow up key and the input is disabled", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" disabled/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(1)
+})
+
+test("does not decrement number input's value when pressing the arrow down key and the input is disabled", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" disabled/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(1)
+})
+
+test("does not increment number input's value when pressing the arrow up key and the input is readonly", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" readonly/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowUp'})
+
+  expect(element).toHaveValue(1)
+})
+
+test("does not decrement number input's value when pressing the arrow down key and the input is readonly", () => {
+  const {element} = render<HTMLInputElement>(
+    `<input value="1" type="number" readonly/>`,
+  )
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(1)
+})
+
+test('decrements to a negative value when pressing the arrow down key', () => {
+  const {element} = render<HTMLInputElement>(`<input value="0" type="number"/>`)
+
+  const instance = setupInstance()
+
+  instance.dispatchUIEvent(element, 'keydown', {key: 'ArrowDown'})
+
+  expect(element).toHaveValue(-1)
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

### What
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

With this change you can change the value of a number input by pressing the `ArrowUp` and `ArrowDown` key, like so:

```ts
await userEvent.type(screen.getByRole('spinbutton'), "{ArrowUp}");
```

### Why
<!-- Why are these changes necessary? -->

In browsers users are able to increment or decrement the value of a number input when pressing the up or down arrow key.

Adding this to `userEvent` closes the gap between this package and the browsers.

### How
<!-- How were these changes implemented? -->

Checks if the input field has a `min` or `max` value defined, yes then the value cannot exceed those boundaries. If not the user can increment or decrement the value indefinitely.

If the input field has a `step` property then it increments or decrements in those steps.

### Checklist
<!-- Have you done all of these things?  -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->

- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Resolves #1066
