### PR TITLE
feat: add setter for files to update files attribute during upload

### DIFF
--- a/src/utils/edit/setFiles.ts
+++ b/src/utils/edit/setFiles.ts
@@ -45,7 +45,9 @@ export function setFiles(
     files: {
       configurable: true,
       get: () => files,
-      set: (v) = filesDescr?.set?.call(el, v)
+      set(v: FileList) {
+        filesDescr?.set?.call(el, v)
+      },
     },
     value: {
       configurable: true,

--- a/src/utils/edit/setFiles.ts
+++ b/src/utils/edit/setFiles.ts
@@ -45,6 +45,7 @@ export function setFiles(
     files: {
       configurable: true,
       get: () => files,
+      set: (v) = filesDescr?.set?.call(el, v)
     },
     value: {
       configurable: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

### What
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Add a setter to files to set the files attribute during `upload`

### Why
<!-- Why are these changes necessary? -->
From discussion here 
https://github.com/testing-library/user-event/discussions/1155
and issue here: https://github.com/testing-library/user-event/issues/1293

It's currently not possible to test properly for e.g. a custom file upload, whether a file is set. Additionally in browsers its allowed to set files on a file input

### How
<!-- How were these changes implemented? -->

### Checklist
<!-- Have you done all of these things?  -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- If the item is irrelevant to your changes, remove the item or replace or fill the box with "N/A" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
