### PR TITLE
feat: automatically advance fake timers in Jest and Vitest

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -122,6 +122,11 @@ export interface Options {
   /**
    * A function to be called internally to advance your fake timers (if applicable)
    *
+   * Fake timers installed by Vitest or Jest's modern fake timers are advanced
+   * automatically.
+   * Set this option if you use another implementation of fake timers,
+   * e.g. Jest's legacy fake timers.
+   *
    * @example jest.advanceTimersByTime
    */
   advanceTimers?: ((delay: number) => Promise<void>) | ((delay: number) => void)

--- a/src/setup/setup.ts
+++ b/src/setup/setup.ts
@@ -5,6 +5,7 @@ import {defaultKeyMap as defaultKeyboardMap} from '../keyboard/keyMap'
 import {defaultKeyMap as defaultPointerMap} from '../pointer/keyMap'
 import {Options, PointerEventsCheckLevel} from '../options'
 import {
+  advanceFakeTimers,
   ApiLevel,
   attachClipboardStubToView,
   getDocumentFromNode,
@@ -32,7 +33,7 @@ const defaultOptionsDirect: Required<Options> = {
   skipClick: false,
   skipHover: false,
   writeToClipboard: false,
-  advanceTimers: () => Promise.resolve(),
+  advanceTimers: advanceFakeTimers,
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,6 +30,7 @@ export * from './misc/isElementType'
 export * from './misc/isVisible'
 export * from './misc/isDisabled'
 export * from './misc/level'
+export * from './misc/timerDetection'
 export * from './misc/wait'
 
 export * from './pointer/cssPointerEvents'

--- a/src/utils/misc/timerDetection.ts
+++ b/src/utils/misc/timerDetection.ts
@@ -1,0 +1,22 @@
+interface FakeClock {
+  tick: (ms: number) => void
+}
+
+/**
+ * Advance fake timers if the test framework installed some.
+ *
+ * Jest's modern fake timers and Vitest's fake timers are both built on
+ * `@sinonjs/fake-timers`, which exposes the installed clock on each timer
+ * function it replaces.
+ * Looking for that clock instead of a `jest`/`vi` global detects fake timers
+ * however the framework is imported, and only while they are installed.
+ */
+export function advanceFakeTimers(delay: number): void {
+  const {clock} = globalThis.setTimeout as typeof globalThis.setTimeout & {
+    clock?: FakeClock
+  }
+
+  if (typeof clock?.tick === 'function') {
+    clock.tick(delay)
+  }
+}

--- a/tests/utils/misc/timerDetection.ts
+++ b/tests/utils/misc/timerDetection.ts
@@ -1,0 +1,36 @@
+import {advanceFakeTimers} from '#src/utils'
+
+test('advance fake timers installed on the global scope', () => {
+  timers.useFakeTimers()
+  try {
+    let fired = false
+    globalThis.setTimeout(() => {
+      fired = true
+    }, 100)
+
+    advanceFakeTimers(100)
+
+    expect(fired).toBe(true)
+  } finally {
+    timers.useRealTimers()
+  }
+})
+
+test('do nothing when fake timers are not installed', () => {
+  expect(globalThis.setTimeout).not.toHaveProperty('clock')
+
+  expect(() => advanceFakeTimers(100)).not.toThrow()
+})
+
+test('do nothing when the global timers are not faked', () => {
+  timers.useFakeTimers({toFake: ['Date']})
+  try {
+    const before = Date.now()
+
+    expect(() => advanceFakeTimers(100)).not.toThrow()
+
+    expect(Date.now()).toBe(before)
+  } finally {
+    timers.useRealTimers()
+  }
+})

--- a/tests/utils/misc/wait.ts
+++ b/tests/utils/misc/wait.ts
@@ -16,3 +16,45 @@ test('advances timers when set', async () => {
   timers.useRealTimers()
   expect(performance.now() - beforeReal).toBeLessThan(1000)
 }, 10)
+
+test('advances fake timers without being configured', async () => {
+  const beforeReal = performance.now()
+  timers.useFakeTimers()
+  try {
+    const beforeFake = performance.now()
+
+    const config = createConfig({delay: 500})
+    await wait(config)
+
+    expect(performance.now() - beforeFake).toBe(500)
+  } finally {
+    timers.useRealTimers()
+  }
+  expect(performance.now() - beforeReal).toBeLessThan(1000)
+}, 10)
+
+test('does not interfere with real timers', async () => {
+  expect(globalThis.setTimeout).not.toHaveProperty('clock')
+
+  const config = createConfig({delay: 1})
+  await wait(config)
+})
+
+test('configured function takes precedence over fake timer detection', async () => {
+  timers.useFakeTimers()
+  try {
+    const calls: number[] = []
+    const config = createConfig({
+      delay: 100,
+      advanceTimers: t => {
+        calls.push(t)
+        timers.advanceTimersByTime(t)
+      },
+    })
+    await wait(config)
+
+    expect(calls).toEqual([100])
+  } finally {
+    timers.useRealTimers()
+  }
+}, 10)


### PR DESCRIPTION
This PR makes `userEvent` automatically advance fake timers under both Jest and Vitest, without the need for users to configure `advanceTimers` manually.

Fixes #1115

## Approach

Jest's modern fake timers and Vitest's fake timers are both built on `@sinonjs/fake-timers`, which exposes the installed clock on each timer function it replaces. So tick that clock when it is present:

```ts
export function advanceFakeTimers(delay: number): void {
  const {clock} = globalThis.setTimeout as typeof globalThis.setTimeout & {
    clock?: FakeClock
  }

  if (typeof clock?.tick === 'function') {
    clock.tick(delay)
  }
}
```

This works however the framework is imported, and only while fake timers are installed, so real timers are never touched. It's the same signal `@testing-library/dom` uses in `jestFakeTimersAreEnabled()`.

Detection happens per `wait()` rather than once in `createConfig()`, so calling `userEvent.setup()` in a `beforeEach` before `useFakeTimers()` also works. An explicit `advanceTimers` option still takes precedence.

This does _not_ add support for auto-advancing Jest's legacy fake timers, which don't expose a clock. Modern fake timers have been the default since Jest 27 (2021): https://jestjs.io/blog/2021/05/25/jest-27

## Relevant docs

The "[Using Fake Timers](https://testing-library.com/docs/using-fake-timers)" and "[Options → advanceTimers](https://testing-library.com/docs/user-event/options#advancetimers)" docs should be updated once this is merged. Currently they only mention Jest, not Vitest, and recommend this piece of setup:

```js
userEvent.setup({advanceTimers: jest.advanceTimersByTime})
```

Happy to send a docs PR alongside this.

## Verification

I've confirmed that timers automatically advance under the latest Vitest and Jest with fake timers enabled.

Covered: click and delayed `type()` under fake timers with no options, fake timers installed after `setup()`, `toFake: ['Date']` only, explicit `advanceTimers` still honored, real timers clean.

This repo's test env installs `@sinonjs/fake-timers` the same way Jest and Vitest do, so the unit tests exercise the real mechanism instead of hand-assigned globals.

## Notes for review

- `setTimeout.clock` is undocumented `@sinonjs/fake-timers` internals. `@testing-library/dom` already relies on it, but it's a notable dependency on an implementation detail.
- `waitFor` in `@testing-library/dom` sniffs the `jest` global separately, so Vitest users under fake timers may still need the `globalThis.jest` shim for `findBy*` queries.
Making that "just work" would be a natural follow-up.
- Auto-advancing configs (`jest.useFakeTimers({advanceTimers: true})`, `vi.useFakeTimers({shouldAdvanceTime: true})`) now get both auto-advance and an explicit `tick(delay)`. At the default `delay: 0` no additional virtual time is advanced, since `tick(0)` fires the timers already due without moving the clock. With a non-zero delay, the clock moves by that delay on top of auto-advance. Sinon sets `clock.attachedInterval` only when auto-advance is on, so the tick could be skipped, but advancing by the delay the caller asked for seems more correct than deferring to real time.

