### PR TITLE
types: fix wrong default enum value

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -80,7 +80,7 @@ export interface Options {
    *
    * This is a binary flag option. You can combine multiple Levels.
    *
-   * @default PointerEventsCheckLevel.EachCall
+   * @default PointerEventsCheckLevel.EachApiCall
    */
   pointerEventsCheck?: PointerEventsCheckLevel | number
 


### PR DESCRIPTION
### What
Fix the jsdocs of `pointerEventsCheck`'s default value

### Why
The current docs refer to a non-existing enum value (PointerEventsCheckLevel.EachCall)

### How
The fix refers to the actual default enum value (PointerEventsCheckLevel.EachApiCall)

### Checklist
- [x] Documentation
- [x] Ready to be merged

@MatanBobi ❤️
