### PR TITLE
fix: tab retargeting if focus moved during keydown

### DIFF
--- a/src/event/behavior/keydown.ts
+++ b/src/event/behavior/keydown.ts
@@ -101,7 +101,7 @@ const keydownBehavior: {
   Tab: (event, target, instance) => {
     return () => {
       const dest = getTabDestination(
-        target,
+        document.activeElement ?? target,
         instance.system.keyboard.modifiers.Shift,
       )
       focusElement(dest)

--- a/tests/event/behavior/keydown.ts
+++ b/tests/event/behavior/keydown.ts
@@ -304,6 +304,51 @@ cases(
 )
 
 cases(
+  'tab from a target moved during the keyboard event',
+  ({focus, shiftKey = false, expectedFocus, expectedSelection}) => {
+    const {xpathNode} = render(
+      `<input value="abc"/><button>1</button><input type="number" value="1e23"/><button>2</button>`,
+      {
+        focus,
+      },
+    )
+
+    const instance = setupInstance()
+    instance.system.keyboard.modifiers.Shift = shiftKey
+
+    document.activeElement?.addEventListener('keydown', (e) => {
+      xpathNode('button[1]').focus()
+    })
+    instance.dispatchUIEvent(document.activeElement as Element, 'keydown', {
+      key: 'Tab',
+    })
+    expect(xpathNode(expectedFocus)).toHaveFocus()
+    if (expectedSelection) {
+      expect(getUISelection(xpathNode(expectedFocus))).toEqual(
+        expect.objectContaining(expectedSelection),
+      )
+    }
+  },
+  {
+    'tab to input2': {
+      focus: '//body',
+      expectedFocus: 'input[2]',
+      expectedSelection: {startOffset: 0, endOffset: 4},
+    },
+    'tab to number input': {
+      focus: 'input[1]',
+      expectedFocus: 'input[2]',
+      expectedSelection: {startOffset: 0, endOffset: 4},
+    },
+    'tab backward to input1': {
+      focus: 'input[2]',
+      shiftKey: true,
+      expectedFocus: 'input[1]',
+    },
+  },
+)
+
+cases(
   'walk through radio group per arrow keys',
   ({focus, key, expectedTarget}) => {
     const {getEvents, eventWasFired, xpathNode} = render(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

### What
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Closes https://github.com/testing-library/user-event/issues/1188

### Why
<!-- Why are these changes necessary? -->
This is how the browser behaves, if focus is moved during the keydown of "Tab", then focus is moved from the new activeElement

I came across this in our own repo while testing some new changes.
https://github.com/adobe/react-spectrum/pull/8700

### How
<!-- How were these changes implemented? -->
Instead of using event target, we used the known activeElement when determining where focus should move

### Checklist
<!-- Have you done all of these things?  -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
