### PR TITLE
Make sure the default document is the correct instance

### DIFF
--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -19,8 +19,10 @@ import {DirectOptions} from './directApi'
 
 /**
  * Default options applied when API is called per `userEvent.anyApi()`
+ * We use a function to make sure the document is always the instance
+ * of the time the API is called.
  */
-const defaultOptionsDirect: Required<Options> = {
+const getDefaultOptionsDirect = (): Required<Options> => ({
   applyAccept: true,
   autoModify: true,
   delay: 0,
@@ -33,15 +35,15 @@ const defaultOptionsDirect: Required<Options> = {
   skipHover: false,
   writeToClipboard: false,
   advanceTimers: () => Promise.resolve(),
-}
+})
 
 /**
  * Default options applied when API is called per `userEvent().anyApi()`
  */
-const defaultOptionsSetup: Required<Options> = {
-  ...defaultOptionsDirect,
+const getDefaultOptionsSetup = (): Required<Options> => ({
+  ...getDefaultOptionsDirect(),
   writeToClipboard: true,
-}
+})
 
 export type UserEventApi = typeof userEventApi
 
@@ -65,7 +67,7 @@ export type Config = Required<Options>
 
 export function createConfig(
   options: Options = {},
-  defaults: Required<Options> = defaultOptionsSetup,
+  defaults: Required<Options> = getDefaultOptionsSetup(),
   node?: Node,
 ): Config {
   const document = getDocument(options, node, defaults)
@@ -101,10 +103,10 @@ export function setupDirect(
     keyboardState,
     pointerState,
     ...options
-  }: DirectOptions & {keyboardState?: System, pointerState?: System} = {}, // backward-compatibility
+  }: DirectOptions & {keyboardState?: System; pointerState?: System} = {}, // backward-compatibility
   node?: Node,
 ) {
-  const config = createConfig(options, defaultOptionsDirect, node)
+  const config = createConfig(options, getDefaultOptionsDirect(), node)
   prepareDocument(config.document)
   patchFocus(getWindow(config.document).HTMLElement)
 
@@ -146,9 +148,9 @@ export function createInstance(
   config: Config,
   system: System = new System(),
 ): {
-    instance: Instance
-    api: UserEvent
-  } {
+  instance: Instance
+  api: UserEvent
+} {
   const instance = {} as Instance
   Object.assign(instance, {
     config,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

### What
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I noticed in a setup where a jsdom instance was recreated for each test and globals were reassigned, `userEvent` used an outdated version of document.

### Why
<!-- Why are these changes necessary? -->

Avoid the need of always passing a `document` to `userEvent.setup()`

### How
<!-- How were these changes implemented? -->

Use a function to obtain default values, this makes it capture `globalThis.document` at the time `userEvent.setup()` is called.

### Checklist
<!-- Have you done all of these things?  -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->

- [N/A] Documentation
- [N/A] Tests: feels too challenging to test under the current setup. I've added a clarifying comment.
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
