### PR TITLE
fix: submit form with external submit button when user clicks enter (#1220)

### DIFF
--- a/src/event/behavior/keypress.ts
+++ b/src/event/behavior/keypress.ts
@@ -15,9 +15,14 @@ behavior.keypress = (event, target, instance) => {
       }
     } else if (isElementType(target, 'input')) {
       const form = target.form
-      const submit = form?.querySelector(
-        'input[type="submit"], button:not([type]), button[type="submit"]',
-      )
+      const submit =
+        form?.querySelector(
+          'input[type="submit"], button:not([type]), button[type="submit"]',
+        ) ??
+        (form?.id &&
+          document.querySelector(
+            `input[form="${form.id}"][type="submit"], button[form="${form.id}"]:not([type]), button[form="${form?.id}"][type="submit"]`,
+          ))
       if (submit) {
         return () => instance.dispatchUIEvent(submit, 'click')
       } else if (

--- a/tests/event/behavior/keypress.ts
+++ b/tests/event/behavior/keypress.ts
@@ -127,9 +127,9 @@ cases(
 cases(
   'submit form on [Enter]',
   async ({html, click, submit}) => {
-    const {eventWasFired, xpathNode} = render(html, {focus: 'form/*[2]'})
+    const {eventWasFired, xpathNode} = render(html, {focus: '//form/*[2]'})
 
-    setupInstance().dispatchUIEvent(xpathNode('form/*[2]'), 'keypress', {
+    setupInstance().dispatchUIEvent(xpathNode('//form/*[2]'), 'keypress', {
       key: 'Enter',
     })
 
@@ -142,8 +142,23 @@ cases(
       click: true,
       submit: true,
     },
+    'with `<input type="submit"/>` outside the form': {
+      html: `<div><form id="test-form"><input/><input/></form><input type="submit" form="test-form"/></div>`,
+      click: true,
+      submit: true,
+    },
+    'with `<input type="submit"/>` outside the form not linked by id': {
+      html: `<div><form><input/><input/></form><input type="submit" form="test-form"/></div>`,
+      click: false,
+      submit: false,
+    },
     'with `<button/>`': {
       html: `<form><input/><input/><button/></form>`,
+      click: true,
+      submit: true,
+    },
+    'with `<button/>` outside the form': {
+      html: `<div><form id="test-form"><input/><input/></form><button form="test-form"/></div>`,
       click: true,
       submit: true,
     },
@@ -152,8 +167,23 @@ cases(
       click: true,
       submit: true,
     },
+    'with `<button type="submit"/>` outside the form': {
+      html: `<div><form id="test-form"><input/><input/></form><button type="submit" form="test-form"/></div>`,
+      click: true,
+      submit: true,
+    },
     'with `<button type="button"/>`': {
       html: `<form><input/><input/><button type="button"/></form>`,
+      click: false,
+      submit: false,
+    },
+    'with `<button type="button">` outside the form': {
+      html: `<div><form id="test-form"><input/><input/></form><button type="button" form="test-form"/></div>`,
+      click: false,
+      submit: false,
+    },
+    'with `<button/>` outside the form not linked to the form': {
+      html: `<div><form id="test-form"><input/><input/></form><button /></div>`,
       click: false,
       submit: false,
     },


### PR DESCRIPTION
### What
This PR fixes bug #1220 - userEvent.keyboard('{Enter}') doesn't trigger form submission when the submit button is outside the form element, even if it’s associated with the form element by using the button's form attribute.

### Why
form should be submitted if the user clicks `enter` on a field in the form and there is a button outwith  the form linked by `form` attribute.

### How
if a submit button is not found within the form by the current code, and the form has an id set then search within the document for a suitable button with the correct `form` id

### Checklist
- n/a Documentation
- [ x] Tests
- [ x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->