### PR TITLE
feature: Add iframe support for user.keyboard typing

### DIFF
--- a/src/document/prepareDocument.ts
+++ b/src/document/prepareDocument.ts
@@ -47,7 +47,8 @@ export function prepareDocument(document: Document) {
       const initialValue = getInitialValue(el)
       if (initialValue !== undefined) {
         if (el.value !== initialValue) {
-          dispatchDOMEvent(el, 'change')
+          // a call to blur should already be wrapped in an act
+          el.dispatchEvent(new (document.defaultView ?? window).Event('change'))
         }
         clearInitialValue(el)
       }

--- a/src/utils/focus/getActiveElement.ts
+++ b/src/utils/focus/getActiveElement.ts
@@ -10,6 +10,11 @@ export function getActiveElement(
     if (activeElementInShadowTree) {
       return activeElementInShadowTree
     }
+  } else if (activeElement?.tagName === 'IFRAME') {
+    let contentWindow = (activeElement as HTMLIFrameElement).contentWindow
+    if (contentWindow) {
+      return getActiveElement(contentWindow.document)
+    }
   }
   // Browser does not yield disabled elements as document.activeElement - jsdom does
   if (isDisabled(activeElement)) {

--- a/tests/keyboard/index.ts
+++ b/tests/keyboard/index.ts
@@ -190,3 +190,26 @@ customElements.define(
     }
   },
 )
+
+test('typing on focused element with iframe', async () => {
+  let iframe: HTMLIFrameElement
+  let iframeButton: HTMLElement
+  const {user} = setup(
+    '<div id="iframe-container"></div>',
+  )
+  iframe = document.createElement('iframe')
+  window.document.body.appendChild(iframe)
+  iframeButton = iframe.contentWindow!.document.createElement('button')
+  iframe.contentWindow!.document.body.appendChild(iframeButton)
+  let keydown = jest.fn()
+  let keyup = jest.fn()
+  iframeButton.addEventListener('keydown', keydown)
+  iframeButton.addEventListener('keyup', keyup)
+
+  iframeButton.focus()
+  await user.keyboard('[Space]')
+  expect(keydown).toHaveBeenCalled()
+  expect(keyup).toHaveBeenCalled()
+
+  iframe.remove()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

### What
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
This adds user.keyboard iframe support (next to the already existing shadow dom support) to the active element so that userEvent can fire keyboard events on the correct element. This is particularly important because the event needs to stay within the iframe, it shouldn't ever appear outside of it.

This doesn't address tab behaviour, focus patching, and doesn't test removal of iframes with focus.

### Why
<!-- Why are these changes necessary? -->
We ran into this while developing a feature in https://github.com/adobe/react-spectrum/pull/7561

### How
<!-- How were these changes implemented? -->

### Checklist
<!-- Have you done all of these things?  -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
